### PR TITLE
Add batched subscription daemon processing

### DIFF
--- a/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
+++ b/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
@@ -53,9 +53,15 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
         }
     }
 
-    public void AddSubscriptionDaemon(Func<IServiceProvider, IDistributedLockProvider> factory)
+    public void AddSubscriptionDaemon(
+        Func<IServiceProvider, IDistributedLockProvider> factory,
+        Action<SubscriptionOptions>? configure = null)
     {
         services.TryAddSingleton(factory);
+        services.Configure<SubscriptionOptions>(opts =>
+        {
+            configure?.Invoke(opts);
+        });
         services.TryAddSingleton<SubscriptionDaemon<TDbContext>>();
         services.TryAddScoped<ISubscriptionManager>(sp =>
         {

--- a/src/EventStoreCore/EventStoreBuilderEfCoreExtensions.cs
+++ b/src/EventStoreCore/EventStoreBuilderEfCoreExtensions.cs
@@ -48,11 +48,16 @@ public static class EventStoreBuilderEfCoreExtensions
     /// </summary>
     /// <typeparam name="TDbContext">The DbContext type.</typeparam>
     /// <param name="builder">The event store builder.</param>
+    /// <param name="configure">Optional daemon configuration.</param>
     /// <returns>The event store builder.</returns>
-    public static IEventStoreBuilder AddSubscriptionDaemon<TDbContext>(this IEventStoreBuilder builder)
+    public static IEventStoreBuilder AddSubscriptionDaemon<TDbContext>(
+        this IEventStoreBuilder builder,
+        Action<SubscriptionOptions>? configure = null)
         where TDbContext : DbContext
     {
-        return builder.AddSubscriptionDaemon<TDbContext>(sp => sp.GetRequiredService<IDistributedLockProvider>());
+        return builder.AddSubscriptionDaemon<TDbContext>(
+            sp => sp.GetRequiredService<IDistributedLockProvider>(),
+            configure);
     }
 
     /// <summary>
@@ -61,14 +66,16 @@ public static class EventStoreBuilderEfCoreExtensions
     /// <typeparam name="TDbContext">The DbContext type.</typeparam>
     /// <param name="builder">The event store builder.</param>
     /// <param name="factory">Factory that returns the distributed lock provider.</param>
+    /// <param name="configure">Optional daemon configuration.</param>
     /// <returns>The event store builder.</returns>
     public static IEventStoreBuilder AddSubscriptionDaemon<TDbContext>(
         this IEventStoreBuilder builder,
-        Func<IServiceProvider, IDistributedLockProvider> factory)
+        Func<IServiceProvider, IDistributedLockProvider> factory,
+        Action<SubscriptionOptions>? configure = null)
         where TDbContext : DbContext
     {
         var provider = GetProvider<TDbContext>(builder);
-        provider.Daemon.AddSubscriptionDaemon(factory);
+        provider.Daemon.AddSubscriptionDaemon(factory, configure);
         return builder;
     }
 

--- a/src/EventStoreCore/ISubscriptionDaemonRegistrar.cs
+++ b/src/EventStoreCore/ISubscriptionDaemonRegistrar.cs
@@ -5,5 +5,7 @@ namespace EventStoreCore;
 
 internal interface ISubscriptionDaemonRegistrar
 {
-    void AddSubscriptionDaemon(Func<IServiceProvider, IDistributedLockProvider> factory);
+    void AddSubscriptionDaemon(
+        Func<IServiceProvider, IDistributedLockProvider> factory,
+        Action<SubscriptionOptions>? configure = null);
 }

--- a/src/EventStoreCore/SubscriptionDaemon.cs
+++ b/src/EventStoreCore/SubscriptionDaemon.cs
@@ -132,8 +132,6 @@ public sealed class SubscriptionDaemon<TDbContext>(
         var name = subscriptionImpl.GetType().AssemblyQualifiedName!;
         var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
 
-        await using var transaction = await dbContext.Database.BeginTransactionAsync(stoppingToken);
-
         try
         {
             var subscriptionSet = dbContext.Set<DbSubscription>();
@@ -162,7 +160,6 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 if (createdSubscription)
                 {
                     await dbContext.SaveChangesAsync(stoppingToken);
-                    await transaction.CommitAsync(stoppingToken);
                 }
 
                 return 0;
@@ -201,8 +198,6 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 await dbContext.SaveChangesAsync(stoppingToken);
             }
 
-            await transaction.CommitAsync(stoppingToken);
-
             logger.LogInformation(
                 "Processed {Count} events through sequence {Sequence} for subscription {Subscription}",
                 processedCount,
@@ -214,7 +209,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
         catch
         {
             logger.LogWarning(
-                "Rolling back transaction for subscription {Subscription}",
+                "Subscription {Subscription} failed after processing one or more events",
                 name);
             throw;
         }

--- a/src/EventStoreCore/SubscriptionDaemon.cs
+++ b/src/EventStoreCore/SubscriptionDaemon.cs
@@ -55,9 +55,9 @@ public sealed class SubscriptionDaemon<TDbContext>(
                     await using (acquired)
                     {
                         using var scope = _serviceProvider.CreateScope();
-                        var processed = await ProcessNextEventAsync(scope, subscription, stoppingToken);
+                        var processedCount = await ProcessNextBatchAsync(scope, subscription, stoppingToken);
 
-                        if (!processed)
+                        if (processedCount == 0)
                         {
                             logger.LogInformation(
                                 "No new events to process for subscription {Subscription}",
@@ -102,59 +102,114 @@ public sealed class SubscriptionDaemon<TDbContext>(
     /// <returns>True when an event was processed.</returns>
     internal async Task<bool> ProcessNextEventAsync(IServiceScope scope, ISubscription subscriptionImpl, CancellationToken stoppingToken)
     {
+        return await ProcessNextBatchAsync(scope, subscriptionImpl, stoppingToken, 1, 1) > 0;
+    }
+
+    /// <summary>
+    /// Processes the next available batch of events for a subscription.
+    /// </summary>
+    /// <param name="scope">The scoped service provider.</param>
+    /// <param name="subscriptionImpl">The subscription instance.</param>
+    /// <param name="stoppingToken">Cancellation token.</param>
+    /// <returns>The number of events processed in the batch.</returns>
+    internal Task<int> ProcessNextBatchAsync(IServiceScope scope, ISubscription subscriptionImpl, CancellationToken stoppingToken)
+    {
+        return ProcessNextBatchAsync(
+            scope,
+            subscriptionImpl,
+            stoppingToken,
+            Math.Max(1, _options.BatchSize),
+            Math.Max(1, _options.CheckpointFrequency));
+    }
+
+    private async Task<int> ProcessNextBatchAsync(
+        IServiceScope scope,
+        ISubscription subscriptionImpl,
+        CancellationToken stoppingToken,
+        int batchSize,
+        int checkpointFrequency)
+    {
         var name = subscriptionImpl.GetType().AssemblyQualifiedName!;
-
         var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
-
 
         await using var transaction = await dbContext.Database.BeginTransactionAsync(stoppingToken);
 
         try
         {
+            var subscriptionSet = dbContext.Set<DbSubscription>();
             var subscription = await dbContext.Set<DbSubscription>().FindAsync([name], stoppingToken);
+            var createdSubscription = false;
+
             if (subscription is null)
             {
                 subscription = new DbSubscription
                 {
                     SubscriptionAssemblyQualifiedName = name,
                 };
-                dbContext.Set<DbSubscription>().Add(subscription);
-                await dbContext.SaveChangesAsync(stoppingToken);
+                subscriptionSet.Add(subscription);
+                createdSubscription = true;
                 logger.LogInformation("Created new subscription entity for {Subscription}", name);
             }
 
-            var nextEvent = await dbContext.Events
+            var nextEvents = await dbContext.Events
                 .Where(e => e.Sequence > subscription.Sequence)
-                .OrderBy(e => e.Sequence) // Ensure ordering
-                .FirstOrDefaultAsync(stoppingToken);
+                .OrderBy(e => e.Sequence)
+                .Take(batchSize)
+                .ToListAsync(stoppingToken);
 
-            if (nextEvent is null)
+            if (nextEvents.Count == 0)
             {
-                return false;
+                if (createdSubscription)
+                {
+                    await dbContext.SaveChangesAsync(stoppingToken);
+                    await transaction.CommitAsync(stoppingToken);
+                }
+
+                return 0;
             }
 
             var registry = scope.ServiceProvider.GetService<EventTypeRegistry>();
-            var @event = nextEvent.ToEvent(registry);
+            var processedCount = 0;
+            long? lastProcessedSequence = null;
 
-            if (subscriptionImpl is IScopedSubscription scoped)
+            foreach (var nextEvent in nextEvents)
             {
-                await scoped.HandleAsync(dbContext, @event, stoppingToken);
-            }
-            else
-            {
-                await subscriptionImpl.Handle(@event, stoppingToken);
+                var @event = nextEvent.ToEvent(registry);
+
+                if (subscriptionImpl is IScopedSubscription scoped)
+                {
+                    await scoped.HandleAsync(dbContext, @event, stoppingToken);
+                }
+                else
+                {
+                    await subscriptionImpl.Handle(@event, stoppingToken);
+                }
+
+                processedCount++;
+                lastProcessedSequence = nextEvent.Sequence;
+
+                if (processedCount % checkpointFrequency == 0)
+                {
+                    subscription.Sequence = nextEvent.Sequence;
+                    await dbContext.SaveChangesAsync(stoppingToken);
+                }
             }
 
-            subscription.Sequence = nextEvent.Sequence;
-            await dbContext.SaveChangesAsync(stoppingToken);
+            if (lastProcessedSequence is long finalSequence && subscription.Sequence != finalSequence)
+            {
+                subscription.Sequence = finalSequence;
+                await dbContext.SaveChangesAsync(stoppingToken);
+            }
 
             await transaction.CommitAsync(stoppingToken);
 
             logger.LogInformation(
-                "Processed event {EventId} (Sequence {Sequence}) for subscription {Subscription}",
-                @event.Id, nextEvent.Sequence, name);
+                "Processed {Count} events through sequence {Sequence} for subscription {Subscription}",
+                processedCount,
+                lastProcessedSequence,
+                name);
 
-            return true;
+            return processedCount;
         }
         catch
         {

--- a/src/EventStoreCore/SubscriptionOptions.cs
+++ b/src/EventStoreCore/SubscriptionOptions.cs
@@ -4,6 +4,16 @@
 public sealed class SubscriptionOptions
 {
     /// <summary>
+    /// The number of events to read and process in each daemon batch.
+    /// </summary>
+    public int BatchSize { get; set; } = 500;
+
+    /// <summary>
+    /// How many processed events to handle before persisting the subscription checkpoint.
+    /// </summary>
+    public int CheckpointFrequency { get; set; } = 1;
+
+    /// <summary>
     /// How often to poll for new events when caught up.
     /// </summary>
     public TimeSpan PollingInterval { get; set; } = TimeSpan.FromSeconds(10);

--- a/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
@@ -12,7 +12,7 @@ namespace EventStoreCore.Tests;
 
 public class SubscriptionDaemonExecutionTests
 {
-    private sealed class ExecutionDbContext : DbContext
+    private class ExecutionDbContext : DbContext
     {
         public ExecutionDbContext(DbContextOptions<ExecutionDbContext> options) : base(options)
         {
@@ -24,12 +24,43 @@ public class SubscriptionDaemonExecutionTests
         }
     }
 
+    private sealed class CountingExecutionDbContext : ExecutionDbContext
+    {
+        public CountingExecutionDbContext(DbContextOptions<ExecutionDbContext> options) : base(options)
+        {
+        }
+
+        public int SubscriptionSaveChangesCount { get; private set; }
+
+        public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            CountSubscriptionCheckpointWrite();
+            return base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+        }
+
+        public void ResetCounters()
+        {
+            SubscriptionSaveChangesCount = 0;
+        }
+
+        private void CountSubscriptionCheckpointWrite()
+        {
+            if (ChangeTracker.Entries<DbSubscription>()
+                .Any(entry => entry.State is EntityState.Added or EntityState.Modified))
+            {
+                SubscriptionSaveChangesCount++;
+            }
+        }
+    }
+
     private sealed class RecordingSubscription : ISubscription
     {
         public bool Handled { get; private set; }
+        public int HandledCount { get; private set; }
         public Task Handle(IEvent @event, CancellationToken ct)
         {
             Handled = true;
+            HandledCount++;
             return Task.CompletedTask;
         }
     }
@@ -89,7 +120,8 @@ public class SubscriptionDaemonExecutionTests
         await task;
     }
 
-    private static ServiceProvider BuildProvider(ExecutionDbContext db, RecordingSubscription subscription)
+    private static ServiceProvider BuildProvider<TDbContext>(TDbContext db, RecordingSubscription subscription)
+        where TDbContext : DbContext
     {
         var services = new ServiceCollection();
         services.AddSingleton(db);
@@ -169,5 +201,96 @@ public class SubscriptionDaemonExecutionTests
         await RunExecuteAsync(daemon, cts.Token);
 
         Assert.False(subscription.Handled);
+    }
+
+    [Fact]
+    public async Task ProcessNextBatchAsync_ProcessesConfiguredBatchSize()
+    {
+        var db = BuildDbContext();
+        var subscription = new RecordingSubscription();
+        var provider = BuildProvider(db, subscription);
+        var lockProvider = new FakeLockProvider();
+        var options = Options.Create(new SubscriptionOptions
+        {
+            BatchSize = 2,
+            CheckpointFrequency = 2
+        });
+
+        db.Streams.StartStream(Guid.NewGuid(), events: [new object(), new object(), new object()]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await EnsureSequencesAsync(db);
+
+        var daemon = new SubscriptionDaemon<ExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            lockProvider,
+            options);
+
+        var processed = await daemon.ProcessNextBatchAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
+
+        var subscriptionEntity = await db.Set<DbSubscription>()
+            .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, processed);
+        Assert.Equal(2, subscription.HandledCount);
+        Assert.NotNull(subscriptionEntity);
+        Assert.Equal(2, subscriptionEntity.Sequence);
+    }
+
+    [Fact]
+    public async Task ProcessNextBatchAsync_CheckpointsAtConfiguredFrequency()
+    {
+        var db = BuildCountingDbContext();
+        var subscription = new RecordingSubscription();
+        var provider = BuildProvider(db, subscription);
+        var lockProvider = new FakeLockProvider();
+        var options = Options.Create(new SubscriptionOptions
+        {
+            BatchSize = 3,
+            CheckpointFrequency = 2
+        });
+
+        db.Streams.StartStream(Guid.NewGuid(), events: [new object(), new object(), new object()]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await EnsureSequencesAsync(db);
+        db.ResetCounters();
+
+        var daemon = new SubscriptionDaemon<CountingExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<CountingExecutionDbContext>>.Instance,
+            provider,
+            lockProvider,
+            options);
+
+        var processed = await daemon.ProcessNextBatchAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, processed);
+        Assert.Equal(3, subscription.HandledCount);
+        Assert.Equal(2, db.SubscriptionSaveChangesCount);
+    }
+
+    private static async Task EnsureSequencesAsync(ExecutionDbContext db)
+    {
+        var events = await db.Events
+            .OrderBy(e => e.Version)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        for (var i = 0; i < events.Count; i++)
+        {
+            events[i].Sequence = i + 1;
+        }
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static CountingExecutionDbContext BuildCountingDbContext()
+    {
+        var options = new DbContextOptionsBuilder<ExecutionDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .ConfigureWarnings(warnings =>
+                warnings.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        var db = new CountingExecutionDbContext(options);
+        db.Database.EnsureCreated();
+        return db;
     }
 }

--- a/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
@@ -65,6 +65,30 @@ public class SubscriptionDaemonExecutionTests
         }
     }
 
+    private sealed class ThrowingSubscription : ISubscription
+    {
+        private readonly int _throwOnAttempt;
+
+        public ThrowingSubscription(int throwOnAttempt)
+        {
+            _throwOnAttempt = throwOnAttempt;
+        }
+
+        public int HandledCount { get; private set; }
+
+        public Task Handle(IEvent @event, CancellationToken ct)
+        {
+            HandledCount++;
+
+            if (HandledCount == _throwOnAttempt)
+            {
+                throw new InvalidOperationException("Subscription handler failed.");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class FakeLockProvider : IDistributedLockProvider
     {
         public bool ReturnNullHandle { get; set; }
@@ -120,7 +144,7 @@ public class SubscriptionDaemonExecutionTests
         await task;
     }
 
-    private static ServiceProvider BuildProvider<TDbContext>(TDbContext db, RecordingSubscription subscription)
+    private static ServiceProvider BuildProvider<TDbContext>(TDbContext db, ISubscription subscription)
         where TDbContext : DbContext
     {
         var services = new ServiceCollection();
@@ -266,6 +290,40 @@ public class SubscriptionDaemonExecutionTests
         Assert.Equal(3, processed);
         Assert.Equal(3, subscription.HandledCount);
         Assert.Equal(2, db.SubscriptionSaveChangesCount);
+    }
+
+    [Fact]
+    public async Task ProcessNextBatchAsync_KeepsPersistedCheckpointWhenLaterEventFails()
+    {
+        var db = BuildDbContext();
+        var subscription = new ThrowingSubscription(throwOnAttempt: 2);
+        var provider = BuildProvider(db, subscription);
+        var lockProvider = new FakeLockProvider();
+        var options = Options.Create(new SubscriptionOptions
+        {
+            BatchSize = 3,
+            CheckpointFrequency = 1
+        });
+
+        db.Streams.StartStream(Guid.NewGuid(), events: [new object(), new object(), new object()]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await EnsureSequencesAsync(db);
+
+        var daemon = new SubscriptionDaemon<ExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            lockProvider,
+            options);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            daemon.ProcessNextBatchAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken));
+
+        var subscriptionEntity = await db.Set<DbSubscription>()
+            .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, subscription.HandledCount);
+        Assert.NotNull(subscriptionEntity);
+        Assert.Equal(1, subscriptionEntity.Sequence);
     }
 
     private static async Task EnsureSequencesAsync(ExecutionDbContext db)

--- a/tests/EventStoreCore.Tests/EventStoreBuilderPostgresExtensionsTests.cs
+++ b/tests/EventStoreCore.Tests/EventStoreBuilderPostgresExtensionsTests.cs
@@ -25,12 +25,16 @@ public class EventStoreBuilderPostgresExtensionsTests
         public Func<IServiceProvider, IDistributedLockProvider>? AddedFactory { get; private set; }
         public ProjectionMode? AddedMode { get; private set; }
         public Action<IProjectionOptions>? AddedConfigure { get; private set; }
+        public Action<SubscriptionOptions>? AddedSubscriptionConfigure { get; private set; }
         public bool ProjectionDaemonAdded { get; private set; }
         public Action<ProjectionDaemonOptions>? AddedDaemonConfigure { get; private set; }
 
-        public void AddSubscriptionDaemon(Func<IServiceProvider, IDistributedLockProvider> factory)
+        public void AddSubscriptionDaemon(
+            Func<IServiceProvider, IDistributedLockProvider> factory,
+            Action<SubscriptionOptions>? configure = null)
         {
             AddedFactory = factory;
+            AddedSubscriptionConfigure = configure;
         }
 
         public void AddProjection<TProjection, TSnapshot>(ProjectionMode mode, Action<IProjectionOptions>? configure) where TProjection : IProjection<TSnapshot>, new() where TSnapshot : class, new()
@@ -117,6 +121,35 @@ public class EventStoreBuilderPostgresExtensionsTests
         Assert.Same(builder, returned);
         Assert.NotNull(registrar.AddedFactory);
         Assert.Same(services, builder.Services);
+    }
+
+    [Fact]
+    public void AddSubscriptionDaemon_PassesConfigureCallback()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IDistributedLockProvider>());
+        var builder = new EventStoreBuilder(services);
+        var registrar = new FakeRegistrar();
+        builder.UseProvider(registrar);
+
+        var configureCalled = false;
+        var returned = builder.AddSubscriptionDaemon<EventStoreFixture.EventStoreDbContext>(options =>
+        {
+            configureCalled = true;
+            options.BatchSize = 123;
+            options.CheckpointFrequency = 7;
+        });
+
+        Assert.Same(builder, returned);
+        Assert.NotNull(registrar.AddedFactory);
+        Assert.NotNull(registrar.AddedSubscriptionConfigure);
+
+        var options = new SubscriptionOptions();
+        registrar.AddedSubscriptionConfigure!(options);
+
+        Assert.True(configureCalled);
+        Assert.Equal(123, options.BatchSize);
+        Assert.Equal(7, options.CheckpointFrequency);
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/SubscriptionOptionsTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionOptionsTests.cs
@@ -9,6 +9,8 @@ public class SubscriptionOptionsTests
     {
         var options = new SubscriptionOptions();
 
+        Assert.Equal(500, options.BatchSize);
+        Assert.Equal(1, options.CheckpointFrequency);
         Assert.Equal(TimeSpan.FromSeconds(10), options.PollingInterval);
         Assert.Equal(TimeSpan.FromMinutes(5), options.LockTimeout);
         Assert.Equal(3, options.MaxRetryAttempts);


### PR DESCRIPTION
## Summary
- add BatchSize and CheckpointFrequency to subscription daemon options and builder configuration
- process subscription events in batches while checkpointing at configurable intervals
- add test coverage for option defaults, builder wiring, and batch checkpoint behavior

Closes #27