### PR TITLE
Strengthen inline projection contracts and delivery coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ services.AddEventStore(builder =>
 
 Projection and subscription daemons require an `IDistributedLockProvider`. Register any implementation (Redis, SQL Server, Postgres, etc.) in DI.
 
+## Inline projection contract
+
+Inline projections run inside the same `DbContext` scope and `SaveChanges` transaction that appends events. If an inline projection throws, the append is rolled back with it.
+
+Inline projections should therefore be:
+
+- Deterministic: the same event history should always produce the same snapshot state.
+- Idempotent: reprocessing the same event should not produce duplicate side effects.
+- Local: treat inline execution as part of persistence, not as a place for remote I/O.
+
+### Pure vs Advanced
+
+`Pure` inline projections only mutate their snapshot from event data. This is the safest default and the easiest mode to reason about.
+
+`Advanced` inline projections may use the projection context and shared EF Core scope to update additional local state in the same transaction. Keep that work inside the database boundary and make it idempotent.
+
+Avoid network calls, message publishing, HTTP requests, and other remote side effects in inline projections. Inline projections can be retried, rolled back, or skipped during rebuild flows, so external side effects belong in subscriptions or eventual projections instead.
+
+Subscriptions and eventual projections are at-least-once. Consumers should use `EventId` as a stable deduplication key when replay or retry can redeliver an event.
+
 ## Event type names
 
 EventStore now persists a logical event type name in `DbEvent.TypeName`. By default, it uses snake_case based on the CLR type name (for example, `UserCreated` becomes `user_created`).

--- a/src/EventStoreCore.Abstractions/IProjection.cs
+++ b/src/EventStoreCore.Abstractions/IProjection.cs
@@ -9,6 +9,8 @@ public interface IProjection<TSnapshot>
 {
     /// <summary>
     /// Apply the event to the snapshot. Implementations perform any required persistence inside the supplied context.
+    /// Projection logic should be deterministic and idempotent because inline execution can be rolled back and
+    /// eventual execution can redeliver events.
     /// </summary>
     /// <param name="snapshot">The snapshot instance to mutate.</param>
     /// <param name="event">The event to apply.</param>

--- a/src/EventStoreCore.Abstractions/IProjectionContext.cs
+++ b/src/EventStoreCore.Abstractions/IProjectionContext.cs
@@ -7,11 +7,13 @@ public interface IProjectionContext
 {
     /// <summary>
     /// Service provider available for resolving dependencies during projection execution.
+    /// Prefer local persistence dependencies over remote side-effecting services.
     /// </summary>
     IServiceProvider Services { get; }
 
     /// <summary>
     /// Provider-specific state, such as an EF DbContext instance.
+    /// When projections run inline, this state participates in the same persistence scope as the event append.
     /// </summary>
     object? ProviderState { get; }
 }

--- a/src/EventStoreCore/EventStoreBuilderEfCoreExtensions.cs
+++ b/src/EventStoreCore/EventStoreBuilderEfCoreExtensions.cs
@@ -113,7 +113,11 @@ public static class EventStoreBuilderEfCoreExtensions
     /// <typeparam name="TProjection">The projection implementation.</typeparam>
     /// <typeparam name="TSnapshot">The snapshot entity type.</typeparam>
     /// <param name="builder">The event store builder.</param>
-    /// <param name="mode">Whether to run inline or eventual projections.</param>
+    /// <param name="mode">
+    /// Whether to run inline or eventual projections. Inline projections execute inside the caller's
+    /// <c>SaveChanges</c> transaction and should stay deterministic, idempotent, and free of remote side effects.
+    /// Eventual projections run through the daemon pipeline and inherit at-least-once delivery semantics.
+    /// </param>
     /// <param name="configure">Optional projection options configuration.</param>
     /// <returns>The event store builder.</returns>
     public static IEventStoreBuilder AddProjection<TDbContext, TProjection, TSnapshot>(

--- a/src/EventStoreCore/ProjectionMode.cs
+++ b/src/EventStoreCore/ProjectionMode.cs
@@ -6,12 +6,14 @@ namespace EventStoreCore;
 public enum ProjectionMode
 {
     /// <summary>
-    /// Executes projections inline during SaveChanges.
+    /// Executes projections inline during SaveChanges using the caller's DbContext and transaction.
+    /// Use this mode for deterministic, idempotent, local projection work that must commit with the append.
     /// </summary>
     Inline,
 
     /// <summary>
     /// Executes projections asynchronously via the projection daemon.
+    /// This mode is eventually consistent and follows at-least-once delivery semantics.
     /// </summary>
     Eventual
 }

--- a/tests/EventStoreCore.Tests/ProjectionTests.cs
+++ b/tests/EventStoreCore.Tests/ProjectionTests.cs
@@ -6,6 +6,8 @@ using EventStoreCore.Postgres;
 
 using Medallion.Threading.Postgres;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using static EventStoreCore.Tests.EventStoreFixture;
 
@@ -83,6 +85,53 @@ public class ProjectionTests(PostgresFixture fixture) : IClassFixture<PostgresFi
         {
             var db = (DbContext)context.ProviderState!;
             return db.Set<BookPageSummary>().ExecuteDeleteAsync(ct);
+        }
+    }
+
+    public class FailingUserSnapshot
+    {
+        public Guid UserId { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class FailingUserProjection : IProjection<FailingUserSnapshot>
+    {
+        public static Task Evolve(FailingUserSnapshot snapshot, IEvent @event, IProjectionContext context, CancellationToken ct)
+        {
+            if (@event is IEvent<UserCreated> e)
+            {
+                snapshot.UserId = e.StreamId;
+                snapshot.Name = e.Data.Name;
+            }
+
+            throw new InvalidOperationException("Inline projection failure");
+        }
+
+        public static Task ClearAsync(IProjectionContext context, CancellationToken ct)
+        {
+            return context.DbContext.Set<FailingUserSnapshot>().ExecuteDeleteAsync(ct);
+        }
+    }
+
+    public class InlineFailureProjectionDbContext : DbContext
+    {
+        public InlineFailureProjectionDbContext(DbContextOptions<InlineFailureProjectionDbContext> options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.UseEventStore();
+            modelBuilder.Entity<DbStream>().ToTable("InlineFailureProjectionStreams");
+            modelBuilder.Entity<DbEvent>().ToTable("InlineFailureProjectionEvents");
+            modelBuilder.Entity<DbProjectionStatus>().ToTable("InlineFailureProjectionStatuses");
+            modelBuilder.Entity<DbSubscription>().ToTable("InlineFailureProjectionSubscriptions");
+            modelBuilder.Entity<FailingUserSnapshot>(entity =>
+            {
+                entity.ToTable("InlineFailureProjectionSnapshots");
+                entity.HasKey(e => e.UserId);
+            });
         }
     }
 
@@ -196,6 +245,58 @@ public class ProjectionTests(PostgresFixture fixture) : IClassFixture<PostgresFi
 
         Assert.NotNull(snapshot);
         Assert.Equal(streamId, snapshot.BookId);
+    }
+
+    [Fact]
+    public async Task InlineProjectionFailureRollsBackAppendSnapshotAndStatus()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<InlineFailureProjectionDbContext>(options => options.UseNpgsql(fixture.ConnectionString));
+        services.AddEventStore(c =>
+        {
+            c.ExistingDbContext<InlineFailureProjectionDbContext>();
+            c.AddProjection<InlineFailureProjectionDbContext, FailingUserProjection, FailingUserSnapshot>(ProjectionMode.Inline, p =>
+            {
+                p.Handles<UserCreated>();
+            });
+        });
+
+        services.AddLogging();
+        var provider = services.BuildServiceProvider();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var arrangeScope = provider.CreateAsyncScope())
+        {
+            var db = arrangeScope.ServiceProvider.GetRequiredService<InlineFailureProjectionDbContext>();
+            await db.Database.GetService<IRelationalDatabaseCreator>().CreateTablesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var saveScope = provider.CreateAsyncScope())
+        {
+            var db = saveScope.ServiceProvider.GetRequiredService<InlineFailureProjectionDbContext>();
+            db.Streams.StartStream(streamId, events: [new UserCreated { Name = "John Doe" }]);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => db.SaveChangesAsync(TestContext.Current.CancellationToken));
+        }
+
+        await using var assertScope = provider.CreateAsyncScope();
+        var assertDb = assertScope.ServiceProvider.GetRequiredService<InlineFailureProjectionDbContext>();
+        var projectionName = typeof(FailingUserProjection).FullName!;
+
+        var persistedEvents = await assertDb.Set<DbEvent>()
+            .Where(e => e.StreamId == streamId)
+            .CountAsync(TestContext.Current.CancellationToken);
+        var snapshots = await assertDb.Set<FailingUserSnapshot>()
+            .Where(e => e.UserId == streamId)
+            .CountAsync(TestContext.Current.CancellationToken);
+        var status = await assertDb.Set<DbProjectionStatus>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.ProjectionName == projectionName, TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, persistedEvents);
+        Assert.Equal(0, snapshots);
+        Assert.Null(status);
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/SubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionTests.cs
@@ -11,6 +11,23 @@ namespace EventStoreCore.Tests;
 
 public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>
 {
+    public class DeliveryTrackingDbContext : DbContext
+    {
+        public DeliveryTrackingDbContext(DbContextOptions<DeliveryTrackingDbContext> options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.UseEventStore();
+            modelBuilder.Entity<ProcessedEventRecord>(entity =>
+            {
+                entity.HasKey(e => e.EventId);
+            });
+        }
+    }
+
     public class TestSub : ISubscription
     {
         public static List<IEvent> HandledEvents { get; } = new();
@@ -36,30 +53,117 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         public Guid Id { get; set; } = Guid.NewGuid();
     }
 
+    public sealed class RetryTrackingSubscription : ISubscription
+    {
+        public static List<Guid> HandledEventIds { get; } = new();
+        public static int Attempts { get; private set; }
 
-    [Fact]
-    public async Task should_handle_events()
+        public Task Handle(IEvent @event, CancellationToken ct)
+        {
+            Attempts++;
+            HandledEventIds.Add(@event.Id);
+
+            if (Attempts == 1)
+            {
+                throw new InvalidOperationException("Simulated subscription failure");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public static void Reset()
+        {
+            Attempts = 0;
+            HandledEventIds.Clear();
+        }
+    }
+
+    public sealed class ProcessedEventRecord
+    {
+        public Guid EventId { get; set; }
+    }
+
+    public sealed class DeduplicatingScopedSubscription : IScopedSubscription
+    {
+        public static List<Guid> DeliveredEventIds { get; } = new();
+
+        public Task Handle(IEvent @event, CancellationToken ct)
+        {
+            throw new NotSupportedException("Use HandleAsync for scoped subscription execution.");
+        }
+
+        public async Task HandleAsync(DbContext dbContext, IEvent @event, CancellationToken ct)
+        {
+            DeliveredEventIds.Add(@event.Id);
+
+            var processedEvents = dbContext.Set<ProcessedEventRecord>();
+            if (await processedEvents.AnyAsync(e => e.EventId == @event.Id, ct))
+            {
+                return;
+            }
+
+            processedEvents.Add(new ProcessedEventRecord
+            {
+                EventId = @event.Id
+            });
+        }
+
+        public static void Reset()
+        {
+            DeliveredEventIds.Clear();
+        }
+    }
+
+    private ServiceProvider BuildProvider<TDbContext>(Action<IEventStoreBuilder> configure)
+        where TDbContext : DbContext
     {
         var services = new ServiceCollection();
-        services.AddDbContext<EventStoreDbContext>(options =>
+        services.AddDbContext<TDbContext>(options =>
         {
             options.UseNpgsql(fixture.ConnectionString);
         });
         services.AddEventStore(c =>
         {
-            c.ExistingDbContext<EventStoreDbContext>();
-            c.AddSubscriptionDaemon<EventStoreDbContext>(_ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString));
-            c.AddSubscription<TestSub>();
+            c.ExistingDbContext<TDbContext>();
+            c.AddSubscriptionDaemon<TDbContext>(_ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString));
+            configure(c);
         });
         services.AddLogging();
-        var provider = services.BuildServiceProvider();
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task ResetDatabaseAsync(EventStoreDbContext dbContext, CancellationToken ct)
+    {
+        await dbContext.Set<DbSubscription>().ExecuteDeleteAsync(ct);
+        await dbContext.Events.ExecuteDeleteAsync(ct);
+        await dbContext.Set<DbStream>().ExecuteDeleteAsync(ct);
+    }
+
+    private static async Task ResetDeliveryTrackingDatabaseAsync(DeliveryTrackingDbContext dbContext, CancellationToken ct)
+    {
+        await dbContext.Set<ProcessedEventRecord>().ExecuteDeleteAsync(ct);
+        await dbContext.Set<DbSubscription>().ExecuteDeleteAsync(ct);
+        await dbContext.Events.ExecuteDeleteAsync(ct);
+        await dbContext.Set<DbStream>().ExecuteDeleteAsync(ct);
+    }
+
+
+    [Fact]
+    public async Task should_handle_events()
+    {
+        TestSub.HandledEvents.Clear();
+        var provider = BuildProvider<EventStoreDbContext>(c => c.AddSubscription<TestSub>());
         var eventStoreDbContext = provider.GetRequiredService<EventStoreDbContext>();
         eventStoreDbContext.Database.EnsureCreated();
+        await ResetDatabaseAsync(eventStoreDbContext, TestContext.Current.CancellationToken);
 
         var eventStore = eventStoreDbContext.Streams;
         var streamId = Guid.NewGuid();
         eventStore.StartStream(streamId, events: [new TestEvent()]);
         await eventStoreDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var persistedEvent = await eventStoreDbContext.Events
+            .AsNoTracking()
+            .SingleAsync(e => e.StreamId == streamId, TestContext.Current.CancellationToken);
 
         var daemon = provider.GetRequiredService<SubscriptionDaemon<EventStoreDbContext>>();
         var subscription = provider.GetRequiredService<TestSub>();
@@ -71,7 +175,7 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
 
 
         Assert.NotNull(subscriptionEntity);
-        Assert.Equal(1, subscriptionEntity.Sequence);
+        Assert.Equal(persistedEvent.Sequence, subscriptionEntity.Sequence);
         Assert.True(processed, "No event was processed");
         Assert.Single(TestSub.HandledEvents);
         Assert.IsType<TestEvent>(TestSub.HandledEvents[0].Data);
@@ -83,23 +187,14 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         TestSub.HandledEvents.Clear();
         TestSub2.HandledEvents.Clear();
 
-        var services = new ServiceCollection();
-        services.AddDbContext<EventStoreDbContext>(options =>
+        var provider = BuildProvider<EventStoreDbContext>(c =>
         {
-            options.UseNpgsql(fixture.ConnectionString);
-        });
-        services.AddEventStore(c =>
-        {
-            c.ExistingDbContext<EventStoreDbContext>();
-            c.AddSubscriptionDaemon<EventStoreDbContext>(_ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString));
             c.AddSubscription<TestSub>();
             c.AddSubscription<TestSub2>();
         });
-
-        services.AddLogging();
-        var provider = services.BuildServiceProvider();
         var eventStoreDbContext = provider.GetRequiredService<EventStoreDbContext>();
         eventStoreDbContext.Database.EnsureCreated();
+        await ResetDatabaseAsync(eventStoreDbContext, TestContext.Current.CancellationToken);
 
         var eventStore = eventStoreDbContext.Streams;
         var streamId = Guid.NewGuid();
@@ -130,6 +225,90 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         Assert.IsType<TestEvent>(TestSub.HandledEvents[0].Data);
         Assert.IsType<TestEvent>(TestSub2.HandledEvents[0].Data);
 
+    }
+
+    [Fact]
+    public async Task failed_subscription_delivery_is_retried_with_the_same_event_id()
+    {
+        RetryTrackingSubscription.Reset();
+
+        var provider = BuildProvider<EventStoreDbContext>(c => c.AddSubscription<RetryTrackingSubscription>());
+        var eventStoreDbContext = provider.GetRequiredService<EventStoreDbContext>();
+        await eventStoreDbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        await ResetDatabaseAsync(eventStoreDbContext, TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        eventStoreDbContext.Streams.StartStream(streamId, events: [new TestEvent()]);
+        await eventStoreDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var expectedEvent = await eventStoreDbContext.Events
+            .AsNoTracking()
+            .SingleAsync(e => e.StreamId == streamId, TestContext.Current.CancellationToken);
+
+        var daemon = provider.GetRequiredService<SubscriptionDaemon<EventStoreDbContext>>();
+        var subscription = provider.GetRequiredService<RetryTrackingSubscription>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken));
+
+        var failedSubscriptionRow = await eventStoreDbContext.Set<DbSubscription>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                e => e.SubscriptionAssemblyQualifiedName == typeof(RetryTrackingSubscription).AssemblyQualifiedName!,
+                TestContext.Current.CancellationToken);
+
+        Assert.Null(failedSubscriptionRow);
+        Assert.Single(RetryTrackingSubscription.HandledEventIds);
+        Assert.Equal(expectedEvent.EventId, RetryTrackingSubscription.HandledEventIds[0]);
+
+        var processed = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
+
+        var succeededSubscriptionRow = await eventStoreDbContext.Set<DbSubscription>()
+            .AsNoTracking()
+            .SingleAsync(
+                e => e.SubscriptionAssemblyQualifiedName == typeof(RetryTrackingSubscription).AssemblyQualifiedName!,
+                TestContext.Current.CancellationToken);
+
+        Assert.True(processed);
+        Assert.Equal(2, RetryTrackingSubscription.Attempts);
+        Assert.Equal(expectedEvent.EventId, RetryTrackingSubscription.HandledEventIds[1]);
+        Assert.Equal(expectedEvent.Sequence, succeededSubscriptionRow.Sequence);
+    }
+
+    [Fact]
+    public async Task replay_redelivers_the_same_event_id_so_consumers_can_deduplicate()
+    {
+        DeduplicatingScopedSubscription.Reset();
+
+        var provider = BuildProvider<DeliveryTrackingDbContext>(c => c.AddSubscription<DeduplicatingScopedSubscription>());
+        var dbContext = provider.GetRequiredService<DeliveryTrackingDbContext>();
+        await dbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        await ResetDeliveryTrackingDatabaseAsync(dbContext, TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        dbContext.Streams.StartStream(streamId, events: [new TestEvent()]);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var daemon = provider.GetRequiredService<SubscriptionDaemon<DeliveryTrackingDbContext>>();
+        var subscription = provider.GetRequiredService<DeduplicatingScopedSubscription>();
+        var manager = provider.GetRequiredService<ISubscriptionManager>();
+        var subscriptionName = typeof(DeduplicatingScopedSubscription).AssemblyQualifiedName!;
+
+        Assert.True(await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken));
+
+        await manager.ReplayAsync(subscriptionName, startSequence: 1, ct: TestContext.Current.CancellationToken);
+
+        Assert.True(await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken));
+
+        var processedEventIds = await dbContext.Set<ProcessedEventRecord>()
+            .AsNoTracking()
+            .Select(e => e.EventId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, DeduplicatingScopedSubscription.DeliveredEventIds.Count);
+        Assert.All(DeduplicatingScopedSubscription.DeliveredEventIds, id => Assert.Equal(DeduplicatingScopedSubscription.DeliveredEventIds[0], id));
+        Assert.Single(processedEventIds);
+        Assert.Equal(DeduplicatingScopedSubscription.DeliveredEventIds[0], processedEventIds[0]);
     }
 }
 


### PR DESCRIPTION
## Summary
- document the inline projection contract, including Pure vs Advanced guidance and remote side-effect restrictions
- tighten public XML docs around inline vs eventual projection execution semantics
- add tests for inline rollback, subscription redelivery, and EventId-based deduplication

## Testing
- dotnet test tests/EventStoreCore.Tests/EventStoreCore.Tests.csproj

Closes #30