### PR TITLE
Track inline projection status updates to keep status consistent with…

### DIFF
--- a/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
+++ b/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
@@ -36,7 +36,7 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
         {
             dbContextOptionsBuilders.Add((sp, dbContextOptionsBuilder) =>
             {
-                dbContextOptionsBuilder.AddInterceptors(new ProjectionInterceptor<TProjection, TSnapshot>(options, sp));
+                dbContextOptionsBuilder.AddInterceptors(new ProjectionInterceptor<TProjection, TSnapshot>(options, sp, version));
             });
         }
         else

--- a/src/EventStoreCore/ProjectionInterceptor.cs
+++ b/src/EventStoreCore/ProjectionInterceptor.cs
@@ -1,4 +1,4 @@
-using EventStoreCore;
+using System.Runtime.CompilerServices;
 using EventStoreCore.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -6,21 +6,24 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace EventStoreCore;
 
-
-
 public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesInterceptor
     where TProjection : IProjection<TSnapshot>, new()
     where TSnapshot : class, new()
 {
+    private static readonly ConditionalWeakTable<DbContext, List<DbEvent>> PendingEvents = new();
+    private static readonly AsyncLocal<bool> SuppressStatusTracking = new();
+
     private readonly ProjectionOptions _options;
     private readonly IServiceProvider _serviceProvider;
     private readonly string _projectionName;
+    private readonly int _projectionVersion;
 
-    public ProjectionInterceptor(ProjectionOptions options, IServiceProvider serviceProvider)
+    public ProjectionInterceptor(ProjectionOptions options, IServiceProvider serviceProvider, int projectionVersion)
     {
         _options = options;
         _serviceProvider = serviceProvider;
         _projectionName = typeof(TProjection).FullName ?? typeof(TProjection).Name;
+        _projectionVersion = projectionVersion;
     }
 
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
@@ -28,6 +31,11 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
         InterceptionResult<int> result,
         CancellationToken cancellationToken = default)
     {
+        if (SuppressStatusTracking.Value)
+        {
+            return result;
+        }
+
         if (eventData.Context is not DbContext db)
         {
             return result;
@@ -44,13 +52,15 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
             .Where(e => e.State is EntityState.Added or EntityState.Modified)
             .ToList();
 
+        var handledEvents = new List<DbEvent>();
+
         foreach (var stream in streams)
         {
             var events = db.ChangeTracker.Entries<DbEvent>()
                 .Where(e => e.State is EntityState.Added && e.Entity.StreamId == stream.Entity.Id)
                 .OrderBy(e => e.Entity.Version)
-                .Select(e => e.Entity.ToEvent())
-                .Where(e => _options.IsHandeled(e.EventType))
+                .Select(e => new { Entry = e, Event = e.Entity.ToEvent() })
+                .Where(e => _options.IsHandeled(e.Event.EventType))
                 .ToArray();
 
             if (events is not { Length: > 0 })
@@ -61,11 +71,11 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
             using var scope = _serviceProvider.CreateScope();
             var projectionContext = new ProjectionContext(db, scope.ServiceProvider);
 
-            foreach (var @event in events.OrderBy(e => e.Version))
+            foreach (var item in events.OrderBy(e => e.Event.Version))
             {
-                var keySelector = _options.GetKeySelector(@event.EventType);
+                var keySelector = _options.GetKeySelector(item.Event.EventType);
 
-                var key = keySelector((IEvent<object>)@event);
+                var key = keySelector((IEvent<object>)item.Event);
 
                 var snaphost = await db
                     .Set<TSnapshot>()
@@ -74,16 +84,114 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
                 if (snaphost is null)
                 {
                     snaphost = new TSnapshot();
-                    await TProjection.Evolve(snaphost, @event, projectionContext, cancellationToken);
+                    await TProjection.Evolve(snaphost, item.Event, projectionContext, cancellationToken);
                     db.Add(snaphost);
                 }
                 else
                 {
-                    await TProjection.Evolve(snaphost, @event, projectionContext, cancellationToken);
+                    await TProjection.Evolve(snaphost, item.Event, projectionContext, cancellationToken);
                 }
+
+                handledEvents.Add(item.Entry.Entity);
             }
         }
+
+        if (handledEvents.Count > 0)
+        {
+            var pending = PendingEvents.GetOrCreateValue(db);
+            pending.AddRange(handledEvents);
+        }
+
         return result;
+    }
+
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        if (SuppressStatusTracking.Value)
+        {
+            return result;
+        }
+
+        if (eventData.Context is not DbContext db)
+        {
+            return result;
+        }
+
+        if (!PendingEvents.TryGetValue(db, out var pendingEvents) || pendingEvents.Count == 0)
+        {
+            return result;
+        }
+
+        PendingEvents.Remove(db);
+
+        if (await IsProjectionRebuildingAsync(db, cancellationToken))
+        {
+            return result;
+        }
+
+        var maxSequence = pendingEvents.Max(e => e.Sequence);
+        if (maxSequence <= 0)
+        {
+            return result;
+        }
+
+        try
+        {
+            var statusSet = db.Set<DbProjectionStatus>();
+            var status = await statusSet
+                .FirstOrDefaultAsync(s => s.ProjectionName == _projectionName, cancellationToken);
+
+            if (status == null)
+            {
+                status = new DbProjectionStatus
+                {
+                    ProjectionName = _projectionName,
+                    Version = _projectionVersion,
+                    State = ProjectionState.Active,
+                    Position = maxSequence,
+                    LastProcessedAt = DateTimeOffset.UtcNow
+                };
+                statusSet.Add(status);
+            }
+            else
+            {
+                status.Version = _projectionVersion;
+                status.State = ProjectionState.Active;
+                status.Position = Math.Max(status.Position, maxSequence);
+                status.LastProcessedAt = DateTimeOffset.UtcNow;
+                status.LastError = null;
+                status.FailedEventSequence = null;
+            }
+
+            SuppressStatusTracking.Value = true;
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (InvalidOperationException)
+        {
+            // DbProjectionStatus entity is not configured in this context
+            // This is expected if the user hasn't set up the projection daemon
+        }
+        finally
+        {
+            SuppressStatusTracking.Value = false;
+        }
+
+        return result;
+    }
+
+    public override Task SaveChangesFailedAsync(
+        DbContextErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is DbContext db)
+        {
+            PendingEvents.Remove(db);
+        }
+
+        return Task.CompletedTask;
     }
 
     private async Task<bool> IsProjectionRebuildingAsync(DbContext db, CancellationToken ct)


### PR DESCRIPTION
… daemon processing