### PR TITLE
Add subscription fault handling and admin controls

### DIFF
--- a/src/EventStoreCore.Abstractions/ISubscriptionManager.cs
+++ b/src/EventStoreCore.Abstractions/ISubscriptionManager.cs
@@ -1,7 +1,7 @@
 namespace EventStoreCore.Abstractions;
 
 /// <summary>
-/// Provides management operations for subscriptions including status and replay control.
+/// Provides management operations for subscriptions including status, fault handling, and replay control.
 /// </summary>
 public interface ISubscriptionManager
 {
@@ -19,6 +19,42 @@ public interface ISubscriptionManager
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A list of all subscription statuses.</returns>
     Task<IReadOnlyList<SubscriptionStatusDto>> GetAllStatusesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Pauses processing of the specified subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task PauseAsync(string subscriptionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resumes processing of a paused subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ResumeAsync(string subscriptionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retries the failed event for a faulted or dead-lettered subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task RetryFailedEventAsync(string subscriptionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Skips the failed event and resumes processing from the next event.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task SkipFailedEventAsync(string subscriptionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets details about the failed event for a faulted or dead-lettered subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Details about the failed event, or null if the subscription is not faulted.</returns>
+    Task<SubscriptionFailedEventDto?> GetFailedEventAsync(string subscriptionName, CancellationToken ct = default);
 
     /// <summary>
     /// Replays a subscription from a specific sequence or timestamp.
@@ -39,13 +75,73 @@ public interface ISubscriptionManager
 /// </summary>
 /// <param name="SubscriptionName">The unique subscription name.</param>
 /// <param name="Position">The sequence number of the last processed event.</param>
+/// <param name="State">The current lifecycle state of the subscription.</param>
 /// <param name="TotalEvents">The total number of events in the event store.</param>
 /// <param name="ProgressPercentage">The progress percentage based on current position.</param>
 /// <param name="LastProcessedAt">When the last processed event occurred.</param>
+/// <param name="LastError">The last error message if the subscription is faulted or dead-lettered.</param>
+/// <param name="AttemptCount">The number of attempts made against the current failed event.</param>
+/// <param name="LastAttemptAt">When the current failed event was last attempted.</param>
+/// <param name="NextAttemptAt">When the daemon will next retry the failed event, if applicable.</param>
+/// <param name="FailedEventSequence">The sequence number of the event that caused the fault.</param>
 public sealed record SubscriptionStatusDto(
     string SubscriptionName,
     long Position,
+    SubscriptionState State,
     long? TotalEvents,
     double? ProgressPercentage,
-    DateTimeOffset? LastProcessedAt
+    DateTimeOffset? LastProcessedAt,
+    string? LastError,
+    int AttemptCount,
+    DateTimeOffset? LastAttemptAt,
+    DateTimeOffset? NextAttemptAt,
+    long? FailedEventSequence
+);
+
+/// <summary>
+/// Represents the possible states of a subscription.
+/// </summary>
+public enum SubscriptionState
+{
+    /// <summary>
+    /// The subscription is operating normally.
+    /// </summary>
+    Active = 0,
+
+    /// <summary>
+    /// The subscription has been manually paused.
+    /// </summary>
+    Paused = 1,
+
+    /// <summary>
+    /// The subscription encountered an error and will be retried.
+    /// </summary>
+    Faulted = 2,
+
+    /// <summary>
+    /// The subscription exceeded retry attempts and requires manual intervention.
+    /// </summary>
+    DeadLettered = 3
+}
+
+/// <summary>
+/// Contains details about a failed subscription event for diagnostic purposes.
+/// </summary>
+/// <param name="EventId">The unique identifier of the event.</param>
+/// <param name="StreamId">The stream the event belongs to.</param>
+/// <param name="Version">The version of the event within its stream.</param>
+/// <param name="Sequence">The global sequence number of the event.</param>
+/// <param name="EventType">The type name of the event.</param>
+/// <param name="Data">The serialized event data as JSON.</param>
+/// <param name="Timestamp">When the event was created.</param>
+/// <param name="SubscriptionError">The last processing error for the subscription.</param>
+public sealed record SubscriptionFailedEventDto(
+    Guid EventId,
+    Guid StreamId,
+    long Version,
+    long Sequence,
+    string EventType,
+    string Data,
+    DateTimeOffset Timestamp,
+    string SubscriptionError
 );

--- a/src/EventStoreCore.Endpoints/RouteBuilderExtensions.cs
+++ b/src/EventStoreCore.Endpoints/RouteBuilderExtensions.cs
@@ -167,6 +167,89 @@ public static class RouteBuilderExtensions
         .Produces<SubscriptionStatusDto>()
         .Produces(StatusCodes.Status404NotFound);
 
+        // POST /subscriptions/{name}/pause - Pause subscription
+        group.MapPost("/subscriptions/{name}/pause", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        {
+            try
+            {
+                await manager.PauseAsync(name, ct);
+                return Results.Ok();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .WithName("PauseSubscription")
+        .WithDescription("Pauses processing of the specified subscription")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        // POST /subscriptions/{name}/resume - Resume subscription
+        group.MapPost("/subscriptions/{name}/resume", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        {
+            try
+            {
+                await manager.ResumeAsync(name, ct);
+                return Results.Ok();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .WithName("ResumeSubscription")
+        .WithDescription("Resumes processing of a paused subscription")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        // GET /subscriptions/{name}/failed-event - Get failed event details
+        group.MapGet("/subscriptions/{name}/failed-event", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        {
+            var failedEvent = await manager.GetFailedEventAsync(name, ct);
+            return failedEvent != null ? Results.Ok(failedEvent) : Results.NotFound();
+        })
+        .WithName("GetSubscriptionFailedEvent")
+        .WithDescription("Gets details about the failed event for a faulted or dead-lettered subscription")
+        .Produces<SubscriptionFailedEventDto>()
+        .Produces(StatusCodes.Status404NotFound);
+
+        // POST /subscriptions/{name}/retry - Retry failed event
+        group.MapPost("/subscriptions/{name}/retry", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        {
+            try
+            {
+                await manager.RetryFailedEventAsync(name, ct);
+                return Results.Ok();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .WithName("RetrySubscriptionFailedEvent")
+        .WithDescription("Retries processing the failed subscription event")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        // POST /subscriptions/{name}/skip - Skip failed event
+        group.MapPost("/subscriptions/{name}/skip", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        {
+            try
+            {
+                await manager.SkipFailedEventAsync(name, ct);
+                return Results.Ok();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .WithName("SkipSubscriptionFailedEvent")
+        .WithDescription("Skips the failed subscription event and resumes processing")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest);
+
         // POST /subscriptions/{name}/replay - Trigger replay
         group.MapPost("/subscriptions/{name}/replay", async (
             [FromRoute] string name,

--- a/src/EventStoreCore.SDK/IEventStoreEndpointsClient.cs
+++ b/src/EventStoreCore.SDK/IEventStoreEndpointsClient.cs
@@ -93,6 +93,47 @@ public interface IEventStoreEndpointsClient
     Task<SubscriptionStatusDto?> GetSubscriptionAsync(string name, CancellationToken ct = default);
 
     /// <summary>
+    /// Pauses processing of the specified subscription.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/pause")]
+    Task PauseSubscriptionAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resumes processing of a paused subscription.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/resume")]
+    Task ResumeSubscriptionAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets details about the failed event for a faulted or dead-lettered subscription.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The failed event details, or null when not found.</returns>
+    [Get("/subscriptions/{name}/failed-event")]
+    Task<SubscriptionFailedEventDto?> GetSubscriptionFailedEventAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retries processing the failed subscription event.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/retry")]
+    Task RetrySubscriptionFailedEventAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Skips the failed subscription event and resumes processing.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/skip")]
+    Task SkipSubscriptionFailedEventAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
     /// Replays a subscription from a specific sequence or timestamp.
     /// </summary>
     /// <param name="name">The subscription name.</param>

--- a/src/EventStoreCore/DbSubscription.cs
+++ b/src/EventStoreCore/DbSubscription.cs
@@ -1,7 +1,9 @@
 namespace EventStoreCore;
 
+using EventStoreCore.Abstractions;
+
 /// <summary>
-/// Represents persisted subscription progress.
+/// Represents persisted subscription progress and operational state.
 /// </summary>
 public sealed class DbSubscription
 {
@@ -14,5 +16,60 @@ public sealed class DbSubscription
     /// The last processed event sequence number.
     /// </summary>
     public long Sequence { get; set; } = 0;
+
+    /// <summary>
+    /// The current lifecycle state of the subscription.
+    /// </summary>
+    public SubscriptionState State { get; set; } = SubscriptionState.Active;
+
+    /// <summary>
+    /// The last error observed while processing the current failed event.
+    /// </summary>
+    public string? LastError { get; set; }
+
+    /// <summary>
+    /// The number of attempts made against the current failed event.
+    /// </summary>
+    public int AttemptCount { get; set; }
+
+    /// <summary>
+    /// When the current failed event was last attempted.
+    /// </summary>
+    public DateTimeOffset? LastAttemptAt { get; set; }
+
+    /// <summary>
+    /// When the daemon should next retry the current failed event.
+    /// </summary>
+    public DateTimeOffset? NextAttemptAt { get; set; }
+
+    /// <summary>
+    /// The sequence number of the event that caused the current fault.
+    /// </summary>
+    public long? FailedEventSequence { get; set; }
+
+    /// <summary>
+    /// Converts this entity to an external status DTO.
+    /// </summary>
+    /// <param name="totalEvents">The total number of events in the store.</param>
+    /// <param name="lastProcessedAt">When the last processed event occurred.</param>
+    public SubscriptionStatusDto ToDto(long? totalEvents, DateTimeOffset? lastProcessedAt)
+    {
+        var progress = totalEvents.HasValue && totalEvents.Value > 0
+            ? Math.Round((double)Sequence / totalEvents.Value * 100, 2)
+            : (double?)null;
+
+        return new SubscriptionStatusDto(
+            SubscriptionAssemblyQualifiedName,
+            Sequence,
+            State,
+            totalEvents,
+            progress,
+            lastProcessedAt,
+            LastError,
+            AttemptCount,
+            LastAttemptAt,
+            NextAttemptAt,
+            FailedEventSequence);
+    }
 }
 

--- a/src/EventStoreCore/ModelBuilderExtensions.cs
+++ b/src/EventStoreCore/ModelBuilderExtensions.cs
@@ -96,8 +96,27 @@ internal static class ModelBuilderExtensions
 
             entity.HasKey(e => e.SubscriptionAssemblyQualifiedName);
 
+            entity.Property(e => e.SubscriptionAssemblyQualifiedName)
+                .IsRequired();
+
             entity.Property(e => e.Sequence)
-                    .IsRequired();
+                .IsRequired();
+
+            entity.Property(e => e.State)
+                .IsRequired();
+
+            entity.Property(e => e.LastError);
+
+            entity.Property(e => e.AttemptCount)
+                .IsRequired();
+
+            entity.Property(e => e.LastAttemptAt);
+
+            entity.Property(e => e.NextAttemptAt);
+
+            entity.Property(e => e.FailedEventSequence);
+
+            entity.HasIndex(e => e.State);
         });
 
         modelBuilder.Entity<DbProjectionStatus>(entity =>

--- a/src/EventStoreCore/SubscriptionDaemon.cs
+++ b/src/EventStoreCore/SubscriptionDaemon.cs
@@ -132,10 +132,12 @@ public sealed class SubscriptionDaemon<TDbContext>(
         var name = subscriptionImpl.GetType().AssemblyQualifiedName!;
         var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
 
+        await using var transaction = await dbContext.Database.BeginTransactionAsync(stoppingToken);
+
         try
         {
             var subscriptionSet = dbContext.Set<DbSubscription>();
-            var subscription = await dbContext.Set<DbSubscription>().FindAsync([name], stoppingToken);
+            var subscription = await subscriptionSet.FindAsync([name], stoppingToken);
             var createdSubscription = false;
 
             if (subscription is null)
@@ -149,6 +151,17 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 logger.LogInformation("Created new subscription entity for {Subscription}", name);
             }
 
+            if (!CanProcess(subscription, name))
+            {
+                if (createdSubscription)
+                {
+                    await dbContext.SaveChangesAsync(stoppingToken);
+                    await transaction.CommitAsync(stoppingToken);
+                }
+
+                return 0;
+            }
+
             var nextEvents = await dbContext.Events
                 .Where(e => e.Sequence > subscription.Sequence)
                 .OrderBy(e => e.Sequence)
@@ -160,6 +173,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 if (createdSubscription)
                 {
                     await dbContext.SaveChangesAsync(stoppingToken);
+                    await transaction.CommitAsync(stoppingToken);
                 }
 
                 return 0;
@@ -171,24 +185,51 @@ public sealed class SubscriptionDaemon<TDbContext>(
 
             foreach (var nextEvent in nextEvents)
             {
-                var @event = nextEvent.ToEvent(registry);
-
-                if (subscriptionImpl is IScopedSubscription scoped)
+                try
                 {
-                    await scoped.HandleAsync(dbContext, @event, stoppingToken);
+                    subscription.LastAttemptAt = DateTimeOffset.UtcNow;
+                    var @event = nextEvent.ToEvent(registry);
+
+                    if (subscriptionImpl is IScopedSubscription scoped)
+                    {
+                        await scoped.HandleAsync(dbContext, @event, stoppingToken);
+                    }
+                    else
+                    {
+                        await subscriptionImpl.Handle(@event, stoppingToken);
+                    }
+
+                    processedCount++;
+                    lastProcessedSequence = nextEvent.Sequence;
+
+                    subscription.State = SubscriptionState.Active;
+                    subscription.LastError = null;
+                    subscription.AttemptCount = 0;
+                    subscription.NextAttemptAt = null;
+                    subscription.FailedEventSequence = null;
+
+                    if (processedCount % checkpointFrequency == 0)
+                    {
+                        subscription.Sequence = nextEvent.Sequence;
+                        await dbContext.SaveChangesAsync(stoppingToken);
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    await subscriptionImpl.Handle(@event, stoppingToken);
-                }
+                    logger.LogError(
+                        ex,
+                        "Error processing event at sequence {Sequence} for subscription {Subscription}",
+                        nextEvent.Sequence,
+                        name);
 
-                processedCount++;
-                lastProcessedSequence = nextEvent.Sequence;
+                    if (lastProcessedSequence is long persistedSequence && subscription.Sequence != persistedSequence)
+                    {
+                        subscription.Sequence = persistedSequence;
+                        await dbContext.SaveChangesAsync(stoppingToken);
+                    }
 
-                if (processedCount % checkpointFrequency == 0)
-                {
-                    subscription.Sequence = nextEvent.Sequence;
-                    await dbContext.SaveChangesAsync(stoppingToken);
+                    await PersistFailureAsync(name, nextEvent.Sequence, ex, stoppingToken);
+                    return processedCount;
                 }
             }
 
@@ -197,6 +238,8 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 subscription.Sequence = finalSequence;
                 await dbContext.SaveChangesAsync(stoppingToken);
             }
+
+            await transaction.CommitAsync(stoppingToken);
 
             logger.LogInformation(
                 "Processed {Count} events through sequence {Sequence} for subscription {Subscription}",
@@ -262,5 +305,73 @@ public sealed class SubscriptionDaemon<TDbContext>(
                     name);
             return null;
         }
+    }
+
+    private bool CanProcess(DbSubscription subscription, string name)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        switch (subscription.State)
+        {
+            case SubscriptionState.Active:
+                return true;
+
+            case SubscriptionState.Paused:
+                logger.LogDebug("Subscription {Subscription} is paused, skipping", name);
+                return false;
+
+            case SubscriptionState.Faulted when subscription.NextAttemptAt.HasValue && subscription.NextAttemptAt.Value > now:
+                logger.LogDebug(
+                    "Subscription {Subscription} is faulted until {NextAttemptAt}, skipping",
+                    name,
+                    subscription.NextAttemptAt);
+                return false;
+
+            case SubscriptionState.Faulted:
+                return true;
+
+            case SubscriptionState.DeadLettered:
+                logger.LogDebug("Subscription {Subscription} is dead-lettered, requires manual intervention", name);
+                return false;
+
+            default:
+                return true;
+        }
+    }
+
+    private async Task PersistFailureAsync(
+        string subscriptionName,
+        long failedSequence,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        using var errorScope = _serviceProvider.CreateScope();
+        var errorContext = errorScope.ServiceProvider.GetRequiredService<TDbContext>();
+        var subscriptionSet = errorContext.Set<DbSubscription>();
+        var status = subscriptionSet.Local
+            .FirstOrDefault(s => s.SubscriptionAssemblyQualifiedName == subscriptionName)
+            ?? await subscriptionSet.FirstOrDefaultAsync(
+                s => s.SubscriptionAssemblyQualifiedName == subscriptionName,
+                cancellationToken);
+
+        if (status is null)
+        {
+            status = new DbSubscription
+            {
+                SubscriptionAssemblyQualifiedName = subscriptionName
+            };
+            subscriptionSet.Add(status);
+        }
+
+        status.AttemptCount += 1;
+        status.LastAttemptAt = DateTimeOffset.UtcNow;
+        status.NextAttemptAt = status.LastAttemptAt.Value.Add(_options.RetryDelay);
+        status.LastError = exception.ToString();
+        status.FailedEventSequence = failedSequence;
+        status.State = status.AttemptCount >= _options.MaxRetryAttempts
+            ? SubscriptionState.DeadLettered
+            : SubscriptionState.Faulted;
+
+        await errorContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/EventStoreCore/SubscriptionDaemon.cs
+++ b/src/EventStoreCore/SubscriptionDaemon.cs
@@ -214,6 +214,10 @@ public sealed class SubscriptionDaemon<TDbContext>(
                         await dbContext.SaveChangesAsync(stoppingToken);
                     }
                 }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     logger.LogError(
@@ -225,10 +229,11 @@ public sealed class SubscriptionDaemon<TDbContext>(
                     if (lastProcessedSequence is long persistedSequence && subscription.Sequence != persistedSequence)
                     {
                         subscription.Sequence = persistedSequence;
-                        await dbContext.SaveChangesAsync(stoppingToken);
                     }
 
-                    await PersistFailureAsync(name, nextEvent.Sequence, ex, stoppingToken);
+                    PersistFailure(subscription, nextEvent.Sequence, ex);
+                    await dbContext.SaveChangesAsync(stoppingToken);
+                    await transaction.CommitAsync(stoppingToken);
                     return processedCount;
                 }
             }
@@ -339,39 +344,18 @@ public sealed class SubscriptionDaemon<TDbContext>(
         }
     }
 
-    private async Task PersistFailureAsync(
-        string subscriptionName,
+    private void PersistFailure(
+        DbSubscription subscription,
         long failedSequence,
-        Exception exception,
-        CancellationToken cancellationToken)
+        Exception exception)
     {
-        using var errorScope = _serviceProvider.CreateScope();
-        var errorContext = errorScope.ServiceProvider.GetRequiredService<TDbContext>();
-        var subscriptionSet = errorContext.Set<DbSubscription>();
-        var status = subscriptionSet.Local
-            .FirstOrDefault(s => s.SubscriptionAssemblyQualifiedName == subscriptionName)
-            ?? await subscriptionSet.FirstOrDefaultAsync(
-                s => s.SubscriptionAssemblyQualifiedName == subscriptionName,
-                cancellationToken);
-
-        if (status is null)
-        {
-            status = new DbSubscription
-            {
-                SubscriptionAssemblyQualifiedName = subscriptionName
-            };
-            subscriptionSet.Add(status);
-        }
-
-        status.AttemptCount += 1;
-        status.LastAttemptAt = DateTimeOffset.UtcNow;
-        status.NextAttemptAt = status.LastAttemptAt.Value.Add(_options.RetryDelay);
-        status.LastError = exception.ToString();
-        status.FailedEventSequence = failedSequence;
-        status.State = status.AttemptCount >= _options.MaxRetryAttempts
+        subscription.AttemptCount += 1;
+        subscription.LastAttemptAt ??= DateTimeOffset.UtcNow;
+        subscription.NextAttemptAt = subscription.LastAttemptAt.Value.Add(_options.RetryDelay);
+        subscription.LastError = exception.ToString();
+        subscription.FailedEventSequence = failedSequence;
+        subscription.State = subscription.AttemptCount >= _options.MaxRetryAttempts
             ? SubscriptionState.DeadLettered
             : SubscriptionState.Faulted;
-
-        await errorContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/EventStoreCore/SubscriptionManager.cs
+++ b/src/EventStoreCore/SubscriptionManager.cs
@@ -57,20 +57,21 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
             return new SubscriptionStatusDto(
                 subscriptionName,
                 0,
+                SubscriptionState.Active,
                 totalEvents,
                 CalculateProgress(0, totalEvents),
+                null,
+                null,
+                0,
+                null,
+                null,
                 null);
         }
 
         var lastProcessedAt = await GetLastProcessedAtAsync(record.Sequence, ct);
         var totalCount = await _dbContext.Events.LongCountAsync(ct);
 
-        return new SubscriptionStatusDto(
-            record.SubscriptionAssemblyQualifiedName,
-            record.Sequence,
-            totalCount,
-            CalculateProgress(record.Sequence, totalCount),
-            lastProcessedAt);
+        return record.ToDto(totalCount, lastProcessedAt);
     }
 
     /// <inheritdoc />
@@ -88,13 +89,7 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         foreach (var record in records)
         {
             lastProcessedLookup.TryGetValue(record.Sequence, out var lastProcessedAt);
-
-            result.Add(new SubscriptionStatusDto(
-                record.SubscriptionAssemblyQualifiedName,
-                record.Sequence,
-                totalEvents,
-                CalculateProgress(record.Sequence, totalEvents),
-                lastProcessedAt));
+            result.Add(record.ToDto(totalEvents, lastProcessedAt));
         }
 
         foreach (var subscriptionName in _subscriptionNames)
@@ -104,13 +99,130 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
                 result.Add(new SubscriptionStatusDto(
                     subscriptionName,
                     0,
+                    SubscriptionState.Active,
                     totalEvents,
                     CalculateProgress(0, totalEvents),
+                    null,
+                    null,
+                    0,
+                    null,
+                    null,
                     null));
             }
         }
 
         return result;
+    }
+
+    /// <inheritdoc />
+    public async Task PauseAsync(string subscriptionName, CancellationToken ct = default)
+    {
+        var status = await GetExistingStatusAsync(subscriptionName, ct);
+
+        if (status.State is SubscriptionState.Faulted or SubscriptionState.DeadLettered)
+        {
+            throw new InvalidOperationException("Cannot pause a faulted or dead-lettered subscription. Retry or skip the failed event first.");
+        }
+
+        if (status.State == SubscriptionState.Paused)
+        {
+            throw new InvalidOperationException("Subscription is already paused.");
+        }
+
+        status.State = SubscriptionState.Paused;
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Paused subscription {Subscription}", subscriptionName);
+    }
+
+    /// <inheritdoc />
+    public async Task ResumeAsync(string subscriptionName, CancellationToken ct = default)
+    {
+        var status = await GetExistingStatusAsync(subscriptionName, ct);
+
+        if (status.State != SubscriptionState.Paused)
+        {
+            throw new InvalidOperationException($"Subscription is not paused. Current state: {status.State}");
+        }
+
+        status.State = SubscriptionState.Active;
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Resumed subscription {Subscription}", subscriptionName);
+    }
+
+    /// <inheritdoc />
+    public async Task RetryFailedEventAsync(string subscriptionName, CancellationToken ct = default)
+    {
+        var status = await GetExistingStatusAsync(subscriptionName, ct);
+
+        if (status.State is not (SubscriptionState.Faulted or SubscriptionState.DeadLettered))
+        {
+            throw new InvalidOperationException($"Subscription is not faulted. Current state: {status.State}");
+        }
+
+        ResetFailureState(status);
+        status.State = SubscriptionState.Active;
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Retrying failed event for subscription {Subscription}", subscriptionName);
+    }
+
+    /// <inheritdoc />
+    public async Task SkipFailedEventAsync(string subscriptionName, CancellationToken ct = default)
+    {
+        var status = await GetExistingStatusAsync(subscriptionName, ct);
+
+        if (status.State is not (SubscriptionState.Faulted or SubscriptionState.DeadLettered) || !status.FailedEventSequence.HasValue)
+        {
+            throw new InvalidOperationException("Subscription is not faulted or has no failed event to skip.");
+        }
+
+        status.Sequence = status.FailedEventSequence.Value;
+        ResetFailureState(status);
+        status.State = SubscriptionState.Active;
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Skipped failed event at sequence {Sequence} for subscription {Subscription}",
+            status.Sequence,
+            subscriptionName);
+    }
+
+    /// <inheritdoc />
+    public async Task<SubscriptionFailedEventDto?> GetFailedEventAsync(string subscriptionName, CancellationToken ct = default)
+    {
+        var status = await _dbContext.Set<DbSubscription>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.SubscriptionAssemblyQualifiedName == subscriptionName, ct);
+
+        if (status?.State is not (SubscriptionState.Faulted or SubscriptionState.DeadLettered) || !status.FailedEventSequence.HasValue)
+        {
+            return null;
+        }
+
+        var dbEvent = await _dbContext.Events
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Sequence == status.FailedEventSequence, ct);
+
+        if (dbEvent == null)
+        {
+            return null;
+        }
+
+        var eventTypeName = string.IsNullOrWhiteSpace(dbEvent.TypeName)
+            ? dbEvent.Type
+            : dbEvent.TypeName;
+
+        return new SubscriptionFailedEventDto(
+            dbEvent.EventId,
+            dbEvent.StreamId,
+            dbEvent.Version,
+            dbEvent.Sequence,
+            eventTypeName,
+            dbEvent.Data,
+            dbEvent.Timestamp,
+            status.LastError ?? "Unknown error");
     }
 
     /// <inheritdoc />
@@ -147,6 +259,8 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
 
         var targetSequence = await ResolveReplayPositionAsync(startSequence, fromTimestamp, ct);
         record.Sequence = targetSequence;
+        record.State = SubscriptionState.Active;
+        ResetFailureState(record);
 
         await _dbContext.SaveChangesAsync(ct);
 
@@ -192,6 +306,22 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         }
 
         return 0;
+    }
+
+    private async Task<DbSubscription> GetExistingStatusAsync(string subscriptionName, CancellationToken ct)
+    {
+        return await _dbContext.Set<DbSubscription>()
+            .FirstOrDefaultAsync(s => s.SubscriptionAssemblyQualifiedName == subscriptionName, ct)
+            ?? throw new InvalidOperationException($"Subscription '{subscriptionName}' not found.");
+    }
+
+    private static void ResetFailureState(DbSubscription status)
+    {
+        status.LastError = null;
+        status.AttemptCount = 0;
+        status.LastAttemptAt = null;
+        status.NextAttemptAt = null;
+        status.FailedEventSequence = null;
     }
 
     /// <summary>

--- a/tests/EventStoreCore.Tests/AdminEndpointTests.cs
+++ b/tests/EventStoreCore.Tests/AdminEndpointTests.cs
@@ -22,10 +22,12 @@ public class AdminEndpointTests : IAsyncLifetime
     private IHost _host = null!;
     private HttpClient _client = null!;
     private IProjectionManager _mockManager = null!;
+    private ISubscriptionManager _mockSubscriptionManager = null!;
 
     public async ValueTask InitializeAsync()
     {
         _mockManager = Substitute.For<IProjectionManager>();
+        _mockSubscriptionManager = Substitute.For<ISubscriptionManager>();
 
         _host = new HostBuilder()
             .ConfigureWebHost(webBuilder =>
@@ -36,6 +38,7 @@ public class AdminEndpointTests : IAsyncLifetime
                     {
                         services.AddRouting();
                         services.AddSingleton(_mockManager);
+                        services.AddSingleton(_mockSubscriptionManager);
                     })
                     .Configure(app =>
                     {
@@ -115,6 +118,160 @@ public class AdminEndpointTests : IAsyncLifetime
         Assert.Equal("TestProjection", projections[0].ProjectionName);
         Assert.Equal(ProjectionState.Active, projections[0].State);
         Assert.Equal(100, projections[0].Position);
+    }
+
+    #endregion
+
+    #region GET /subscriptions Tests
+
+    [Fact]
+    public async Task GetAllSubscriptions_ReturnsSubscriptions_WhenSubscriptionsExist()
+    {
+        var expected = new List<SubscriptionStatusDto>
+        {
+            new SubscriptionStatusDto(
+                SubscriptionName: "TestSubscription",
+                Position: 10,
+                State: SubscriptionState.Faulted,
+                TotalEvents: 20,
+                ProgressPercentage: 50.0,
+                LastProcessedAt: DateTimeOffset.UtcNow,
+                LastError: "boom",
+                AttemptCount: 2,
+                LastAttemptAt: DateTimeOffset.UtcNow,
+                NextAttemptAt: DateTimeOffset.UtcNow.AddMinutes(1),
+                FailedEventSequence: 11)
+        };
+
+        _mockSubscriptionManager.GetAllStatusesAsync(Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var response = await _client.GetAsync("/api/eventstore/admin/subscriptions",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var subscriptions = await response.Content.ReadFromJsonAsync<List<SubscriptionStatusDto>>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(subscriptions);
+        Assert.Single(subscriptions);
+        Assert.Equal(SubscriptionState.Faulted, subscriptions[0].State);
+    }
+
+    [Fact]
+    public async Task GetSubscription_ReturnsSubscription_WhenSubscriptionExists()
+    {
+        var expected = new SubscriptionStatusDto(
+            SubscriptionName: "TestSubscription",
+            Position: 10,
+            State: SubscriptionState.Paused,
+            TotalEvents: 20,
+            ProgressPercentage: 50.0,
+            LastProcessedAt: DateTimeOffset.UtcNow,
+            LastError: null,
+            AttemptCount: 0,
+            LastAttemptAt: null,
+            NextAttemptAt: null,
+            FailedEventSequence: null);
+
+        _mockSubscriptionManager.GetStatusAsync("TestSubscription", Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var response = await _client.GetAsync(
+            "/api/eventstore/admin/subscriptions/TestSubscription",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var subscription = await response.Content.ReadFromJsonAsync<SubscriptionStatusDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(subscription);
+        Assert.Equal(SubscriptionState.Paused, subscription.State);
+    }
+
+    [Fact]
+    public async Task PauseSubscription_ReturnsOk_WhenSuccessful()
+    {
+        _mockSubscriptionManager.PauseAsync("TestSubscription", Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var response = await _client.PostAsync(
+            "/api/eventstore/admin/subscriptions/TestSubscription/pause",
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await _mockSubscriptionManager.Received(1).PauseAsync("TestSubscription", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResumeSubscription_ReturnsOk_WhenSuccessful()
+    {
+        _mockSubscriptionManager.ResumeAsync("TestSubscription", Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var response = await _client.PostAsync(
+            "/api/eventstore/admin/subscriptions/TestSubscription/resume",
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await _mockSubscriptionManager.Received(1).ResumeAsync("TestSubscription", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetSubscriptionFailedEvent_ReturnsFailedEvent_WhenFaulted()
+    {
+        var expected = new SubscriptionFailedEventDto(
+            EventId: Guid.NewGuid(),
+            StreamId: Guid.NewGuid(),
+            Version: 1,
+            Sequence: 42,
+            EventType: "TestEvent",
+            Data: "{}",
+            Timestamp: DateTimeOffset.UtcNow,
+            SubscriptionError: "boom");
+
+        _mockSubscriptionManager.GetFailedEventAsync("TestSubscription", Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var response = await _client.GetAsync(
+            "/api/eventstore/admin/subscriptions/TestSubscription/failed-event",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var failedEvent = await response.Content.ReadFromJsonAsync<SubscriptionFailedEventDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(failedEvent);
+        Assert.Equal(42, failedEvent.Sequence);
+    }
+
+    [Fact]
+    public async Task RetrySubscriptionFailedEvent_ReturnsOk_WhenSuccessful()
+    {
+        _mockSubscriptionManager.RetryFailedEventAsync("TestSubscription", Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var response = await _client.PostAsync(
+            "/api/eventstore/admin/subscriptions/TestSubscription/retry",
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await _mockSubscriptionManager.Received(1).RetryFailedEventAsync("TestSubscription", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SkipSubscriptionFailedEvent_ReturnsOk_WhenSuccessful()
+    {
+        _mockSubscriptionManager.SkipFailedEventAsync("TestSubscription", Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var response = await _client.PostAsync(
+            "/api/eventstore/admin/subscriptions/TestSubscription/skip",
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await _mockSubscriptionManager.Received(1).SkipFailedEventAsync("TestSubscription", Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -459,12 +616,16 @@ public class AdminEndpointOptionsTests : IAsyncLifetime
     private IHost _host = null!;
     private HttpClient _client = null!;
     private IProjectionManager _mockManager = null!;
+    private ISubscriptionManager _mockSubscriptionManager = null!;
 
     public async ValueTask InitializeAsync()
     {
         _mockManager = Substitute.For<IProjectionManager>();
         _mockManager.GetAllStatusesAsync(Arg.Any<CancellationToken>())
             .Returns(new List<ProjectionStatusDto>());
+        _mockSubscriptionManager = Substitute.For<ISubscriptionManager>();
+        _mockSubscriptionManager.GetAllStatusesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<SubscriptionStatusDto>());
 
         _host = new HostBuilder()
             .ConfigureWebHost(webBuilder =>
@@ -475,6 +636,7 @@ public class AdminEndpointOptionsTests : IAsyncLifetime
                     {
                         services.AddRouting();
                         services.AddSingleton(_mockManager);
+                        services.AddSingleton(_mockSubscriptionManager);
                     })
                     .Configure(app =>
                     {

--- a/tests/EventStoreCore.Tests/Coverage/SubscriptionManagerCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/SubscriptionManagerCoverageTests.cs
@@ -127,6 +127,7 @@ public class SubscriptionManagerCoverageTests
         Assert.Single(statuses);
         Assert.Equal(typeof(SampleSubscription).AssemblyQualifiedName, statuses[0].SubscriptionName);
         Assert.Equal(0, statuses[0].Position);
+        Assert.Equal(SubscriptionState.Active, statuses[0].State);
     }
 
     [Fact]
@@ -159,5 +160,46 @@ public class SubscriptionManagerCoverageTests
 
         Assert.NotNull(status);
         Assert.Equal(trackedEvent.Sequence, status!.Position);
+    }
+
+    [Fact]
+    public async Task RetryFailedEventAsync_ThrowsWhenSubscriptionIsNotFaulted()
+    {
+        var db = BuildDbContext();
+        var subscription = new SampleSubscription();
+        var manager = BuildManager(db, new[] { subscription });
+        var name = typeof(SampleSubscription).AssemblyQualifiedName!;
+
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = name,
+            State = SubscriptionState.Active
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            manager.RetryFailedEventAsync(name, TestContext.Current.CancellationToken));
+
+        Assert.Contains("not faulted", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetFailedEventAsync_ReturnsNull_WhenSubscriptionIsNotFaulted()
+    {
+        var db = BuildDbContext();
+        var subscription = new SampleSubscription();
+        var manager = BuildManager(db, new[] { subscription });
+        var name = typeof(SampleSubscription).AssemblyQualifiedName!;
+
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = name,
+            State = SubscriptionState.Active
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var failedEvent = await manager.GetFailedEventAsync(name, TestContext.Current.CancellationToken);
+
+        Assert.Null(failedEvent);
     }
 }

--- a/tests/EventStoreCore.Tests/Coverage/SubscriptionStatusDtoCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/SubscriptionStatusDtoCoverageTests.cs
@@ -8,12 +8,30 @@ public class SubscriptionStatusDtoCoverageTests
     public void RecordProperties_AreAccessible()
     {
         var timestamp = DateTimeOffset.UtcNow;
-        var dto = new SubscriptionStatusDto("sub", 2, 10, 20.5, timestamp);
+        var nextAttemptAt = timestamp.AddMinutes(1);
+        var dto = new SubscriptionStatusDto(
+            "sub",
+            2,
+            SubscriptionState.Faulted,
+            10,
+            20.5,
+            timestamp,
+            "boom",
+            3,
+            timestamp,
+            nextAttemptAt,
+            4);
 
         Assert.Equal("sub", dto.SubscriptionName);
         Assert.Equal(2, dto.Position);
+        Assert.Equal(SubscriptionState.Faulted, dto.State);
         Assert.Equal(10, dto.TotalEvents);
         Assert.Equal(20.5, dto.ProgressPercentage);
         Assert.Equal(timestamp, dto.LastProcessedAt);
+        Assert.Equal("boom", dto.LastError);
+        Assert.Equal(3, dto.AttemptCount);
+        Assert.Equal(timestamp, dto.LastAttemptAt);
+        Assert.Equal(nextAttemptAt, dto.NextAttemptAt);
+        Assert.Equal(4, dto.FailedEventSequence);
     }
 }

--- a/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
@@ -69,7 +69,7 @@ public class SubscriptionDaemonExecutionTests
     {
         private readonly int _throwOnAttempt;
 
-        public ThrowingSubscription(int throwOnAttempt)
+        public ThrowingSubscription(int throwOnAttempt = 1)
         {
             _throwOnAttempt = throwOnAttempt;
         }
@@ -302,7 +302,9 @@ public class SubscriptionDaemonExecutionTests
         var options = Options.Create(new SubscriptionOptions
         {
             BatchSize = 3,
-            CheckpointFrequency = 1
+            CheckpointFrequency = 1,
+            RetryDelay = TimeSpan.FromSeconds(5),
+            MaxRetryAttempts = 3
         });
 
         db.Streams.StartStream(Guid.NewGuid(), events: [new object(), new object(), new object()]);
@@ -315,15 +317,117 @@ public class SubscriptionDaemonExecutionTests
             lockProvider,
             options);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            daemon.ProcessNextBatchAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken));
-
+        var processed = await daemon.ProcessNextBatchAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
         var subscriptionEntity = await db.Set<DbSubscription>()
             .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
 
+        Assert.Equal(1, processed);
         Assert.Equal(2, subscription.HandledCount);
         Assert.NotNull(subscriptionEntity);
+        Assert.Equal(SubscriptionState.Faulted, subscriptionEntity!.State);
         Assert.Equal(1, subscriptionEntity.Sequence);
+        Assert.Equal(2, subscriptionEntity.FailedEventSequence);
+    }
+
+    [Fact]
+    public async Task ProcessNextEventAsync_FaultsSubscriptionAndSchedulesRetry()
+    {
+        var db = BuildDbContext();
+        var subscription = new ThrowingSubscription();
+        var provider = BuildProvider(db, subscription);
+        var daemon = new SubscriptionDaemon<ExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new SubscriptionOptions
+            {
+                RetryDelay = TimeSpan.FromSeconds(5),
+                MaxRetryAttempts = 3
+            }));
+
+        db.Streams.StartStream(Guid.NewGuid(), events: [new object()]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await EnsureSequenceAsync(db);
+
+        var processed = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
+        var status = await db.Set<DbSubscription>()
+            .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
+
+        Assert.False(processed);
+        Assert.NotNull(status);
+        Assert.Equal(SubscriptionState.Faulted, status!.State);
+        Assert.Equal(1, status.AttemptCount);
+        Assert.NotNull(status.LastError);
+        Assert.NotNull(status.LastAttemptAt);
+        Assert.NotNull(status.NextAttemptAt);
+        Assert.NotNull(status.FailedEventSequence);
+    }
+
+    [Fact]
+    public async Task ProcessNextEventAsync_DeadLettersSubscription_WhenMaxRetryAttemptsReached()
+    {
+        var db = BuildDbContext();
+        var subscription = new ThrowingSubscription();
+        var provider = BuildProvider(db, subscription);
+        var daemon = new SubscriptionDaemon<ExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new SubscriptionOptions
+            {
+                RetryDelay = TimeSpan.FromMilliseconds(1),
+                MaxRetryAttempts = 1
+            }));
+
+        db.Streams.StartStream(Guid.NewGuid(), events: [new object()]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await EnsureSequenceAsync(db);
+
+        var processed = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
+        var status = await db.Set<DbSubscription>()
+            .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
+
+        Assert.False(processed);
+        Assert.NotNull(status);
+        Assert.Equal(SubscriptionState.DeadLettered, status!.State);
+        Assert.Equal(1, status.AttemptCount);
+    }
+
+    [Fact]
+    public async Task ProcessNextEventAsync_DoesNotProcessPausedSubscription()
+    {
+        var db = BuildDbContext();
+        var subscription = new RecordingSubscription();
+        var provider = BuildProvider(db, subscription);
+        var daemon = new SubscriptionDaemon<ExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new SubscriptionOptions()));
+
+        db.Streams.StartStream(Guid.NewGuid(), events: [new object()]);
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = subscription.GetType().AssemblyQualifiedName!,
+            State = SubscriptionState.Paused
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await EnsureSequenceAsync(db);
+
+        var processed = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
+
+        Assert.False(processed);
+        Assert.False(subscription.Handled);
+    }
+
+    private static async Task EnsureSequenceAsync(ExecutionDbContext db)
+    {
+        var storedEvent = await db.Events.FirstAsync(TestContext.Current.CancellationToken);
+        if (storedEvent.Sequence == 0)
+        {
+            storedEvent.Sequence = 1;
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
     }
 
     private static async Task EnsureSequencesAsync(ExecutionDbContext db)

--- a/tests/EventStoreCore.Tests/SubscriptionManagerTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionManagerTests.cs
@@ -62,6 +62,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
         Assert.NotNull(status);
         Assert.Equal(name, status!.SubscriptionName);
         Assert.Equal(0, status.Position);
+        Assert.Equal(SubscriptionState.Active, status.State);
     }
 
     [Fact]
@@ -121,5 +122,158 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
 
         Assert.NotNull(subscription);
         Assert.Equal(dbEvents[1].Sequence - 1, subscription!.Sequence);
+    }
+
+    [Fact]
+    public async Task PauseAsync_TransitionsSubscriptionToPaused()
+    {
+        var provider = BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EventStoreDbContext>();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        await ResetDatabaseAsync(db, TestContext.Current.CancellationToken);
+
+        var name = typeof(TestSub).AssemblyQualifiedName!;
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = name
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
+        await manager.PauseAsync(name, TestContext.Current.CancellationToken);
+
+        var subscription = await db.Set<DbSubscription>()
+            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(SubscriptionState.Paused, subscription!.State);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_TransitionsPausedSubscriptionToActive()
+    {
+        var provider = BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EventStoreDbContext>();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        await ResetDatabaseAsync(db, TestContext.Current.CancellationToken);
+
+        var name = typeof(TestSub).AssemblyQualifiedName!;
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = name,
+            State = SubscriptionState.Paused
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
+        await manager.ResumeAsync(name, TestContext.Current.CancellationToken);
+
+        var subscription = await db.Set<DbSubscription>()
+            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(SubscriptionState.Active, subscription!.State);
+    }
+
+    [Fact]
+    public async Task RetryFailedEventAsync_ClearsFaultState()
+    {
+        var provider = BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EventStoreDbContext>();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        await ResetDatabaseAsync(db, TestContext.Current.CancellationToken);
+
+        var name = typeof(TestSub).AssemblyQualifiedName!;
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = name,
+            State = SubscriptionState.DeadLettered,
+            AttemptCount = 3,
+            LastError = "boom",
+            FailedEventSequence = 4,
+            LastAttemptAt = DateTimeOffset.UtcNow,
+            NextAttemptAt = DateTimeOffset.UtcNow.AddMinutes(1)
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
+        await manager.RetryFailedEventAsync(name, TestContext.Current.CancellationToken);
+
+        var subscription = await db.Set<DbSubscription>()
+            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(SubscriptionState.Active, subscription!.State);
+        Assert.Equal(0, subscription.AttemptCount);
+        Assert.Null(subscription.LastError);
+        Assert.Null(subscription.FailedEventSequence);
+        Assert.Null(subscription.LastAttemptAt);
+        Assert.Null(subscription.NextAttemptAt);
+    }
+
+    [Fact]
+    public async Task SkipFailedEventAsync_AdvancesPastFailedEventAndResumes()
+    {
+        var provider = BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EventStoreDbContext>();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        await ResetDatabaseAsync(db, TestContext.Current.CancellationToken);
+
+        var name = typeof(TestSub).AssemblyQualifiedName!;
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = name,
+            Sequence = 1,
+            State = SubscriptionState.Faulted,
+            AttemptCount = 1,
+            LastError = "boom",
+            FailedEventSequence = 2
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
+        await manager.SkipFailedEventAsync(name, TestContext.Current.CancellationToken);
+
+        var subscription = await db.Set<DbSubscription>()
+            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(SubscriptionState.Active, subscription!.State);
+        Assert.Equal(2, subscription.Sequence);
+        Assert.Equal(0, subscription.AttemptCount);
+        Assert.Null(subscription.LastError);
+        Assert.Null(subscription.FailedEventSequence);
+    }
+
+    [Fact]
+    public async Task GetFailedEventAsync_ReturnsFaultedEventDetails()
+    {
+        var provider = BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EventStoreDbContext>();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        await ResetDatabaseAsync(db, TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        db.Streams.StartStream(streamId, events: [new TestEvent()]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var dbEvent = await db.Events.FirstAsync(TestContext.Current.CancellationToken);
+        var name = typeof(TestSub).AssemblyQualifiedName!;
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = name,
+            State = SubscriptionState.Faulted,
+            LastError = "boom",
+            FailedEventSequence = dbEvent.Sequence
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
+        var failedEvent = await manager.GetFailedEventAsync(name, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(failedEvent);
+        Assert.Equal(dbEvent.Sequence, failedEvent!.Sequence);
+        Assert.Equal("boom", failedEvent.SubscriptionError);
     }
 }

--- a/tests/EventStoreCore.Tests/SubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionTests.cs
@@ -246,32 +246,42 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
 
         var daemon = provider.GetRequiredService<SubscriptionDaemon<EventStoreDbContext>>();
         var subscription = provider.GetRequiredService<RetryTrackingSubscription>();
+        var manager = provider.GetRequiredService<ISubscriptionManager>();
+        var subscriptionName = typeof(RetryTrackingSubscription).AssemblyQualifiedName!;
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken));
+        var firstProcessed = await daemon.ProcessNextEventAsync(
+            provider.CreateScope(),
+            subscription,
+            TestContext.Current.CancellationToken);
 
         var failedSubscriptionRow = await eventStoreDbContext.Set<DbSubscription>()
             .AsNoTracking()
             .FirstOrDefaultAsync(
-                e => e.SubscriptionAssemblyQualifiedName == typeof(RetryTrackingSubscription).AssemblyQualifiedName!,
+                e => e.SubscriptionAssemblyQualifiedName == subscriptionName,
                 TestContext.Current.CancellationToken);
 
-        Assert.Null(failedSubscriptionRow);
+        Assert.False(firstProcessed);
+        Assert.NotNull(failedSubscriptionRow);
+        Assert.Equal(SubscriptionState.Faulted, failedSubscriptionRow!.State);
+        Assert.Equal(expectedEvent.Sequence, failedSubscriptionRow.FailedEventSequence);
         Assert.Single(RetryTrackingSubscription.HandledEventIds);
         Assert.Equal(expectedEvent.EventId, RetryTrackingSubscription.HandledEventIds[0]);
+
+        await manager.RetryFailedEventAsync(subscriptionName, TestContext.Current.CancellationToken);
 
         var processed = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
 
         var succeededSubscriptionRow = await eventStoreDbContext.Set<DbSubscription>()
             .AsNoTracking()
             .SingleAsync(
-                e => e.SubscriptionAssemblyQualifiedName == typeof(RetryTrackingSubscription).AssemblyQualifiedName!,
+                e => e.SubscriptionAssemblyQualifiedName == subscriptionName,
                 TestContext.Current.CancellationToken);
 
         Assert.True(processed);
         Assert.Equal(2, RetryTrackingSubscription.Attempts);
         Assert.Equal(expectedEvent.EventId, RetryTrackingSubscription.HandledEventIds[1]);
         Assert.Equal(expectedEvent.Sequence, succeededSubscriptionRow.Sequence);
+        Assert.Equal(SubscriptionState.Active, succeededSubscriptionRow.State);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- persist subscription state, retry metadata, and failed event information for operational visibility
- add pause/resume/retry/skip/failed-event admin APIs for subscriptions across abstractions, endpoints, and SDK
- update the subscription daemon and tests to handle poison events, retries, dead-lettering, and operational transitions

Closes #26