### PR TITLE
feat: add Ignores<T>() and IgnoreUnknown() to projection options

### DIFF
--- a/src/EventStoreCore.Abstractions/IProjectionOptions.cs
+++ b/src/EventStoreCore.Abstractions/IProjectionOptions.cs
@@ -22,5 +22,17 @@ public interface IProjectionOptions
     /// <param name="keySelector">Selects a snapshot key for the event.</param>
     /// <typeparam name="TEvent">The event payload type.</typeparam>
     void Handles<TEvent>(Func<IEvent<TEvent>, object>? keySelector = default) where TEvent : class;
+
+    /// <summary>
+    /// Excludes a specific event type from processing.
+    /// </summary>
+    /// <typeparam name="T">The event payload type to ignore.</typeparam>
+    void Ignores<T>() where T : class;
+
+    /// <summary>
+    /// Instructs the projection to skip events whose CLR type cannot be resolved
+    /// instead of throwing an <see cref="System.Exception"/>.
+    /// </summary>
+    void IgnoreUnknown();
 }
 

--- a/src/EventStoreCore/ProjectionDaemon.cs
+++ b/src/EventStoreCore/ProjectionDaemon.cs
@@ -315,7 +315,20 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
         {
             foreach (var dbEvent in events)
             {
-                var @event = dbEvent.ToEvent(registry);
+                IEvent @event;
+                try
+                {
+                    @event = dbEvent.ToEvent(registry);
+                }
+                catch (EventMaterializationException ex) when (projection.Options.ShouldIgnoreUnknown)
+                {
+                    _logger.LogDebug(
+                        ex,
+                        "Skipping unresolvable event at sequence {Sequence} for projection {Projection}",
+                        dbEvent.Sequence, projection.Name);
+                    status.Position = dbEvent.Sequence;
+                    continue;
+                }
 
                 // Check if this event type is handled by the projection
                 if (!projection.Options.IsHandeled(@event.EventType))

--- a/src/EventStoreCore/ProjectionInterceptor.cs
+++ b/src/EventStoreCore/ProjectionInterceptor.cs
@@ -69,14 +69,34 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
 
         foreach (var stream in streams)
         {
-            var events = db.ChangeTracker.Entries<DbEvent>()
+            var dbEventEntries = db.ChangeTracker.Entries<DbEvent>()
                 .Where(e => e.State is EntityState.Added && e.Entity.StreamId == stream.Entity.Id)
                 .OrderBy(e => e.Entity.Version)
-                .Select(e => new { Entry = e, Event = e.Entity.ToEvent(registry) })
-                .Where(e => _options.IsHandeled(e.Event.EventType))
                 .ToArray();
 
-            if (events is not { Length: > 0 })
+            var resolvedEvents = new List<(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<DbEvent> Entry, IEvent Event)>();
+
+            foreach (var entry in dbEventEntries)
+            {
+                IEvent resolved;
+                try
+                {
+                    resolved = entry.Entity.ToEvent(registry);
+                }
+                catch (EventMaterializationException) when (_options.ShouldIgnoreUnknown)
+                {
+                    continue;
+                }
+
+                if (!_options.IsHandeled(resolved.EventType))
+                {
+                    continue;
+                }
+
+                resolvedEvents.Add((entry, resolved));
+            }
+
+            if (resolvedEvents.Count == 0)
             {
                 continue;
             }
@@ -84,7 +104,7 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
             using var scope = _serviceProvider.CreateScope();
             var projectionContext = new ProjectionContext(db, scope.ServiceProvider);
 
-            foreach (var item in events.OrderBy(e => e.Event.Version))
+            foreach (var item in resolvedEvents.OrderBy(e => e.Event.Version))
             {
                 var keySelector = _options.GetKeySelector(item.Event.EventType);
 

--- a/src/EventStoreCore/ProjectionOptions.cs
+++ b/src/EventStoreCore/ProjectionOptions.cs
@@ -9,7 +9,9 @@ namespace EventStoreCore;
 public sealed class ProjectionOptions : IProjectionOptions
 {
     private readonly HashSet<Type> _handledEventTypes = new();
+    private readonly HashSet<Type> _ignoredEventTypes = new();
     private bool HandlesAllEvents = true;
+    private bool _ignoreUnknown;
     private int _version = 1;
 
     /// <summary>
@@ -47,12 +49,41 @@ public sealed class ProjectionOptions : IProjectionOptions
     }
 
     /// <summary>
+    /// Excludes a specific event type from processing.
+    /// </summary>
+    /// <typeparam name="T">The event payload type to ignore.</typeparam>
+    public void Ignores<T>() where T : class
+    {
+        _ignoredEventTypes.Add(typeof(T));
+    }
+
+    /// <summary>
+    /// Instructs the projection to skip events whose CLR type cannot be resolved
+    /// instead of throwing an exception.
+    /// </summary>
+    public void IgnoreUnknown()
+    {
+        _ignoreUnknown = true;
+    }
+
+    /// <summary>
+    /// Gets whether unresolvable event types should be silently skipped.
+    /// True when <see cref="IgnoreUnknown"/> was called or the projection uses explicit <see cref="Handles{T}()" /> registration.
+    /// </summary>
+    internal bool ShouldIgnoreUnknown => _ignoreUnknown || !HandlesAllEvents;
+
+    /// <summary>
     /// Checks whether the projection handles the specified event type.
     /// </summary>
     /// <param name="eventType">The CLR event type.</param>
     /// <returns>True when the event type is handled.</returns>
     public bool IsHandeled(Type eventType)
     {
+        if (_ignoredEventTypes.Contains(eventType))
+        {
+            return false;
+        }
+
         return HandlesAllEvents || _handledEventTypes.Contains(eventType);
     }
 

--- a/tests/EventStoreCore.Tests/Coverage/ProjectionDaemonCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/ProjectionDaemonCoverageTests.cs
@@ -119,6 +119,7 @@ public class ProjectionDaemonCoverageTests
     {
         var options = new DbContextOptionsBuilder<ProjectionDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
             .Options;
         return new ProjectionDbContext(options);
     }
@@ -235,5 +236,246 @@ public class ProjectionDaemonCoverageTests
         var updated = await db.Set<DbProjectionStatus>().SingleAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(updated);
+    }
+
+    [Fact]
+    public async Task ProcessBatchAsync_SkipsUnresolvableEvent_WhenHandlesUsed()
+    {
+        var db = BuildDbContext();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        var options = new ProjectionOptions();
+        options.Handles<ProjectionEvent>();
+
+        var evolved = false;
+        var registration = new ProjectionRegistration
+        {
+            Name = "Projection",
+            Version = 1,
+            ProjectionType = typeof(ProjectionSnapshot),
+            SnapshotType = typeof(ProjectionSnapshot),
+            Options = options,
+            ClearAction = (_, _) => Task.CompletedTask,
+            EvolveAction = (_, _, snapshot, @event, _) =>
+            {
+                evolved = true;
+                var entity = (ProjectionSnapshot)snapshot;
+                if (@event is IEvent<ProjectionEvent> evt)
+                {
+                    entity.Id = evt.StreamId;
+                    entity.Name = evt.Data.Name;
+                }
+                return Task.CompletedTask;
+            },
+            GetOrCreateSnapshotAction = (_, _, _) => Task.FromResult<object>(new ProjectionSnapshot()),
+            AddSnapshotAction = (db, snapshot) => db.Add(snapshot)
+        };
+
+        var status = new DbProjectionStatus
+        {
+            ProjectionName = registration.Name,
+            Version = 1,
+            State = ProjectionState.Active,
+            Position = 0
+        };
+        db.Set<DbProjectionStatus>().Add(status);
+
+        var streamId = Guid.NewGuid();
+
+        // Unresolvable event (CLR type no longer exists)
+        var unknownEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = streamId,
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Sequence = 1,
+            Type = "NonExistent.RemovedEvent, NonExistent",
+            TypeName = "removed_event",
+            Data = "{}"
+        };
+
+        // Resolvable and handled event
+        var knownEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = streamId,
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 2,
+            Sequence = 2,
+            Type = typeof(ProjectionEvent).AssemblyQualifiedName!,
+            Data = "{\"Name\":\"Test\"}"
+        };
+
+        db.Set<DbEvent>().AddRange(unknownEvent, knownEvent);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var provider = new ServiceCollection()
+            .AddSingleton(db)
+            .BuildServiceProvider();
+
+        var daemon = new ProjectionDaemon<ProjectionDbContext>(
+            NullLogger<ProjectionDaemon<ProjectionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new ProjectionDaemonOptions()));
+
+        var processBatchMethod = typeof(ProjectionDaemon<ProjectionDbContext>)
+            .GetMethod("ProcessBatchAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var task = (Task<bool>)processBatchMethod.Invoke(daemon, new object[] { db, registration, status, TestContext.Current.CancellationToken })!;
+        var result = await task;
+
+        Assert.True(result);
+        Assert.True(evolved);
+        Assert.Equal(2, status.Position);
+    }
+
+    [Fact]
+    public async Task ProcessBatchAsync_ThrowsForUnresolvableEvent_WhenHandlesAll()
+    {
+        var db = BuildDbContext();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        var options = new ProjectionOptions();
+        // Default is HandlesAll — should throw on unresolvable
+
+        var registration = BuildProjectionRegistration(1, options);
+
+        var status = new DbProjectionStatus
+        {
+            ProjectionName = registration.Name,
+            Version = 1,
+            State = ProjectionState.Active,
+            Position = 0
+        };
+        db.Set<DbProjectionStatus>().Add(status);
+
+        var unknownEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Sequence = 1,
+            Type = "NonExistent.RemovedEvent, NonExistent",
+            TypeName = "removed_event",
+            Data = "{}"
+        };
+        db.Set<DbEvent>().Add(unknownEvent);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var provider = new ServiceCollection()
+            .AddSingleton(db)
+            .BuildServiceProvider();
+
+        var daemon = new ProjectionDaemon<ProjectionDbContext>(
+            NullLogger<ProjectionDaemon<ProjectionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new ProjectionDaemonOptions()));
+
+        var processBatchMethod = typeof(ProjectionDaemon<ProjectionDbContext>)
+            .GetMethod("ProcessBatchAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var task = (Task)processBatchMethod.Invoke(daemon, new object[] { db, registration, status, TestContext.Current.CancellationToken })!;
+        await Assert.ThrowsAsync<EventMaterializationException>(async () => await task);
+    }
+
+    [Fact]
+    public async Task ProcessBatchAsync_SkipsUnresolvableEvent_WhenHandlesAllWithIgnoreUnknown()
+    {
+        var db = BuildDbContext();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        var options = new ProjectionOptions();
+        options.HandlesAll();
+        options.IgnoreUnknown();
+
+        var evolved = false;
+        var registration = new ProjectionRegistration
+        {
+            Name = "Projection",
+            Version = 1,
+            ProjectionType = typeof(ProjectionSnapshot),
+            SnapshotType = typeof(ProjectionSnapshot),
+            Options = options,
+            ClearAction = (_, _) => Task.CompletedTask,
+            EvolveAction = (_, _, snapshot, @event, _) =>
+            {
+                evolved = true;
+                var entity = (ProjectionSnapshot)snapshot;
+                if (@event is IEvent<ProjectionEvent> evt)
+                {
+                    entity.Id = evt.StreamId;
+                    entity.Name = evt.Data.Name;
+                }
+                return Task.CompletedTask;
+            },
+            GetOrCreateSnapshotAction = (_, _, _) => Task.FromResult<object>(new ProjectionSnapshot()),
+            AddSnapshotAction = (db, snapshot) => db.Add(snapshot)
+        };
+
+        var status = new DbProjectionStatus
+        {
+            ProjectionName = registration.Name,
+            Version = 1,
+            State = ProjectionState.Active,
+            Position = 0
+        };
+        db.Set<DbProjectionStatus>().Add(status);
+
+        var streamId = Guid.NewGuid();
+
+        var unknownEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = streamId,
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Sequence = 1,
+            Type = "NonExistent.RemovedEvent, NonExistent",
+            TypeName = "removed_event",
+            Data = "{}"
+        };
+
+        var knownEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = streamId,
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 2,
+            Sequence = 2,
+            Type = typeof(ProjectionEvent).AssemblyQualifiedName!,
+            Data = "{\"Name\":\"Test\"}"
+        };
+
+        db.Set<DbEvent>().AddRange(unknownEvent, knownEvent);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var provider = new ServiceCollection()
+            .AddSingleton(db)
+            .BuildServiceProvider();
+
+        var daemon = new ProjectionDaemon<ProjectionDbContext>(
+            NullLogger<ProjectionDaemon<ProjectionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new ProjectionDaemonOptions()));
+
+        var processBatchMethod = typeof(ProjectionDaemon<ProjectionDbContext>)
+            .GetMethod("ProcessBatchAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var task = (Task<bool>)processBatchMethod.Invoke(daemon, new object[] { db, registration, status, TestContext.Current.CancellationToken })!;
+        var result = await task;
+
+        Assert.True(result);
+        Assert.True(evolved);
+        Assert.Equal(2, status.Position);
     }
 }

--- a/tests/EventStoreCore.Tests/EventStoreBuilderPostgresExtensionsTests.cs
+++ b/tests/EventStoreCore.Tests/EventStoreBuilderPostgresExtensionsTests.cs
@@ -16,6 +16,8 @@ public class EventStoreBuilderPostgresExtensionsTests
         public void Handles<T>() where T : class => HandlesAllCalled = true;
         public void HandlesAll() => HandlesAllCalled = true;
         public void Handles<TEvent>(Func<IEvent<TEvent>, object>? keySelector = null) where TEvent : class => HandlesAllCalled = true;
+        public void Ignores<T>() where T : class { }
+        public void IgnoreUnknown() { }
     }
 
     private sealed class FakeRegistrar : IProjectionRegistrar, ISubscriptionDaemonRegistrar, IProjectionDaemonRegistrar

--- a/tests/EventStoreCore.Tests/ProjectionOptionsTests.cs
+++ b/tests/EventStoreCore.Tests/ProjectionOptionsTests.cs
@@ -1,0 +1,88 @@
+using EventStoreCore;
+
+namespace EventStoreCore.Tests;
+
+public class ProjectionOptionsTests
+{
+    private sealed class EventA;
+    private sealed class EventB;
+    private sealed class EventC;
+
+    [Fact]
+    public void HandlesAll_IsDefault()
+    {
+        var options = new ProjectionOptions();
+
+        Assert.True(options.IsHandeled(typeof(EventA)));
+        Assert.True(options.IsHandeled(typeof(EventB)));
+    }
+
+    [Fact]
+    public void Handles_SwitchesToWhitelist()
+    {
+        var options = new ProjectionOptions();
+        options.Handles<EventA>();
+
+        Assert.True(options.IsHandeled(typeof(EventA)));
+        Assert.False(options.IsHandeled(typeof(EventB)));
+    }
+
+    [Fact]
+    public void Ignores_ExcludesTypeInHandlesAllMode()
+    {
+        var options = new ProjectionOptions();
+        options.Ignores<EventA>();
+
+        Assert.False(options.IsHandeled(typeof(EventA)));
+        Assert.True(options.IsHandeled(typeof(EventB)));
+    }
+
+    [Fact]
+    public void Ignores_ExcludesTypeInHandlesMode()
+    {
+        var options = new ProjectionOptions();
+        options.Handles<EventA>();
+        options.Handles<EventB>();
+        options.Ignores<EventB>();
+
+        Assert.True(options.IsHandeled(typeof(EventA)));
+        Assert.False(options.IsHandeled(typeof(EventB)));
+        Assert.False(options.IsHandeled(typeof(EventC)));
+    }
+
+    [Fact]
+    public void ShouldIgnoreUnknown_FalseByDefault()
+    {
+        var options = new ProjectionOptions();
+
+        Assert.False(options.ShouldIgnoreUnknown);
+    }
+
+    [Fact]
+    public void ShouldIgnoreUnknown_TrueWhenHandlesUsed()
+    {
+        var options = new ProjectionOptions();
+        options.Handles<EventA>();
+
+        Assert.True(options.ShouldIgnoreUnknown);
+    }
+
+    [Fact]
+    public void ShouldIgnoreUnknown_TrueWhenIgnoreUnknownCalled()
+    {
+        var options = new ProjectionOptions();
+        options.IgnoreUnknown();
+
+        Assert.True(options.ShouldIgnoreUnknown);
+    }
+
+    [Fact]
+    public void ShouldIgnoreUnknown_TrueWhenHandlesAllAndIgnoreUnknown()
+    {
+        var options = new ProjectionOptions();
+        options.HandlesAll();
+        options.IgnoreUnknown();
+
+        Assert.True(options.ShouldIgnoreUnknown);
+    }
+}


### PR DESCRIPTION
Projections that use Handles<T>() (whitelist mode) now silently skip events whose CLR type cannot be resolved, instead of crashing the daemon. HandlesAll projections continue to throw unless IgnoreUnknown() is explicitly called.

Changes:
- IProjectionOptions: added Ignores<T>() and IgnoreUnknown()
- ProjectionOptions: ignore set, ShouldIgnoreUnknown flag, updated IsHandeled() to check ignores first
- ProjectionDaemon: catch EventMaterializationException when ShouldIgnoreUnknown, log and skip
- ProjectionInterceptor: restructured LINQ to foreach with same try-catch pattern
- Tests: 7 unit tests for ProjectionOptions, 3 daemon integration tests for skip/throw/IgnoreUnknown scenarios