### PR TITLE
Allow multiple subscriptions

### DIFF
--- a/src/EventStoreCore/EventStoreBuilder.cs
+++ b/src/EventStoreCore/EventStoreBuilder.cs
@@ -18,7 +18,8 @@ internal sealed class EventStoreBuilder(
     public IEventStoreBuilder AddSubscription<TSubscription>() where TSubscription : ISubscription
     {
         services.TryAddSingleton(typeof(TSubscription));
-        services.TryAddSingleton(typeof(ISubscription), sp => sp.GetRequiredService<TSubscription>());
+        services.AddSingleton(typeof(ISubscription), sp => sp.GetRequiredService<TSubscription>());
         return this;
     }
+
 }

--- a/tests/EventStoreCore.Tests/SubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionTests.cs
@@ -20,10 +20,22 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
             return Task.CompletedTask;
         }
     }
+
+    public class TestSub2 : ISubscription
+    {
+        public static List<IEvent> HandledEvents { get; } = new();
+        public Task Handle(IEvent @event, CancellationToken ct)
+        {
+            HandledEvents.Add(@event);
+            return Task.CompletedTask;
+        }
+    }
+
     public class TestEvent
     {
         public Guid Id { get; set; } = Guid.NewGuid();
     }
+
 
     [Fact]
     public async Task should_handle_events()
@@ -64,4 +76,58 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         Assert.Single(TestSub.HandledEvents);
         Assert.IsType<TestEvent>(TestSub.HandledEvents[0].Data);
     }
+
+    [Fact]
+    public async Task should_create_subscription_rows_for_multiple_subscriptions()
+    {
+        TestSub.HandledEvents.Clear();
+        TestSub2.HandledEvents.Clear();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<EventStoreDbContext>(options =>
+        {
+            options.UseNpgsql(fixture.ConnectionString);
+        });
+        services.AddEventStore(c =>
+        {
+            c.ExistingDbContext<EventStoreDbContext>();
+            c.AddSubscriptionDaemon<EventStoreDbContext>(_ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString));
+            c.AddSubscription<TestSub>();
+            c.AddSubscription<TestSub2>();
+        });
+        services.AddLogging();
+        var provider = services.BuildServiceProvider();
+        var eventStoreDbContext = provider.GetRequiredService<EventStoreDbContext>();
+        eventStoreDbContext.Database.EnsureCreated();
+
+        var eventStore = eventStoreDbContext.Streams;
+        var streamId = Guid.NewGuid();
+        eventStore.StartStream(streamId, events: [new TestEvent()]);
+        await eventStoreDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var daemon = provider.GetRequiredService<SubscriptionDaemon<EventStoreDbContext>>();
+        var subscription1 = provider.GetRequiredService<TestSub>();
+        var subscription2 = provider.GetRequiredService<TestSub2>();
+
+        var processed1 = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription1, TestContext.Current.CancellationToken);
+        var processed2 = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription2, TestContext.Current.CancellationToken);
+
+        var subscriptionEntity1 = await eventStoreDbContext.Set<DbSubscription>()
+            .FindAsync(new object[] { subscription1.GetType().AssemblyQualifiedName! }, TestContext.Current.CancellationToken);
+
+        var subscriptionEntity2 = await eventStoreDbContext.Set<DbSubscription>()
+            .FindAsync(new object[] { subscription2.GetType().AssemblyQualifiedName! }, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(subscriptionEntity1);
+        Assert.NotNull(subscriptionEntity2);
+        Assert.Equal(1, subscriptionEntity1.Sequence);
+        Assert.Equal(1, subscriptionEntity2.Sequence);
+        Assert.True(processed1, "No event was processed");
+        Assert.True(processed2, "No event was processed");
+        Assert.Single(TestSub.HandledEvents);
+        Assert.Single(TestSub2.HandledEvents);
+        Assert.IsType<TestEvent>(TestSub.HandledEvents[0].Data);
+        Assert.IsType<TestEvent>(TestSub2.HandledEvents[0].Data);
+    }
 }
+


### PR DESCRIPTION
Register each subscription instance and cover multiple subscriptions in tests.