### PR TITLE
Add optimistic concurrency append modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,33 @@ var stream = await eventStore.FetchForReadingAsync(docId);
 
 **Note**: Changing primary keys in existing databases requires careful migration planning. Consider the impact on your application and data before applying these changes.
 
+## Optimistic concurrency
+
+Use `AppendAsync` when callers need explicit expected-version semantics instead of fetch-and-append behavior.
+
+```csharp
+await eventStore.AppendAsync(
+    streamId,
+    ExpectedVersion.NoStream,
+    [new AccountOpened()]);
+
+await eventStore.AppendAsync(
+    streamId,
+    ExpectedVersion.Exact(3),
+    [new FundsDeposited(100m)]);
+```
+
+Supported modes:
+
+- `ExpectedVersion.Any`: append whether the stream exists or not.
+- `ExpectedVersion.NoStream`: succeed only when the stream does not already exist.
+- `ExpectedVersion.StreamExists`: succeed only when the stream already exists.
+- `ExpectedVersion.Exact(version)`: succeed only when the stream exists at the supplied version.
+
+When an expected-version check fails, or when two writers race and the database wins the tie-breaker, EventStore throws `EventStoreConcurrencyException`.
+
+The final optimistic concurrency guard is enforced by the event table key over stream identity plus event version. This means concurrent writers to the same stream cannot both commit the same next version.
+
 ## Project guidelines
 
 - Keep public APIs small, composable, and backwards compatible.

--- a/src/EventStoreCore.Abstractions/ExpectedVersion.cs
+++ b/src/EventStoreCore.Abstractions/ExpectedVersion.cs
@@ -1,0 +1,83 @@
+namespace EventStoreCore.Abstractions;
+
+/// <summary>
+/// Describes the expected stream version to enforce during append operations.
+/// </summary>
+public readonly record struct ExpectedVersion
+{
+    private ExpectedVersion(ExpectedVersionMode mode, long? version = null)
+    {
+        Mode = mode;
+        Version = version;
+    }
+
+    /// <summary>
+    /// The expected-version mode.
+    /// </summary>
+    public ExpectedVersionMode Mode { get; }
+
+    /// <summary>
+    /// The exact stream version to require when <see cref="Mode" /> is <see cref="ExpectedVersionMode.Exact" />.
+    /// </summary>
+    public long? Version { get; }
+
+    /// <summary>
+    /// Appends regardless of the current stream version.
+    /// </summary>
+    public static ExpectedVersion Any { get; } = new(ExpectedVersionMode.Any);
+
+    /// <summary>
+    /// Requires that the stream does not already exist.
+    /// </summary>
+    public static ExpectedVersion NoStream { get; } = new(ExpectedVersionMode.NoStream);
+
+    /// <summary>
+    /// Requires that the stream already exists, regardless of its current version.
+    /// </summary>
+    public static ExpectedVersion StreamExists { get; } = new(ExpectedVersionMode.StreamExists);
+
+    /// <summary>
+    /// Requires that the stream exists and is currently at the supplied version.
+    /// </summary>
+    /// <param name="version">The exact stream version to require.</param>
+    /// <returns>The expected-version constraint.</returns>
+    public static ExpectedVersion Exact(long version)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(version);
+        return new ExpectedVersion(ExpectedVersionMode.Exact, version);
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return Mode == ExpectedVersionMode.Exact
+            ? $"Exact({Version})"
+            : Mode.ToString();
+    }
+}
+
+/// <summary>
+/// Identifies the optimistic concurrency mode used for append operations.
+/// </summary>
+public enum ExpectedVersionMode
+{
+    /// <summary>
+    /// Appends regardless of the current stream version.
+    /// </summary>
+    Any,
+
+    /// <summary>
+    /// Requires that the stream does not already exist.
+    /// </summary>
+    NoStream,
+
+    /// <summary>
+    /// Requires that the stream already exists.
+    /// </summary>
+    StreamExists,
+
+    /// <summary>
+    /// Requires that the stream exists and matches an exact version.
+    /// </summary>
+    Exact
+}

--- a/src/EventStoreCore.Abstractions/IEventStore.cs
+++ b/src/EventStoreCore.Abstractions/IEventStore.cs
@@ -6,6 +6,70 @@ namespace EventStoreCore.Abstractions;
 public interface IEventStore
 {
     /// <summary>
+    /// Appends events using optimistic concurrency expectations.
+    /// </summary>
+    /// <param name="streamId">The stream identifier.</param>
+    /// <param name="expectedVersion">The expected-version mode to enforce.</param>
+    /// <param name="events">The events to append.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated read-only stream.</returns>
+    Task<IReadOnlyStream> AppendAsync(
+        Guid streamId,
+        ExpectedVersion expectedVersion,
+        IEnumerable<object> events,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends events using optimistic concurrency expectations.
+    /// </summary>
+    /// <param name="streamId">The stream identifier.</param>
+    /// <param name="tenantId">The tenant identifier for multi-tenant scenarios.</param>
+    /// <param name="expectedVersion">The expected-version mode to enforce.</param>
+    /// <param name="events">The events to append.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated read-only stream.</returns>
+    Task<IReadOnlyStream> AppendAsync(
+        Guid streamId,
+        Guid tenantId,
+        ExpectedVersion expectedVersion,
+        IEnumerable<object> events,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends events using optimistic concurrency expectations.
+    /// </summary>
+    /// <param name="streamType">The stream type for distinguishing multiple streams with the same ID.</param>
+    /// <param name="streamId">The stream identifier.</param>
+    /// <param name="expectedVersion">The expected-version mode to enforce.</param>
+    /// <param name="events">The events to append.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated read-only stream.</returns>
+    Task<IReadOnlyStream> AppendAsync(
+        string streamType,
+        Guid streamId,
+        ExpectedVersion expectedVersion,
+        IEnumerable<object> events,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends events using optimistic concurrency expectations.
+    /// </summary>
+    /// <param name="streamType">The stream type for distinguishing multiple streams with the same ID.</param>
+    /// <param name="streamId">The stream identifier.</param>
+    /// <param name="tenantId">The tenant identifier for multi-tenant scenarios.</param>
+    /// <param name="expectedVersion">The expected-version mode to enforce.</param>
+    /// <param name="events">The events to append.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated read-only stream.</returns>
+    Task<IReadOnlyStream> AppendAsync(
+        string streamType,
+        Guid streamId,
+        Guid tenantId,
+        ExpectedVersion expectedVersion,
+        IEnumerable<object> events,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Fetches a stream for appending new events.
     /// </summary>
     /// <param name="streamId">The stream identifier.</param>

--- a/src/EventStoreCore/DbContextEventStore.cs
+++ b/src/EventStoreCore/DbContextEventStore.cs
@@ -91,12 +91,14 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
         }
         catch (DbUpdateException ex) when (IsEventStoreWriteConflict(ex))
         {
+            var actualVersion = await GetActualVersionAsync(streamType, streamId, tenantId, cancellationToken);
+
             throw CreateConcurrencyException(
                 streamType,
                 streamId,
                 tenantId,
                 expectedVersion,
-                stream.CurrentVersion - eventList.Length,
+                actualVersion,
                 "Append failed because another writer modified the stream concurrently.",
                 ex);
         }
@@ -315,7 +317,52 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
 
     private static bool IsEventStoreWriteConflict(DbUpdateException exception)
     {
-        return exception.Entries.Any(entry => entry.Entity is DbEvent or DbStream);
+        return exception.Entries.Any(entry => entry.Entity is DbEvent or DbStream)
+            && IsUniqueConstraintViolation(exception);
+    }
+
+    private async Task<long?> GetActualVersionAsync(string streamType, Guid streamId, Guid tenantId, CancellationToken cancellationToken)
+    {
+        db.ChangeTracker.Clear();
+
+        return await db.Set<DbStream>()
+            .AsNoTracking()
+            .Where(stream => stream.Id == streamId && stream.StreamType == streamType && stream.TenantId == tenantId)
+            .Select(stream => (long?)stream.CurrentVersion)
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+
+    private static bool IsUniqueConstraintViolation(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (GetStringProperty(current, "SqlState") == "23505")
+            {
+                return true;
+            }
+
+            if (GetIntProperty(current, "Number") is 2601 or 2627)
+            {
+                return true;
+            }
+
+            if (GetIntProperty(current, "SqliteErrorCode") == 19)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? GetStringProperty(Exception exception, string propertyName)
+    {
+        return exception.GetType().GetProperty(propertyName)?.GetValue(exception) as string;
+    }
+
+    private static int? GetIntProperty(Exception exception, string propertyName)
+    {
+        return exception.GetType().GetProperty(propertyName)?.GetValue(exception) as int?;
     }
 
     private static EventStoreConcurrencyException CreateConcurrencyException(

--- a/src/EventStoreCore/DbContextEventStore.cs
+++ b/src/EventStoreCore/DbContextEventStore.cs
@@ -10,6 +10,99 @@ namespace EventStoreCore;
 public sealed class DbContextEventStore(DbContext db) : IEventStore
 {
     /// <inheritdoc />
+    public Task<IReadOnlyStream> AppendAsync(
+        Guid streamId,
+        ExpectedVersion expectedVersion,
+        IEnumerable<object> events,
+        CancellationToken cancellationToken = default)
+        => AppendAsync(string.Empty, streamId, Guid.Empty, expectedVersion, events, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyStream> AppendAsync(
+        Guid streamId,
+        Guid tenantId,
+        ExpectedVersion expectedVersion,
+        IEnumerable<object> events,
+        CancellationToken cancellationToken = default)
+        => AppendAsync(string.Empty, streamId, tenantId, expectedVersion, events, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyStream> AppendAsync(
+        string streamType,
+        Guid streamId,
+        ExpectedVersion expectedVersion,
+        IEnumerable<object> events,
+        CancellationToken cancellationToken = default)
+        => AppendAsync(streamType, streamId, Guid.Empty, expectedVersion, events, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyStream> AppendAsync(
+        string streamType,
+        Guid streamId,
+        Guid tenantId,
+        ExpectedVersion expectedVersion,
+        IEnumerable<object> events,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+
+        var eventList = events.ToArray();
+        var stream = await db.Set<DbStream>()
+            .Where(x => x.TenantId == tenantId && x.StreamType == streamType)
+            .Include(x => x.Events)
+            .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
+
+        stream = expectedVersion.Mode switch
+        {
+            ExpectedVersionMode.Any => stream ?? CreateStream(streamType, streamId, tenantId),
+            ExpectedVersionMode.NoStream when stream is null => CreateStream(streamType, streamId, tenantId),
+            ExpectedVersionMode.NoStream => throw CreateConcurrencyException(
+                streamType,
+                streamId,
+                tenantId,
+                expectedVersion,
+                stream!.CurrentVersion,
+                "Append expected no stream, but the stream already exists."),
+            ExpectedVersionMode.StreamExists when stream is not null => stream,
+            ExpectedVersionMode.StreamExists => throw CreateConcurrencyException(
+                streamType,
+                streamId,
+                tenantId,
+                expectedVersion,
+                actualVersion: null,
+                "Append expected an existing stream, but the stream was not found."),
+            ExpectedVersionMode.Exact when stream is not null && stream.CurrentVersion == expectedVersion.Version => stream,
+            ExpectedVersionMode.Exact => throw CreateConcurrencyException(
+                streamType,
+                streamId,
+                tenantId,
+                expectedVersion,
+                stream?.CurrentVersion,
+                $"Append expected stream version {expectedVersion.Version}, but observed {(stream is null ? "no stream" : stream.CurrentVersion.ToString())}."),
+            _ => throw new InvalidOperationException($"Unsupported expected-version mode: {expectedVersion.Mode}")
+        };
+
+        new DbContextStream(stream, db).Append(eventList);
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+            return new DbContextStream(stream, db);
+        }
+        catch (DbUpdateException ex) when (IsEventStoreWriteConflict(ex))
+        {
+            throw CreateConcurrencyException(
+                streamType,
+                streamId,
+                tenantId,
+                expectedVersion,
+                stream.CurrentVersion - eventList.Length,
+                "Append failed because another writer modified the stream concurrently.",
+                ex);
+        }
+    }
+
+    /// <inheritdoc />
     public Task<IReadOnlyStream?> FetchForReadingAsync(Guid streamId, CancellationToken cancellationToken = default)
         => FetchForReadingAsync(string.Empty, streamId, Guid.Empty, cancellationToken);
 
@@ -197,6 +290,15 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
     /// <inheritdoc />
     public IStream<T> StartStream<T>(string streamType, Guid streamId, Guid tenantId, params IEnumerable<object> events) where T : IState, new()
     {
+        var dbStream = CreateStream(streamType, streamId, tenantId);
+        var stream = new DbContextStream<T>(dbStream, db);
+
+        stream.Append(events);
+        return stream;
+    }
+
+    private DbStream CreateStream(string streamType, Guid streamId, Guid tenantId)
+    {
         var dbStream = new DbStream
         {
             Id = streamId,
@@ -206,11 +308,33 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
             UpdatedTimestamp = DateTime.UtcNow,
             TenantId = tenantId
         };
-        db.Add(dbStream);
-        var stream = new DbContextStream<T>(dbStream, db);
 
-        stream.Append(events);
-        return stream;
+        db.Add(dbStream);
+        return dbStream;
+    }
+
+    private static bool IsEventStoreWriteConflict(DbUpdateException exception)
+    {
+        return exception.Entries.Any(entry => entry.Entity is DbEvent or DbStream);
+    }
+
+    private static EventStoreConcurrencyException CreateConcurrencyException(
+        string streamType,
+        Guid streamId,
+        Guid tenantId,
+        ExpectedVersion expectedVersion,
+        long? actualVersion,
+        string message,
+        Exception? innerException = null)
+    {
+        return new EventStoreConcurrencyException(
+            streamType,
+            streamId,
+            tenantId,
+            expectedVersion,
+            actualVersion,
+            message,
+            innerException);
     }
 }
 

--- a/src/EventStoreCore/EventStoreConcurrencyException.cs
+++ b/src/EventStoreCore/EventStoreConcurrencyException.cs
@@ -1,0 +1,61 @@
+using EventStoreCore.Abstractions;
+
+namespace EventStoreCore;
+
+/// <summary>
+/// Exception thrown when an append operation violates optimistic concurrency expectations.
+/// </summary>
+public sealed class EventStoreConcurrencyException : Exception
+{
+    /// <summary>
+    /// Creates a new concurrency exception.
+    /// </summary>
+    /// <param name="streamType">The stream type.</param>
+    /// <param name="streamId">The stream identifier.</param>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="expectedVersion">The expected-version mode.</param>
+    /// <param name="actualVersion">The observed stream version, when known.</param>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public EventStoreConcurrencyException(
+        string streamType,
+        Guid streamId,
+        Guid tenantId,
+        ExpectedVersion expectedVersion,
+        long? actualVersion,
+        string message,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        StreamType = streamType;
+        StreamId = streamId;
+        TenantId = tenantId;
+        ExpectedVersion = expectedVersion;
+        ActualVersion = actualVersion;
+    }
+
+    /// <summary>
+    /// The stream type.
+    /// </summary>
+    public string StreamType { get; }
+
+    /// <summary>
+    /// The stream identifier.
+    /// </summary>
+    public Guid StreamId { get; }
+
+    /// <summary>
+    /// The tenant identifier.
+    /// </summary>
+    public Guid TenantId { get; }
+
+    /// <summary>
+    /// The expected-version mode.
+    /// </summary>
+    public ExpectedVersion ExpectedVersion { get; }
+
+    /// <summary>
+    /// The observed version at the time of failure, when known.
+    /// </summary>
+    public long? ActualVersion { get; }
+}

--- a/tests/EventStoreCore.Tests/EventStoreTests.cs
+++ b/tests/EventStoreCore.Tests/EventStoreTests.cs
@@ -34,6 +34,21 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
         }
     }
 
+    private static async Task<long> GetCurrentVersionAsync(
+        EventStoreFixture.EventStoreDbContext dbContext,
+        Guid streamId,
+        Guid tenantId = default,
+        string streamType = "")
+    {
+        var stream = await dbContext.Set<DbStream>()
+            .AsNoTracking()
+            .SingleAsync(
+                s => s.Id == streamId && s.TenantId == tenantId && s.StreamType == streamType,
+                TestContext.Current.CancellationToken);
+
+        return stream.CurrentVersion;
+    }
+
     [Fact]
     public async Task CanStartStream()
     {
@@ -222,6 +237,128 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
         
         Assert.Equal("Upload Event", uploadEvent?.Data.Name);
         Assert.Equal("Analysis Event", analysisEvent?.Data.Name);
+    }
+
+    [Fact]
+    public async Task AppendAsync_NoStream_Throws_WhenStreamAlreadyExists()
+    {
+        var streamId = Guid.NewGuid();
+
+        using (var dbContext = eventStoreFixture.CreateNewContext())
+        {
+            dbContext.Streams.StartStream(streamId, events: [new TestEvent()]);
+            await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var appendContext = eventStoreFixture.CreateNewContext();
+
+        var exception = await Assert.ThrowsAsync<EventStoreConcurrencyException>(() =>
+            appendContext.Streams.AppendAsync(
+                streamId,
+                ExpectedVersion.NoStream,
+                [new TestEvent { Name = "Unexpected" }],
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(ExpectedVersion.NoStream, exception.ExpectedVersion);
+        Assert.Equal(streamId, exception.StreamId);
+        Assert.Equal(1, exception.ActualVersion);
+    }
+
+    [Fact]
+    public async Task AppendAsync_StreamExists_Throws_WhenStreamDoesNotExist()
+    {
+        var streamId = Guid.NewGuid();
+
+        using var dbContext = eventStoreFixture.CreateNewContext();
+
+        var exception = await Assert.ThrowsAsync<EventStoreConcurrencyException>(() =>
+            dbContext.Streams.AppendAsync(
+                streamId,
+                ExpectedVersion.StreamExists,
+                [new TestEvent()],
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(ExpectedVersion.StreamExists, exception.ExpectedVersion);
+        Assert.Equal(streamId, exception.StreamId);
+        Assert.Null(exception.ActualVersion);
+    }
+
+    [Fact]
+    public async Task AppendAsync_Exact_Throws_WhenVersionDoesNotMatch()
+    {
+        var streamId = Guid.NewGuid();
+
+        using (var dbContext = eventStoreFixture.CreateNewContext())
+        {
+            dbContext.Streams.StartStream(streamId, events: [new TestEvent()]);
+            await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var appendContext = eventStoreFixture.CreateNewContext();
+
+        var exception = await Assert.ThrowsAsync<EventStoreConcurrencyException>(() =>
+            appendContext.Streams.AppendAsync(
+                streamId,
+                ExpectedVersion.Exact(0),
+                [new TestEvent { Name = "Version mismatch" }],
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(ExpectedVersionMode.Exact, exception.ExpectedVersion.Mode);
+        Assert.Equal(0, exception.ExpectedVersion.Version);
+        Assert.Equal(1, exception.ActualVersion);
+    }
+
+    [Fact]
+    public async Task AppendAsync_ConcurrentExactWriters_CauseOneConcurrencyFailure()
+    {
+        var streamId = Guid.NewGuid();
+
+        using (var dbContext = eventStoreFixture.CreateNewContext())
+        {
+            dbContext.Streams.StartStream(streamId, events: [new TestEvent()]);
+            await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task<Exception?> AppendFromNewContext(string name)
+        {
+            using var dbContext = eventStoreFixture.CreateNewContext();
+            await gate.Task;
+
+            try
+            {
+                await dbContext.Streams.AppendAsync(
+                    streamId,
+                    ExpectedVersion.Exact(1),
+                    [new TestEvent { Name = name }],
+                    TestContext.Current.CancellationToken);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+
+        var writer1 = AppendFromNewContext("writer-1");
+        var writer2 = AppendFromNewContext("writer-2");
+
+        gate.SetResult();
+
+        var results = await Task.WhenAll(writer1, writer2);
+        var failures = results.OfType<Exception>().ToArray();
+
+        Assert.Equal(1, results.Count(r => r is null));
+        var failure = Assert.Single(failures);
+        Assert.IsType<EventStoreConcurrencyException>(failure);
+
+        using var verifyContext = eventStoreFixture.CreateNewContext();
+        var readStream = await verifyContext.Streams.FetchForReadingAsync(streamId, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(readStream);
+        Assert.Equal(2, readStream!.Events.Count);
+        Assert.Equal(2, await GetCurrentVersionAsync(verifyContext, streamId));
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/EventStoreTests.cs
+++ b/tests/EventStoreCore.Tests/EventStoreTests.cs
@@ -351,7 +351,8 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
 
         Assert.Equal(1, results.Count(r => r is null));
         var failure = Assert.Single(failures);
-        Assert.IsType<EventStoreConcurrencyException>(failure);
+        var concurrencyException = Assert.IsType<EventStoreConcurrencyException>(failure);
+        Assert.Equal(2, concurrencyException.ActualVersion);
 
         using var verifyContext = eventStoreFixture.CreateNewContext();
         var readStream = await verifyContext.Streams.FetchForReadingAsync(streamId, TestContext.Current.CancellationToken);


### PR DESCRIPTION
## Summary
- add expected-version append modes to the public event store API
- translate append races and expectation mismatches into EventStoreConcurrencyException
- document optimistic concurrency semantics and add concurrent writer coverage

## Testing
- dotnet test tests/EventStoreCore.Tests/EventStoreCore.Tests.csproj

Closes #23