### PR TITLE
Support tenant-scoped checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,45 @@ Avoid network calls, message publishing, HTTP requests, and other remote side ef
 
 Subscriptions and eventual projections are at-least-once. Consumers should use `EventId` as a stable deduplication key when replay or retry can redeliver an event.
 
+## Tenant-scoped checkpoints
+
+Streams and events include `TenantId`. By default, subscription and projection daemons use global checkpoints for backwards compatibility: one checkpoint row tracks progress across all tenants.
+
+Use tenant-scoped checkpoints when a poison event, pause, retry, skip, or replay in one tenant should not affect other tenants:
+
+```csharp
+using EventStoreCore.Abstractions;
+
+services.AddEventStore(builder =>
+{
+    builder.ExistingDbContext<MyEventStoreDbContext>();
+
+    builder.AddSubscriptionDaemon<MyEventStoreDbContext>(
+        _ => distributedLockProvider,
+        options => options.CheckpointScope = CheckpointScope.Tenant);
+
+    builder.AddProjectionDaemon<MyEventStoreDbContext>(
+        _ => distributedLockProvider,
+        options =>
+        {
+            options.CheckpointScope = CheckpointScope.Tenant;
+            options.AutoRebuildOnVersionChange = false;
+        });
+});
+```
+
+Global checkpoint rows use `CheckpointScope.Global`. Tenant checkpoint rows use `CheckpointScope.Tenant` plus the event `TenantId`, including `Guid.Empty` for the default tenant. The admin endpoints accept an optional `tenantId` query parameter for tenant-scoped status and operations, for example `POST /subscriptions/{name}/retry?tenantId={tenantId}`.
+
+Tenant-scoped checkpoints isolate daemon progress and failure state; they do not automatically make projection snapshots tenant-isolated. If multiple tenants can use the same stream id, include tenant id in the projection key or snapshot key.
+
+Projection rebuild remains global because `IProjection<TSnapshot>.ClearAsync` has no tenant parameter. Tenant-scoped projection checkpoints therefore do not support automatic version-change rebuilds; disable `AutoRebuildOnVersionChange` when using tenant-scoped projection checkpoints and run global rebuilds intentionally.
+
+### Migration steps
+
+1. Add `CheckpointScope` and `TenantId` columns to `Subscriptions` and `ProjectionStatuses`.
+2. Backfill existing rows with `CheckpointScope.Global` and `TenantId = Guid.Empty`.
+3. Update the primary keys to `(SubscriptionAssemblyQualifiedName, CheckpointScope, TenantId)` and `(ProjectionName, CheckpointScope, TenantId)`.
+
 ## Event type names
 
 EventStore now persists a logical event type name in `DbEvent.TypeName`. By default, it uses snake_case based on the CLR type name (for example, `UserCreated` becomes `user_created`).

--- a/src/EventStoreCore.Abstractions/CheckpointScope.cs
+++ b/src/EventStoreCore.Abstractions/CheckpointScope.cs
@@ -1,0 +1,17 @@
+namespace EventStoreCore.Abstractions;
+
+/// <summary>
+/// Defines how daemon checkpoint rows are shared across tenants.
+/// </summary>
+public enum CheckpointScope
+{
+    /// <summary>
+    /// A single checkpoint row is shared across all tenants.
+    /// </summary>
+    Global = 0,
+
+    /// <summary>
+    /// Each tenant has an independent checkpoint row.
+    /// </summary>
+    Tenant = 1
+}

--- a/src/EventStoreCore.Abstractions/IProjectionManager.cs
+++ b/src/EventStoreCore.Abstractions/IProjectionManager.cs
@@ -14,11 +14,34 @@ public interface IProjectionManager
     Task<ProjectionStatusDto?> GetStatusAsync(string projectionName, CancellationToken ct = default);
 
     /// <summary>
+    /// Gets the tenant-scoped status of a specific projection.
+    /// </summary>
+    /// <param name="projectionName">The name of the projection.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The projection status, or null if not found.</returns>
+    Task<ProjectionStatusDto?> GetStatusAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped projection status is not supported by this manager.");
+    }
+
+    /// <summary>
     /// Gets the status of all registered projections.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A list of all projection statuses.</returns>
     Task<IReadOnlyList<ProjectionStatusDto>> GetAllStatusesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the tenant-scoped status of all registered projections for a tenant.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A list of projection statuses for the tenant.</returns>
+    Task<IReadOnlyList<ProjectionStatusDto>> GetAllStatusesAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped projection status is not supported by this manager.");
+    }
 
     /// <summary>
     /// Triggers a rebuild of the specified projection.
@@ -36,11 +59,33 @@ public interface IProjectionManager
     Task PauseAsync(string projectionName, CancellationToken ct = default);
 
     /// <summary>
+    /// Pauses tenant-scoped processing of the specified projection.
+    /// </summary>
+    /// <param name="projectionName">The name of the projection to pause.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task PauseAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped projection pause is not supported by this manager.");
+    }
+
+    /// <summary>
     /// Resumes processing of a paused projection.
     /// </summary>
     /// <param name="projectionName">The name of the projection to resume.</param>
     /// <param name="ct">Cancellation token.</param>
     Task ResumeAsync(string projectionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resumes tenant-scoped processing of a paused projection.
+    /// </summary>
+    /// <param name="projectionName">The name of the projection to resume.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ResumeAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped projection resume is not supported by this manager.");
+    }
 
     /// <summary>
     /// Retries processing the failed event for the specified projection.
@@ -50,11 +95,33 @@ public interface IProjectionManager
     Task RetryFailedEventAsync(string projectionName, CancellationToken ct = default);
 
     /// <summary>
+    /// Retries processing the failed tenant-scoped event for the specified projection.
+    /// </summary>
+    /// <param name="projectionName">The name of the projection.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task RetryFailedEventAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped projection retry is not supported by this manager.");
+    }
+
+    /// <summary>
     /// Skips the failed event and resumes processing from the next event.
     /// </summary>
     /// <param name="projectionName">The name of the projection.</param>
     /// <param name="ct">Cancellation token.</param>
     Task SkipFailedEventAsync(string projectionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Skips the failed tenant-scoped event and resumes processing from the next event.
+    /// </summary>
+    /// <param name="projectionName">The name of the projection.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task SkipFailedEventAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped projection skip is not supported by this manager.");
+    }
 
     /// <summary>
     /// Gets details about the failed event for a faulted projection.
@@ -63,6 +130,18 @@ public interface IProjectionManager
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Details about the failed event, or null if the projection is not faulted.</returns>
     Task<FailedEventDto?> GetFailedEventAsync(string projectionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets details about the failed tenant-scoped event for a faulted projection.
+    /// </summary>
+    /// <param name="projectionName">The name of the projection.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Details about the failed event, or null if the projection is not faulted.</returns>
+    Task<FailedEventDto?> GetFailedEventAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped projection failed-event lookup is not supported by this manager.");
+    }
 }
 
 /// <summary>
@@ -91,7 +170,18 @@ public sealed record ProjectionStatusDto(
     long? FailedEventSequence,
     DateTimeOffset? RebuildStartedAt,
     DateTimeOffset? RebuildCompletedAt
-);
+)
+{
+    /// <summary>
+    /// Whether this status row is global or tenant-scoped.
+    /// </summary>
+    public CheckpointScope CheckpointScope { get; init; } = CheckpointScope.Global;
+
+    /// <summary>
+    /// The tenant id for tenant-scoped status rows, or null for global status rows.
+    /// </summary>
+    public Guid? TenantId { get; init; }
+}
 
 /// <summary>
 /// Represents the possible states of a projection.
@@ -139,4 +229,15 @@ public sealed record FailedEventDto(
     string Data,
     DateTimeOffset Timestamp,
     string ProjectionError
-);
+)
+{
+    /// <summary>
+    /// Whether the failed event belongs to a global or tenant-scoped checkpoint.
+    /// </summary>
+    public CheckpointScope CheckpointScope { get; init; } = CheckpointScope.Global;
+
+    /// <summary>
+    /// The tenant id for tenant-scoped failures, or null for global failures.
+    /// </summary>
+    public Guid? TenantId { get; init; }
+}

--- a/src/EventStoreCore.Abstractions/ISubscriptionManager.cs
+++ b/src/EventStoreCore.Abstractions/ISubscriptionManager.cs
@@ -14,11 +14,34 @@ public interface ISubscriptionManager
     Task<SubscriptionStatusDto?> GetStatusAsync(string subscriptionName, CancellationToken ct = default);
 
     /// <summary>
+    /// Gets the tenant-scoped status of a specific subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The subscription status, or null if not found.</returns>
+    Task<SubscriptionStatusDto?> GetStatusAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped subscription status is not supported by this manager.");
+    }
+
+    /// <summary>
     /// Gets the status of all registered subscriptions.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A list of all subscription statuses.</returns>
     Task<IReadOnlyList<SubscriptionStatusDto>> GetAllStatusesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the tenant-scoped status of all registered subscriptions for a tenant.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A list of subscription statuses for the tenant.</returns>
+    Task<IReadOnlyList<SubscriptionStatusDto>> GetAllStatusesAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped subscription status is not supported by this manager.");
+    }
 
     /// <summary>
     /// Pauses processing of the specified subscription.
@@ -28,11 +51,33 @@ public interface ISubscriptionManager
     Task PauseAsync(string subscriptionName, CancellationToken ct = default);
 
     /// <summary>
+    /// Pauses tenant-scoped processing of the specified subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task PauseAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped subscription pause is not supported by this manager.");
+    }
+
+    /// <summary>
     /// Resumes processing of a paused subscription.
     /// </summary>
     /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
     /// <param name="ct">Cancellation token.</param>
     Task ResumeAsync(string subscriptionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resumes tenant-scoped processing of a paused subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ResumeAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped subscription resume is not supported by this manager.");
+    }
 
     /// <summary>
     /// Retries the failed event for a faulted or dead-lettered subscription.
@@ -42,11 +87,33 @@ public interface ISubscriptionManager
     Task RetryFailedEventAsync(string subscriptionName, CancellationToken ct = default);
 
     /// <summary>
+    /// Retries the failed tenant-scoped event for a faulted or dead-lettered subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task RetryFailedEventAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped subscription retry is not supported by this manager.");
+    }
+
+    /// <summary>
     /// Skips the failed event and resumes processing from the next event.
     /// </summary>
     /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
     /// <param name="ct">Cancellation token.</param>
     Task SkipFailedEventAsync(string subscriptionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Skips the failed tenant-scoped event and resumes processing from the next event.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task SkipFailedEventAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped subscription skip is not supported by this manager.");
+    }
 
     /// <summary>
     /// Gets details about the failed event for a faulted or dead-lettered subscription.
@@ -55,6 +122,18 @@ public interface ISubscriptionManager
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Details about the failed event, or null if the subscription is not faulted.</returns>
     Task<SubscriptionFailedEventDto?> GetFailedEventAsync(string subscriptionName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets details about the failed tenant-scoped event for a faulted or dead-lettered subscription.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Details about the failed event, or null if the subscription is not faulted.</returns>
+    Task<SubscriptionFailedEventDto?> GetFailedEventAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped subscription failed-event lookup is not supported by this manager.");
+    }
 
     /// <summary>
     /// Replays a subscription from a specific sequence or timestamp.
@@ -68,6 +147,24 @@ public interface ISubscriptionManager
         long? startSequence = null,
         DateTimeOffset? fromTimestamp = null,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Replays a tenant-scoped subscription from a specific sequence or timestamp.
+    /// </summary>
+    /// <param name="subscriptionName">The subscription's assembly-qualified name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="startSequence">The sequence to start replaying from (inclusive).</param>
+    /// <param name="fromTimestamp">Replay events starting from the first event at or after this timestamp.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ReplayAsync(
+        string subscriptionName,
+        Guid tenantId,
+        long? startSequence = null,
+        DateTimeOffset? fromTimestamp = null,
+        CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Tenant-scoped subscription replay is not supported by this manager.");
+    }
 }
 
 /// <summary>
@@ -96,7 +193,18 @@ public sealed record SubscriptionStatusDto(
     DateTimeOffset? LastAttemptAt,
     DateTimeOffset? NextAttemptAt,
     long? FailedEventSequence
-);
+)
+{
+    /// <summary>
+    /// Whether this status row is global or tenant-scoped.
+    /// </summary>
+    public CheckpointScope CheckpointScope { get; init; } = CheckpointScope.Global;
+
+    /// <summary>
+    /// The tenant id for tenant-scoped status rows, or null for global status rows.
+    /// </summary>
+    public Guid? TenantId { get; init; }
+}
 
 /// <summary>
 /// Represents the possible states of a subscription.
@@ -144,4 +252,15 @@ public sealed record SubscriptionFailedEventDto(
     string Data,
     DateTimeOffset Timestamp,
     string SubscriptionError
-);
+)
+{
+    /// <summary>
+    /// Whether the failed event belongs to a global or tenant-scoped checkpoint.
+    /// </summary>
+    public CheckpointScope CheckpointScope { get; init; } = CheckpointScope.Global;
+
+    /// <summary>
+    /// The tenant id for tenant-scoped failures, or null for global failures.
+    /// </summary>
+    public Guid? TenantId { get; init; }
+}

--- a/src/EventStoreCore.Endpoints/RouteBuilderExtensions.cs
+++ b/src/EventStoreCore.Endpoints/RouteBuilderExtensions.cs
@@ -25,9 +25,11 @@ public static class RouteBuilderExtensions
 
 
         // GET /projections - List all projections
-        group.MapGet("/projections", async ([FromServices] IProjectionManager manager, CancellationToken ct) =>
+        group.MapGet("/projections", async ([FromServices] IProjectionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
-            var statuses = await manager.GetAllStatusesAsync(ct);
+            var statuses = tenantId.HasValue
+                ? await manager.GetAllStatusesAsync(tenantId.Value, ct)
+                : await manager.GetAllStatusesAsync(ct);
             return Results.Ok(statuses);
         })
         .WithName("GetAllProjections")
@@ -35,9 +37,11 @@ public static class RouteBuilderExtensions
         .Produces<IReadOnlyList<ProjectionStatusDto>>();
 
         // GET /projections/{name} - Get specific projection
-        group.MapGet("/projections/{name}", async ([FromRoute] string name, [FromServices] IProjectionManager manager, CancellationToken ct) =>
+        group.MapGet("/projections/{name}", async ([FromRoute] string name, [FromServices] IProjectionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
-            var status = await manager.GetStatusAsync(name, ct);
+            var status = tenantId.HasValue
+                ? await manager.GetStatusAsync(name, tenantId.Value, ct)
+                : await manager.GetStatusAsync(name, ct);
             return status != null ? Results.Ok(status) : Results.NotFound();
         })
         .WithName("GetProjection")
@@ -64,11 +68,18 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status400BadRequest);
 
         // POST /projections/{name}/pause - Pause projection
-        group.MapPost("/projections/{name}/pause", async ([FromRoute] string name, [FromServices] IProjectionManager manager, CancellationToken ct) =>
+        group.MapPost("/projections/{name}/pause", async ([FromRoute] string name, [FromServices] IProjectionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
             try
             {
-                await manager.PauseAsync(name, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.PauseAsync(name, tenantId.Value, ct);
+                }
+                else
+                {
+                    await manager.PauseAsync(name, ct);
+                }
                 return Results.Ok();
             }
             catch (InvalidOperationException ex)
@@ -82,11 +93,18 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status400BadRequest);
 
         // POST /projections/{name}/resume - Resume projection
-        group.MapPost("/projections/{name}/resume", async ([FromRoute] string name, [FromServices] IProjectionManager manager, CancellationToken ct) =>
+        group.MapPost("/projections/{name}/resume", async ([FromRoute] string name, [FromServices] IProjectionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
             try
             {
-                await manager.ResumeAsync(name, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.ResumeAsync(name, tenantId.Value, ct);
+                }
+                else
+                {
+                    await manager.ResumeAsync(name, ct);
+                }
                 return Results.Ok();
             }
             catch (InvalidOperationException ex)
@@ -100,9 +118,11 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status400BadRequest);
 
         // GET /projections/{name}/failed-event - Get failed event details
-        group.MapGet("/projections/{name}/failed-event", async ([FromRoute] string name, [FromServices] IProjectionManager manager, CancellationToken ct) =>
+        group.MapGet("/projections/{name}/failed-event", async ([FromRoute] string name, [FromServices] IProjectionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
-            var failedEvent = await manager.GetFailedEventAsync(name, ct);
+            var failedEvent = tenantId.HasValue
+                ? await manager.GetFailedEventAsync(name, tenantId.Value, ct)
+                : await manager.GetFailedEventAsync(name, ct);
             return failedEvent != null ? Results.Ok(failedEvent) : Results.NotFound();
         })
         .WithName("GetFailedEvent")
@@ -111,11 +131,18 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status404NotFound);
 
         // POST /projections/{name}/retry - Retry failed event
-        group.MapPost("/projections/{name}/retry", async ([FromRoute] string name, [FromServices] IProjectionManager manager, CancellationToken ct) =>
+        group.MapPost("/projections/{name}/retry", async ([FromRoute] string name, [FromServices] IProjectionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
             try
             {
-                await manager.RetryFailedEventAsync(name, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.RetryFailedEventAsync(name, tenantId.Value, ct);
+                }
+                else
+                {
+                    await manager.RetryFailedEventAsync(name, ct);
+                }
                 return Results.Ok();
             }
             catch (InvalidOperationException ex)
@@ -129,11 +156,18 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status400BadRequest);
 
         // POST /projections/{name}/skip - Skip failed event
-        group.MapPost("/projections/{name}/skip", async ([FromRoute] string name, [FromServices] IProjectionManager manager, CancellationToken ct) =>
+        group.MapPost("/projections/{name}/skip", async ([FromRoute] string name, [FromServices] IProjectionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
             try
             {
-                await manager.SkipFailedEventAsync(name, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.SkipFailedEventAsync(name, tenantId.Value, ct);
+                }
+                else
+                {
+                    await manager.SkipFailedEventAsync(name, ct);
+                }
                 return Results.Ok();
             }
             catch (InvalidOperationException ex)
@@ -147,9 +181,11 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status400BadRequest);
 
         // GET /subscriptions - List all subscriptions
-        group.MapGet("/subscriptions", async ([FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        group.MapGet("/subscriptions", async ([FromServices] ISubscriptionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
-            var statuses = await manager.GetAllStatusesAsync(ct);
+            var statuses = tenantId.HasValue
+                ? await manager.GetAllStatusesAsync(tenantId.Value, ct)
+                : await manager.GetAllStatusesAsync(ct);
             return Results.Ok(statuses);
         })
         .WithName("GetAllSubscriptions")
@@ -157,9 +193,11 @@ public static class RouteBuilderExtensions
         .Produces<IReadOnlyList<SubscriptionStatusDto>>();
 
         // GET /subscriptions/{name} - Get specific subscription
-        group.MapGet("/subscriptions/{name}", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        group.MapGet("/subscriptions/{name}", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
-            var status = await manager.GetStatusAsync(name, ct);
+            var status = tenantId.HasValue
+                ? await manager.GetStatusAsync(name, tenantId.Value, ct)
+                : await manager.GetStatusAsync(name, ct);
             return status != null ? Results.Ok(status) : Results.NotFound();
         })
         .WithName("GetSubscription")
@@ -168,11 +206,18 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status404NotFound);
 
         // POST /subscriptions/{name}/pause - Pause subscription
-        group.MapPost("/subscriptions/{name}/pause", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        group.MapPost("/subscriptions/{name}/pause", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
             try
             {
-                await manager.PauseAsync(name, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.PauseAsync(name, tenantId.Value, ct);
+                }
+                else
+                {
+                    await manager.PauseAsync(name, ct);
+                }
                 return Results.Ok();
             }
             catch (InvalidOperationException ex)
@@ -186,11 +231,18 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status400BadRequest);
 
         // POST /subscriptions/{name}/resume - Resume subscription
-        group.MapPost("/subscriptions/{name}/resume", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        group.MapPost("/subscriptions/{name}/resume", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
             try
             {
-                await manager.ResumeAsync(name, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.ResumeAsync(name, tenantId.Value, ct);
+                }
+                else
+                {
+                    await manager.ResumeAsync(name, ct);
+                }
                 return Results.Ok();
             }
             catch (InvalidOperationException ex)
@@ -204,9 +256,11 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status400BadRequest);
 
         // GET /subscriptions/{name}/failed-event - Get failed event details
-        group.MapGet("/subscriptions/{name}/failed-event", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        group.MapGet("/subscriptions/{name}/failed-event", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
-            var failedEvent = await manager.GetFailedEventAsync(name, ct);
+            var failedEvent = tenantId.HasValue
+                ? await manager.GetFailedEventAsync(name, tenantId.Value, ct)
+                : await manager.GetFailedEventAsync(name, ct);
             return failedEvent != null ? Results.Ok(failedEvent) : Results.NotFound();
         })
         .WithName("GetSubscriptionFailedEvent")
@@ -215,11 +269,18 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status404NotFound);
 
         // POST /subscriptions/{name}/retry - Retry failed event
-        group.MapPost("/subscriptions/{name}/retry", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        group.MapPost("/subscriptions/{name}/retry", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
             try
             {
-                await manager.RetryFailedEventAsync(name, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.RetryFailedEventAsync(name, tenantId.Value, ct);
+                }
+                else
+                {
+                    await manager.RetryFailedEventAsync(name, ct);
+                }
                 return Results.Ok();
             }
             catch (InvalidOperationException ex)
@@ -233,11 +294,18 @@ public static class RouteBuilderExtensions
         .Produces(StatusCodes.Status400BadRequest);
 
         // POST /subscriptions/{name}/skip - Skip failed event
-        group.MapPost("/subscriptions/{name}/skip", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, CancellationToken ct) =>
+        group.MapPost("/subscriptions/{name}/skip", async ([FromRoute] string name, [FromServices] ISubscriptionManager manager, [FromQuery] Guid? tenantId, CancellationToken ct) =>
         {
             try
             {
-                await manager.SkipFailedEventAsync(name, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.SkipFailedEventAsync(name, tenantId.Value, ct);
+                }
+                else
+                {
+                    await manager.SkipFailedEventAsync(name, ct);
+                }
                 return Results.Ok();
             }
             catch (InvalidOperationException ex)
@@ -256,11 +324,19 @@ public static class RouteBuilderExtensions
             [FromServices] ISubscriptionManager manager,
             [FromQuery] long? startSequence,
             [FromQuery] DateTimeOffset? fromTimestamp,
+            [FromQuery] Guid? tenantId,
             CancellationToken ct) =>
         {
             try
             {
-                await manager.ReplayAsync(name, startSequence, fromTimestamp, ct);
+                if (tenantId.HasValue)
+                {
+                    await manager.ReplayAsync(name, tenantId.Value, startSequence, fromTimestamp, ct);
+                }
+                else
+                {
+                    await manager.ReplayAsync(name, startSequence, fromTimestamp, ct);
+                }
                 return Results.Accepted();
             }
             catch (InvalidOperationException ex)

--- a/src/EventStoreCore.SDK/IEventStoreEndpointsClient.cs
+++ b/src/EventStoreCore.SDK/IEventStoreEndpointsClient.cs
@@ -18,6 +18,15 @@ public interface IEventStoreEndpointsClient
     Task<IReadOnlyList<ProjectionStatusDto>> GetAllProjectionsAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Gets the tenant-scoped status of all registered projections.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The list of projection statuses for the tenant.</returns>
+    [Get("/projections")]
+    Task<IReadOnlyList<ProjectionStatusDto>> GetAllProjectionsForTenantAsync([Query] Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Gets the status of a specific projection.
     /// </summary>
     /// <param name="name">The projection name.</param>
@@ -25,6 +34,16 @@ public interface IEventStoreEndpointsClient
     /// <returns>The projection status, or null when not found.</returns>
     [Get("/projections/{name}")]
     Task<ProjectionStatusDto?> GetProjectionAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the tenant-scoped status of a specific projection.
+    /// </summary>
+    /// <param name="name">The projection name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The projection status, or null when not found.</returns>
+    [Get("/projections/{name}")]
+    Task<ProjectionStatusDto?> GetProjectionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Triggers a rebuild of the specified projection.
@@ -43,12 +62,30 @@ public interface IEventStoreEndpointsClient
     Task PauseAsync(string name, CancellationToken ct = default);
 
     /// <summary>
+    /// Pauses tenant-scoped processing of the specified projection.
+    /// </summary>
+    /// <param name="name">The projection name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/projections/{name}/pause")]
+    Task PauseProjectionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Resumes processing of a paused projection.
     /// </summary>
     /// <param name="name">The projection name.</param>
     /// <param name="ct">Cancellation token.</param>
     [Post("/projections/{name}/resume")]
     Task ResumeAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resumes tenant-scoped processing of a paused projection.
+    /// </summary>
+    /// <param name="name">The projection name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/projections/{name}/resume")]
+    Task ResumeProjectionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Gets details about the failed event for a faulted projection.
@@ -60,12 +97,31 @@ public interface IEventStoreEndpointsClient
     Task<FailedEventDto?> GetFailedEventAsync(string name, CancellationToken ct = default);
 
     /// <summary>
+    /// Gets details about the failed event for a tenant-scoped faulted projection.
+    /// </summary>
+    /// <param name="name">The projection name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The failed event details, or null when not found.</returns>
+    [Get("/projections/{name}/failed-event")]
+    Task<FailedEventDto?> GetFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Retries processing the failed event.
     /// </summary>
     /// <param name="name">The projection name.</param>
     /// <param name="ct">Cancellation token.</param>
     [Post("/projections/{name}/retry")]
     Task RetryFailedEventAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retries processing the failed tenant-scoped event.
+    /// </summary>
+    /// <param name="name">The projection name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/projections/{name}/retry")]
+    Task RetryFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Skips the failed event and resumes processing.
@@ -76,12 +132,30 @@ public interface IEventStoreEndpointsClient
     Task SkipFailedEventAsync(string name, CancellationToken ct = default);
 
     /// <summary>
+    /// Skips the failed tenant-scoped event and resumes processing.
+    /// </summary>
+    /// <param name="name">The projection name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/projections/{name}/skip")]
+    Task SkipFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Gets the status of all registered subscriptions.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The list of subscription statuses.</returns>
     [Get("/subscriptions")]
     Task<IReadOnlyList<SubscriptionStatusDto>> GetAllSubscriptionsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the tenant-scoped status of all registered subscriptions.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The list of subscription statuses for the tenant.</returns>
+    [Get("/subscriptions")]
+    Task<IReadOnlyList<SubscriptionStatusDto>> GetAllSubscriptionsForTenantAsync([Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Gets the status of a specific subscription.
@@ -93,6 +167,16 @@ public interface IEventStoreEndpointsClient
     Task<SubscriptionStatusDto?> GetSubscriptionAsync(string name, CancellationToken ct = default);
 
     /// <summary>
+    /// Gets the tenant-scoped status of a specific subscription.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The subscription status, or null when not found.</returns>
+    [Get("/subscriptions/{name}")]
+    Task<SubscriptionStatusDto?> GetSubscriptionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Pauses processing of the specified subscription.
     /// </summary>
     /// <param name="name">The subscription name.</param>
@@ -101,12 +185,30 @@ public interface IEventStoreEndpointsClient
     Task PauseSubscriptionAsync(string name, CancellationToken ct = default);
 
     /// <summary>
+    /// Pauses tenant-scoped processing of the specified subscription.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/pause")]
+    Task PauseSubscriptionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Resumes processing of a paused subscription.
     /// </summary>
     /// <param name="name">The subscription name.</param>
     /// <param name="ct">Cancellation token.</param>
     [Post("/subscriptions/{name}/resume")]
     Task ResumeSubscriptionAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resumes tenant-scoped processing of a paused subscription.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/resume")]
+    Task ResumeSubscriptionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Gets details about the failed event for a faulted or dead-lettered subscription.
@@ -118,6 +220,16 @@ public interface IEventStoreEndpointsClient
     Task<SubscriptionFailedEventDto?> GetSubscriptionFailedEventAsync(string name, CancellationToken ct = default);
 
     /// <summary>
+    /// Gets details about the failed event for a tenant-scoped faulted or dead-lettered subscription.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The failed event details, or null when not found.</returns>
+    [Get("/subscriptions/{name}/failed-event")]
+    Task<SubscriptionFailedEventDto?> GetSubscriptionFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Retries processing the failed subscription event.
     /// </summary>
     /// <param name="name">The subscription name.</param>
@@ -126,12 +238,30 @@ public interface IEventStoreEndpointsClient
     Task RetrySubscriptionFailedEventAsync(string name, CancellationToken ct = default);
 
     /// <summary>
+    /// Retries processing the failed tenant-scoped subscription event.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/retry")]
+    Task RetrySubscriptionFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Skips the failed subscription event and resumes processing.
     /// </summary>
     /// <param name="name">The subscription name.</param>
     /// <param name="ct">Cancellation token.</param>
     [Post("/subscriptions/{name}/skip")]
     Task SkipSubscriptionFailedEventAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Skips the failed tenant-scoped subscription event and resumes processing.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/skip")]
+    Task SkipSubscriptionFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Replays a subscription from a specific sequence or timestamp.
@@ -143,6 +273,22 @@ public interface IEventStoreEndpointsClient
     [Post("/subscriptions/{name}/replay")]
     Task ReplaySubscriptionAsync(
         string name,
+        [Query] long? startSequence = null,
+        [Query] DateTimeOffset? fromTimestamp = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Replays a tenant-scoped subscription from a specific sequence or timestamp.
+    /// </summary>
+    /// <param name="name">The subscription name.</param>
+    /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
+    /// <param name="startSequence">The starting sequence (inclusive) for replay.</param>
+    /// <param name="fromTimestamp">Replay events starting at or after this timestamp.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [Post("/subscriptions/{name}/replay")]
+    Task ReplaySubscriptionForTenantAsync(
+        string name,
+        [Query] Guid tenantId,
         [Query] long? startSequence = null,
         [Query] DateTimeOffset? fromTimestamp = null,
         CancellationToken ct = default);

--- a/src/EventStoreCore/CheckpointScopeKey.cs
+++ b/src/EventStoreCore/CheckpointScopeKey.cs
@@ -1,0 +1,14 @@
+using EventStoreCore.Abstractions;
+
+namespace EventStoreCore;
+
+internal readonly record struct CheckpointScopeKey(CheckpointScope Scope, Guid TenantId)
+{
+    public static CheckpointScopeKey Global { get; } = new(CheckpointScope.Global, Guid.Empty);
+
+    public static CheckpointScopeKey Tenant(Guid tenantId) => new(CheckpointScope.Tenant, tenantId);
+
+    public bool IsTenant => Scope == CheckpointScope.Tenant;
+
+    public string LockSuffix => IsTenant ? $":tenant:{TenantId:N}" : string.Empty;
+}

--- a/src/EventStoreCore/DbProjectionStatus.cs
+++ b/src/EventStoreCore/DbProjectionStatus.cs
@@ -13,6 +13,16 @@ public sealed class DbProjectionStatus
     public string ProjectionName { get; set; } = null!;
 
     /// <summary>
+    /// Whether this checkpoint is shared globally or belongs to a tenant.
+    /// </summary>
+    public CheckpointScope CheckpointScope { get; set; } = CheckpointScope.Global;
+
+    /// <summary>
+    /// The tenant this checkpoint belongs to when <see cref="CheckpointScope" /> is <see cref="Abstractions.CheckpointScope.Tenant" />.
+    /// </summary>
+    public Guid TenantId { get; set; } = Guid.Empty;
+
+    /// <summary>
     /// The version of the projection. Used to detect when a projection needs rebuilding.
     /// </summary>
     public int Version { get; set; } = 1;
@@ -62,7 +72,7 @@ public sealed class DbProjectionStatus
     /// </summary>
     public ProjectionStatusDto ToDto()
     {
-        var progress = TotalEvents.HasValue && TotalEvents.Value > 0
+        var progress = CheckpointScope == Abstractions.CheckpointScope.Global && TotalEvents.HasValue && TotalEvents.Value > 0
             ? Math.Round((double)Position / TotalEvents.Value * 100, 2)
             : (double?)null;
 
@@ -78,6 +88,10 @@ public sealed class DbProjectionStatus
             FailedEventSequence,
             RebuildStartedAt,
             RebuildCompletedAt
-        );
+        )
+        {
+            CheckpointScope = CheckpointScope,
+            TenantId = CheckpointScope == Abstractions.CheckpointScope.Tenant ? TenantId : null
+        };
     }
 }

--- a/src/EventStoreCore/DbSubscription.cs
+++ b/src/EventStoreCore/DbSubscription.cs
@@ -13,6 +13,16 @@ public sealed class DbSubscription
     public string SubscriptionAssemblyQualifiedName { get; set; } = null!;
 
     /// <summary>
+    /// Whether this checkpoint is shared globally or belongs to a tenant.
+    /// </summary>
+    public CheckpointScope CheckpointScope { get; set; } = CheckpointScope.Global;
+
+    /// <summary>
+    /// The tenant this checkpoint belongs to when <see cref="CheckpointScope" /> is <see cref="Abstractions.CheckpointScope.Tenant" />.
+    /// </summary>
+    public Guid TenantId { get; set; } = Guid.Empty;
+
+    /// <summary>
     /// The last processed event sequence number.
     /// </summary>
     public long Sequence { get; set; } = 0;
@@ -52,10 +62,14 @@ public sealed class DbSubscription
     /// </summary>
     /// <param name="totalEvents">The total number of events in the store.</param>
     /// <param name="lastProcessedAt">When the last processed event occurred.</param>
-    public SubscriptionStatusDto ToDto(long? totalEvents, DateTimeOffset? lastProcessedAt)
+    /// <param name="processedEvents">The number of events processed in this checkpoint scope.</param>
+    public SubscriptionStatusDto ToDto(
+        long? totalEvents,
+        DateTimeOffset? lastProcessedAt,
+        long? processedEvents = null)
     {
         var progress = totalEvents.HasValue && totalEvents.Value > 0
-            ? Math.Round((double)Sequence / totalEvents.Value * 100, 2)
+            ? Math.Round((double)(processedEvents ?? Sequence) / totalEvents.Value * 100, 2)
             : (double?)null;
 
         return new SubscriptionStatusDto(
@@ -69,7 +83,11 @@ public sealed class DbSubscription
             AttemptCount,
             LastAttemptAt,
             NextAttemptAt,
-            FailedEventSequence);
+            FailedEventSequence)
+        {
+            CheckpointScope = CheckpointScope,
+            TenantId = CheckpointScope == Abstractions.CheckpointScope.Tenant ? TenantId : null
+        };
     }
 }
 

--- a/src/EventStoreCore/ModelBuilderExtensions.cs
+++ b/src/EventStoreCore/ModelBuilderExtensions.cs
@@ -94,9 +94,15 @@ internal static class ModelBuilderExtensions
         {
             entity.ToTable("Subscriptions");
 
-            entity.HasKey(e => e.SubscriptionAssemblyQualifiedName);
+            entity.HasKey(e => new { e.SubscriptionAssemblyQualifiedName, e.CheckpointScope, e.TenantId });
 
             entity.Property(e => e.SubscriptionAssemblyQualifiedName)
+                .IsRequired();
+
+            entity.Property(e => e.CheckpointScope)
+                .IsRequired();
+
+            entity.Property(e => e.TenantId)
                 .IsRequired();
 
             entity.Property(e => e.Sequence)
@@ -117,16 +123,24 @@ internal static class ModelBuilderExtensions
             entity.Property(e => e.FailedEventSequence);
 
             entity.HasIndex(e => e.State);
+
+            entity.HasIndex(e => new { e.CheckpointScope, e.TenantId, e.State });
         });
 
         modelBuilder.Entity<DbProjectionStatus>(entity =>
         {
             entity.ToTable("ProjectionStatuses");
 
-            entity.HasKey(e => e.ProjectionName);
+            entity.HasKey(e => new { e.ProjectionName, e.CheckpointScope, e.TenantId });
 
             entity.Property(e => e.ProjectionName)
                 .HasMaxLength(500)
+                .IsRequired();
+
+            entity.Property(e => e.CheckpointScope)
+                .IsRequired();
+
+            entity.Property(e => e.TenantId)
                 .IsRequired();
 
             entity.Property(e => e.Version)
@@ -151,6 +165,8 @@ internal static class ModelBuilderExtensions
             entity.Property(e => e.RebuildCompletedAt);
 
             entity.HasIndex(e => e.State);
+
+            entity.HasIndex(e => new { e.CheckpointScope, e.TenantId, e.State });
         });
     }
 

--- a/src/EventStoreCore/ProjectionDaemon.cs
+++ b/src/EventStoreCore/ProjectionDaemon.cs
@@ -88,8 +88,35 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     /// <param name="ct">Cancellation token.</param>
     private async Task ProcessProjectionAsync(ProjectionRegistration projection, CancellationToken ct)
     {
-        var lockName = $"projection:{projection.Name}";
+        var checkpointScopes = await GetCheckpointScopesAsync(projection.Name, ct);
 
+        foreach (var checkpointScope in checkpointScopes)
+        {
+            try
+            {
+                await ProcessProjectionScopeAsync(projection, checkpointScope, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex) when (checkpointScope.IsTenant)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error processing projection {Projection} in tenant checkpoint scope {TenantId}",
+                    projection.Name,
+                    checkpointScope.TenantId);
+            }
+        }
+    }
+
+    private async Task ProcessProjectionScopeAsync(
+        ProjectionRegistration projection,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var lockName = $"projection:{projection.Name}{checkpointScope.LockSuffix}";
 
         IDistributedSynchronizationHandle? lockHandle = null;
         try
@@ -110,11 +137,18 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
             using var scope = _serviceProvider.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
 
-            var status = await GetOrCreateStatusAsync(dbContext, projection, ct);
+            var status = await GetOrCreateStatusAsync(dbContext, projection, checkpointScope, ct);
 
             // Check for version mismatch and trigger rebuild if configured
             if (_options.AutoRebuildOnVersionChange && status.Version != projection.Version)
             {
+                if (checkpointScope.IsTenant)
+                {
+                    throw new InvalidOperationException(
+                        "Tenant-scoped projection checkpoints do not support automatic rebuild because projection ClearAsync is not tenant-aware. " +
+                        "Disable AutoRebuildOnVersionChange or run a global projection rebuild.");
+                }
+
                 _logger.LogInformation(
                     "Projection {Projection} version changed from {OldVersion} to {NewVersion}, triggering rebuild",
                     projection.Name, status.Version, projection.Version);
@@ -162,10 +196,15 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     private async Task<DbProjectionStatus> GetOrCreateStatusAsync(
         TDbContext dbContext,
         ProjectionRegistration projection,
+        CheckpointScopeKey checkpointScope,
         CancellationToken ct)
     {
         var status = await dbContext.Set<DbProjectionStatus>()
-            .FirstOrDefaultAsync(s => s.ProjectionName == projection.Name, ct);
+            .FirstOrDefaultAsync(s =>
+                s.ProjectionName == projection.Name &&
+                s.CheckpointScope == checkpointScope.Scope &&
+                s.TenantId == checkpointScope.TenantId,
+                ct);
 
 
         if (status == null)
@@ -173,6 +212,8 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
             status = new DbProjectionStatus
             {
                 ProjectionName = projection.Name,
+                CheckpointScope = checkpointScope.Scope,
+                TenantId = checkpointScope.TenantId,
                 Version = projection.Version,
                 State = ProjectionState.Active,
                 Position = 0
@@ -211,7 +252,9 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
         status.FailedEventSequence = null;
 
         // Get total events for progress tracking
-        status.TotalEvents = await dbContext.Events.LongCountAsync(ct);
+        var checkpointScope = new CheckpointScopeKey(status.CheckpointScope, status.TenantId);
+        status.TotalEvents = await ApplyCheckpointScope(dbContext.Events, checkpointScope)
+            .LongCountAsync(ct);
 
         await dbContext.SaveChangesAsync(ct);
 
@@ -291,7 +334,8 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
         DbProjectionStatus status,
         CancellationToken ct)
     {
-        var events = await dbContext.Events
+        var checkpointScope = new CheckpointScopeKey(status.CheckpointScope, status.TenantId);
+        var events = await ApplyCheckpointScope(dbContext.Events, checkpointScope)
             .Where(e => e.Sequence > status.Position)
             .OrderBy(e => e.Sequence)
             .Take(_options.BatchSize)
@@ -388,7 +432,11 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
             using var errorScope = _serviceProvider.CreateScope();
             var errorContext = errorScope.ServiceProvider.GetRequiredService<TDbContext>();
             var errorStatus = await errorContext.Set<DbProjectionStatus>()
-                .FirstAsync(s => s.ProjectionName == projection.Name, ct);
+                .FirstAsync(s =>
+                    s.ProjectionName == projection.Name &&
+                    s.CheckpointScope == status.CheckpointScope &&
+                    s.TenantId == status.TenantId,
+                    ct);
             
             errorStatus.State = ProjectionState.Faulted;
             errorStatus.LastError = ex.ToString();
@@ -397,5 +445,49 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
 
             throw;
         }
+    }
+
+    private async Task<IReadOnlyList<CheckpointScopeKey>> GetCheckpointScopesAsync(
+        string projectionName,
+        CancellationToken ct)
+    {
+        if (_options.CheckpointScope == CheckpointScope.Global)
+        {
+            return [CheckpointScopeKey.Global];
+        }
+
+        using var scope = _serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
+
+        var eventTenantIds = await dbContext.Events
+            .AsNoTracking()
+            .Select(e => e.TenantId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        var checkpointTenantIds = await dbContext.Set<DbProjectionStatus>()
+            .AsNoTracking()
+            .Where(s =>
+                s.ProjectionName == projectionName &&
+                s.CheckpointScope == CheckpointScope.Tenant)
+            .Select(s => s.TenantId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        return eventTenantIds
+            .Concat(checkpointTenantIds)
+            .Distinct()
+            .OrderBy(tenantId => tenantId)
+            .Select(CheckpointScopeKey.Tenant)
+            .ToArray();
+    }
+
+    private static IQueryable<DbEvent> ApplyCheckpointScope(
+        IQueryable<DbEvent> query,
+        CheckpointScopeKey checkpointScope)
+    {
+        return checkpointScope.IsTenant
+            ? query.Where(e => e.TenantId == checkpointScope.TenantId)
+            : query;
     }
 }

--- a/src/EventStoreCore/ProjectionDaemonOptions.cs
+++ b/src/EventStoreCore/ProjectionDaemonOptions.cs
@@ -1,3 +1,5 @@
+using EventStoreCore.Abstractions;
+
 namespace EventStoreCore;
 
 
@@ -35,6 +37,12 @@ public sealed class ProjectionDaemonOptions
     /// Default is 30 seconds.
     /// </summary>
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Determines whether projection checkpoints are shared globally or stored separately per tenant.
+    /// Default is <see cref="CheckpointScope.Global" />.
+    /// </summary>
+    public CheckpointScope CheckpointScope { get; set; } = CheckpointScope.Global;
 
     /// <summary>
     /// Optional delay between batches during rebuild (for throttling).

--- a/src/EventStoreCore/ProjectionInterceptor.cs
+++ b/src/EventStoreCore/ProjectionInterceptor.cs
@@ -178,13 +178,19 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
         {
             var statusSet = db.Set<DbProjectionStatus>();
             var status = await statusSet
-                .FirstOrDefaultAsync(s => s.ProjectionName == _projectionName, cancellationToken);
+                .FirstOrDefaultAsync(s =>
+                    s.ProjectionName == _projectionName &&
+                    s.CheckpointScope == CheckpointScope.Global &&
+                    s.TenantId == Guid.Empty,
+                    cancellationToken);
 
             if (status == null)
             {
                 status = new DbProjectionStatus
                 {
                     ProjectionName = _projectionName,
+                    CheckpointScope = CheckpointScope.Global,
+                    TenantId = Guid.Empty,
                     Version = _projectionVersion,
                     State = ProjectionState.Active,
                     Position = maxSequence,
@@ -237,7 +243,11 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
         {
             var status = await db.Set<DbProjectionStatus>()
                 .AsNoTracking()
-                .FirstOrDefaultAsync(s => s.ProjectionName == _projectionName, ct);
+                .FirstOrDefaultAsync(s =>
+                    s.ProjectionName == _projectionName &&
+                    s.CheckpointScope == CheckpointScope.Global &&
+                    s.TenantId == Guid.Empty,
+                    ct);
 
             return status?.State == ProjectionState.Rebuilding;
         }

--- a/src/EventStoreCore/ProjectionManager.cs
+++ b/src/EventStoreCore/ProjectionManager.cs
@@ -1,4 +1,3 @@
-using EventStoreCore;
 using EventStoreCore.Abstractions;
 using Medallion.Threading;
 using Microsoft.EntityFrameworkCore;
@@ -39,34 +38,31 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
     }
 
     /// <inheritdoc />
-    public async Task<ProjectionStatusDto?> GetStatusAsync(string projectionName, CancellationToken ct = default)
+    public Task<ProjectionStatusDto?> GetStatusAsync(string projectionName, CancellationToken ct = default)
     {
-        var status = await _dbContext.Set<DbProjectionStatus>()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(s => s.ProjectionName == projectionName, ct);
+        return GetStatusAsync(projectionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<ProjectionStatusDto?> GetStatusAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return GetStatusAsync(projectionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task<ProjectionStatusDto?> GetStatusAsync(
+        string projectionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var status = await FindStatusAsync(projectionName, checkpointScope, asNoTracking: true)
+            .FirstOrDefaultAsync(ct);
 
         if (status == null)
         {
-            // Check if projection is registered but not yet initialized
             var registration = _projections.FirstOrDefault(p => p.Name == projectionName);
-            if (registration != null)
-            {
-                // Return a default status for uninitialized projection
-                return new ProjectionStatusDto(
-                    projectionName,
-                    registration.Version,
-                    ProjectionState.Active,
-                    0,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                );
-            }
-            return null;
+            return registration == null
+                ? null
+                : CreateDefaultStatus(projectionName, registration.Version, checkpointScope);
         }
 
         return status.ToDto();
@@ -79,32 +75,44 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
             .AsNoTracking()
             .ToListAsync(ct);
 
-        var result = new List<ProjectionStatusDto>();
+        var result = statuses
+            .Select(status => status.ToDto())
+            .ToList();
 
-        // Add statuses for projections that have records
-        foreach (var status in statuses)
+        foreach (var registration in _projections)
         {
-            result.Add(status.ToDto());
+            if (!statuses.Any(s =>
+                s.ProjectionName == registration.Name &&
+                s.CheckpointScope == CheckpointScope.Global &&
+                s.TenantId == Guid.Empty))
+            {
+                result.Add(CreateDefaultStatus(registration.Name, registration.Version, CheckpointScopeKey.Global));
+            }
         }
 
-        // Add default status for registered projections without records
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ProjectionStatusDto>> GetAllStatusesAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        var checkpointScope = CheckpointScopeKey.Tenant(tenantId);
+        var statuses = await _dbContext.Set<DbProjectionStatus>()
+            .AsNoTracking()
+            .Where(s =>
+                s.CheckpointScope == checkpointScope.Scope &&
+                s.TenantId == checkpointScope.TenantId)
+            .ToListAsync(ct);
+
+        var result = statuses
+            .Select(status => status.ToDto())
+            .ToList();
+
         foreach (var registration in _projections)
         {
             if (!statuses.Any(s => s.ProjectionName == registration.Name))
             {
-                result.Add(new ProjectionStatusDto(
-                    registration.Name,
-                    registration.Version,
-                    ProjectionState.Active,
-                    0,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ));
+                result.Add(CreateDefaultStatus(registration.Name, registration.Version, checkpointScope));
             }
         }
 
@@ -118,14 +126,13 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
             ?? throw new InvalidOperationException($"Projection '{projectionName}' is not registered.");
 
         var lockName = $"projection:{projectionName}";
-        
+
         await using var lockHandle = await _lockProvider.AcquireLockAsync(lockName, cancellationToken: ct);
 
         _logger.LogInformation("Initiating manual rebuild for projection {Projection}", projectionName);
 
-        var status = await GetOrCreateStatusAsync(projectionName, registration.Version, ct);
+        var status = await GetOrCreateStatusAsync(projectionName, registration.Version, CheckpointScopeKey.Global, ct);
 
-        // Update status to rebuilding
         status.State = ProjectionState.Rebuilding;
         status.Position = 0;
         status.Version = registration.Version;
@@ -137,7 +144,6 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
 
         await _dbContext.SaveChangesAsync(ct);
 
-        // Clear projection data
         await registration.ClearAction(_dbContext, ct);
         await _dbContext.SaveChangesAsync(ct);
 
@@ -147,11 +153,20 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
     }
 
     /// <inheritdoc />
-    public async Task PauseAsync(string projectionName, CancellationToken ct = default)
+    public Task PauseAsync(string projectionName, CancellationToken ct = default)
     {
-        var status = await _dbContext.Set<DbProjectionStatus>()
-            .FirstOrDefaultAsync(s => s.ProjectionName == projectionName, ct)
-            ?? throw new InvalidOperationException($"Projection '{projectionName}' not found.");
+        return PauseAsync(projectionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task PauseAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return PauseAsync(projectionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task PauseAsync(string projectionName, CheckpointScopeKey checkpointScope, CancellationToken ct)
+    {
+        var status = await GetExistingStatusAsync(projectionName, checkpointScope, ct);
 
         if (status.State == ProjectionState.Faulted)
         {
@@ -161,15 +176,27 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
         status.State = ProjectionState.Paused;
         await _dbContext.SaveChangesAsync(ct);
 
-        _logger.LogInformation("Paused projection {Projection}", projectionName);
+        _logger.LogInformation(
+            "Paused projection {Projection} in checkpoint scope {Scope}",
+            projectionName,
+            checkpointScope);
     }
 
     /// <inheritdoc />
-    public async Task ResumeAsync(string projectionName, CancellationToken ct = default)
+    public Task ResumeAsync(string projectionName, CancellationToken ct = default)
     {
-        var status = await _dbContext.Set<DbProjectionStatus>()
-            .FirstOrDefaultAsync(s => s.ProjectionName == projectionName, ct)
-            ?? throw new InvalidOperationException($"Projection '{projectionName}' not found.");
+        return ResumeAsync(projectionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task ResumeAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return ResumeAsync(projectionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task ResumeAsync(string projectionName, CheckpointScopeKey checkpointScope, CancellationToken ct)
+    {
+        var status = await GetExistingStatusAsync(projectionName, checkpointScope, ct);
 
         if (status.State != ProjectionState.Paused)
         {
@@ -179,44 +206,71 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
         status.State = ProjectionState.Active;
         await _dbContext.SaveChangesAsync(ct);
 
-        _logger.LogInformation("Resumed projection {Projection}", projectionName);
+        _logger.LogInformation(
+            "Resumed projection {Projection} in checkpoint scope {Scope}",
+            projectionName,
+            checkpointScope);
     }
 
     /// <inheritdoc />
-    public async Task RetryFailedEventAsync(string projectionName, CancellationToken ct = default)
+    public Task RetryFailedEventAsync(string projectionName, CancellationToken ct = default)
     {
-        var status = await _dbContext.Set<DbProjectionStatus>()
-            .FirstOrDefaultAsync(s => s.ProjectionName == projectionName, ct)
-            ?? throw new InvalidOperationException($"Projection '{projectionName}' not found.");
+        return RetryFailedEventAsync(projectionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task RetryFailedEventAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return RetryFailedEventAsync(projectionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task RetryFailedEventAsync(
+        string projectionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var status = await GetExistingStatusAsync(projectionName, checkpointScope, ct);
 
         if (status.State != ProjectionState.Faulted)
         {
             throw new InvalidOperationException($"Projection is not faulted. Current state: {status.State}");
         }
 
-        // Clear error state and set back to active
-        // The daemon will retry processing from the current position
         status.State = ProjectionState.Active;
         status.LastError = null;
         status.FailedEventSequence = null;
         await _dbContext.SaveChangesAsync(ct);
 
-        _logger.LogInformation("Retrying failed event for projection {Projection}", projectionName);
+        _logger.LogInformation(
+            "Retrying failed event for projection {Projection} in checkpoint scope {Scope}",
+            projectionName,
+            checkpointScope);
     }
 
     /// <inheritdoc />
-    public async Task SkipFailedEventAsync(string projectionName, CancellationToken ct = default)
+    public Task SkipFailedEventAsync(string projectionName, CancellationToken ct = default)
     {
-        var status = await _dbContext.Set<DbProjectionStatus>()
-            .FirstOrDefaultAsync(s => s.ProjectionName == projectionName, ct)
-            ?? throw new InvalidOperationException($"Projection '{projectionName}' not found.");
+        return SkipFailedEventAsync(projectionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task SkipFailedEventAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return SkipFailedEventAsync(projectionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task SkipFailedEventAsync(
+        string projectionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var status = await GetExistingStatusAsync(projectionName, checkpointScope, ct);
 
         if (status.State != ProjectionState.Faulted || !status.FailedEventSequence.HasValue)
         {
             throw new InvalidOperationException("Projection is not faulted or has no failed event to skip.");
         }
 
-        // Skip the failed event by advancing position past it
         status.Position = status.FailedEventSequence.Value;
         status.State = ProjectionState.Active;
         status.LastError = null;
@@ -224,23 +278,38 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
         await _dbContext.SaveChangesAsync(ct);
 
         _logger.LogInformation(
-            "Skipped failed event at sequence {Sequence} for projection {Projection}",
-            status.Position, projectionName);
+            "Skipped failed event at sequence {Sequence} for projection {Projection} in checkpoint scope {Scope}",
+            status.Position,
+            projectionName,
+            checkpointScope);
     }
 
     /// <inheritdoc />
-    public async Task<FailedEventDto?> GetFailedEventAsync(string projectionName, CancellationToken ct = default)
+    public Task<FailedEventDto?> GetFailedEventAsync(string projectionName, CancellationToken ct = default)
     {
-        var status = await _dbContext.Set<DbProjectionStatus>()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(s => s.ProjectionName == projectionName, ct);
+        return GetFailedEventAsync(projectionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<FailedEventDto?> GetFailedEventAsync(string projectionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return GetFailedEventAsync(projectionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task<FailedEventDto?> GetFailedEventAsync(
+        string projectionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var status = await FindStatusAsync(projectionName, checkpointScope, asNoTracking: true)
+            .FirstOrDefaultAsync(ct);
 
         if (status?.State != ProjectionState.Faulted || !status.FailedEventSequence.HasValue)
         {
             return null;
         }
 
-        var dbEvent = await _dbContext.Events
+        var dbEvent = await ApplyCheckpointScope(_dbContext.Events, checkpointScope)
             .AsNoTracking()
             .FirstOrDefaultAsync(e => e.Sequence == status.FailedEventSequence, ct);
 
@@ -262,19 +331,29 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
             dbEvent.Data,
             dbEvent.Timestamp,
             status.LastError ?? "Unknown error"
-        );
+        )
+        {
+            CheckpointScope = checkpointScope.Scope,
+            TenantId = checkpointScope.IsTenant ? checkpointScope.TenantId : null
+        };
     }
 
-    private async Task<DbProjectionStatus> GetOrCreateStatusAsync(string projectionName, int version, CancellationToken ct)
+    private async Task<DbProjectionStatus> GetOrCreateStatusAsync(
+        string projectionName,
+        int version,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
     {
-        var status = await _dbContext.Set<DbProjectionStatus>()
-            .FirstOrDefaultAsync(s => s.ProjectionName == projectionName, ct);
+        var status = await FindStatusAsync(projectionName, checkpointScope, asNoTracking: false)
+            .FirstOrDefaultAsync(ct);
 
         if (status == null)
         {
             status = new DbProjectionStatus
             {
                 ProjectionName = projectionName,
+                CheckpointScope = checkpointScope.Scope,
+                TenantId = checkpointScope.TenantId,
                 Version = version,
                 State = ProjectionState.Active,
                 Position = 0
@@ -285,5 +364,61 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
 
         return status;
     }
-}
 
+    private async Task<DbProjectionStatus> GetExistingStatusAsync(
+        string projectionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        return await FindStatusAsync(projectionName, checkpointScope, asNoTracking: false)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new InvalidOperationException($"Projection '{projectionName}' not found.");
+    }
+
+    private IQueryable<DbProjectionStatus> FindStatusAsync(
+        string projectionName,
+        CheckpointScopeKey checkpointScope,
+        bool asNoTracking)
+    {
+        var query = _dbContext.Set<DbProjectionStatus>()
+            .Where(s =>
+                s.ProjectionName == projectionName &&
+                s.CheckpointScope == checkpointScope.Scope &&
+                s.TenantId == checkpointScope.TenantId);
+
+        return asNoTracking ? query.AsNoTracking() : query;
+    }
+
+    private static ProjectionStatusDto CreateDefaultStatus(
+        string projectionName,
+        int version,
+        CheckpointScopeKey checkpointScope)
+    {
+        return new ProjectionStatusDto(
+            projectionName,
+            version,
+            ProjectionState.Active,
+            0,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
+        {
+            CheckpointScope = checkpointScope.Scope,
+            TenantId = checkpointScope.IsTenant ? checkpointScope.TenantId : null
+        };
+    }
+
+    private static IQueryable<DbEvent> ApplyCheckpointScope(
+        IQueryable<DbEvent> query,
+        CheckpointScopeKey checkpointScope)
+    {
+        return checkpointScope.IsTenant
+            ? query.Where(e => e.TenantId == checkpointScope.TenantId)
+            : query;
+    }
+}

--- a/src/EventStoreCore/ProjectionManager.cs
+++ b/src/EventStoreCore/ProjectionManager.cs
@@ -131,25 +131,81 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
 
         _logger.LogInformation("Initiating manual rebuild for projection {Projection}", projectionName);
 
-        var status = await GetOrCreateStatusAsync(projectionName, registration.Version, CheckpointScopeKey.Global, ct);
+        var existingTenantScopeIds = await _dbContext.Set<DbProjectionStatus>()
+            .AsNoTracking()
+            .Where(s =>
+                s.ProjectionName == projectionName &&
+                s.CheckpointScope == CheckpointScope.Tenant)
+            .Select(s => s.TenantId)
+            .Distinct()
+            .ToListAsync(ct);
 
-        status.State = ProjectionState.Rebuilding;
-        status.Position = 0;
-        status.Version = registration.Version;
-        status.RebuildStartedAt = DateTimeOffset.UtcNow;
-        status.RebuildCompletedAt = null;
-        status.LastError = null;
-        status.FailedEventSequence = null;
-        status.TotalEvents = await _dbContext.Events.LongCountAsync(ct);
+        var eventTenantScopeIds = existingTenantScopeIds.Count == 0
+            ? []
+            : await _dbContext.Events
+                .AsNoTracking()
+                .Select(e => e.TenantId)
+                .Distinct()
+                .ToListAsync(ct);
 
-        await _dbContext.SaveChangesAsync(ct);
+        var tenantScopeIds = existingTenantScopeIds
+            .Concat(eventTenantScopeIds)
+            .Distinct()
+            .OrderBy(tenantId => tenantId)
+            .ToArray();
 
-        await registration.ClearAction(_dbContext, ct);
-        await _dbContext.SaveChangesAsync(ct);
+        var tenantLockHandles = new List<IAsyncDisposable>();
+        try
+        {
+            foreach (var tenantId in tenantScopeIds)
+            {
+                var tenantLockName = $"projection:{projectionName}{CheckpointScopeKey.Tenant(tenantId).LockSuffix}";
+                tenantLockHandles.Add(await _lockProvider.AcquireLockAsync(tenantLockName, cancellationToken: ct));
+            }
 
-        _logger.LogInformation(
-            "Rebuild initiated for projection {Projection}, clearing data and replaying {Total} events",
-            projectionName, status.TotalEvents);
+            var statuses = await _dbContext.Set<DbProjectionStatus>()
+                .Where(s => s.ProjectionName == projectionName)
+                .ToListAsync(ct);
+
+            var globalStatus = statuses.FirstOrDefault(s =>
+                s.CheckpointScope == CheckpointScope.Global &&
+                s.TenantId == Guid.Empty);
+
+            if (globalStatus == null)
+            {
+                globalStatus = new DbProjectionStatus
+                {
+                    ProjectionName = projectionName,
+                    CheckpointScope = CheckpointScope.Global,
+                    TenantId = Guid.Empty
+                };
+                _dbContext.Set<DbProjectionStatus>().Add(globalStatus);
+                statuses.Add(globalStatus);
+            }
+
+            var rebuildStartedAt = DateTimeOffset.UtcNow;
+            foreach (var status in statuses)
+            {
+                await ResetStatusForRebuildAsync(status, registration.Version, rebuildStartedAt, ct);
+            }
+
+            await _dbContext.SaveChangesAsync(ct);
+
+            await registration.ClearAction(_dbContext, ct);
+            await _dbContext.SaveChangesAsync(ct);
+
+            _logger.LogInformation(
+                "Rebuild initiated for projection {Projection}, clearing data and resetting {CheckpointCount} checkpoint scopes",
+                projectionName,
+                statuses.Count);
+        }
+        finally
+        {
+            foreach (var tenantLockHandle in tenantLockHandles)
+            {
+                await tenantLockHandle.DisposeAsync();
+            }
+        }
     }
 
     /// <inheritdoc />
@@ -363,6 +419,25 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
         }
 
         return status;
+    }
+
+    private async Task ResetStatusForRebuildAsync(
+        DbProjectionStatus status,
+        int version,
+        DateTimeOffset rebuildStartedAt,
+        CancellationToken ct)
+    {
+        var checkpointScope = new CheckpointScopeKey(status.CheckpointScope, status.TenantId);
+
+        status.State = ProjectionState.Rebuilding;
+        status.Position = 0;
+        status.Version = version;
+        status.RebuildStartedAt = rebuildStartedAt;
+        status.RebuildCompletedAt = null;
+        status.LastError = null;
+        status.FailedEventSequence = null;
+        status.TotalEvents = await ApplyCheckpointScope(_dbContext.Events, checkpointScope)
+            .LongCountAsync(ct);
     }
 
     private async Task<DbProjectionStatus> GetExistingStatusAsync(

--- a/src/EventStoreCore/SubscriptionDaemon.cs
+++ b/src/EventStoreCore/SubscriptionDaemon.cs
@@ -44,29 +44,44 @@ public sealed class SubscriptionDaemon<TDbContext>(
 
                 try
                 {
-                    var acquired = await AcquireSubscriptionLockAsync(subscriptionType, stoppingToken);
+                    var checkpointScopes = await GetCheckpointScopesAsync(name, stoppingToken);
 
-                    if (acquired == null)
+                    if (checkpointScopes.Count == 0)
                     {
-                        await Task.Delay(_options.LockTimeout, stoppingToken);
+                        await Task.Delay(_options.PollingInterval, stoppingToken);
                         continue;
                     }
 
-                    await using (acquired)
+                    var processedAny = false;
+                    foreach (var checkpointScope in checkpointScopes)
                     {
-                        using var scope = _serviceProvider.CreateScope();
-                        var processedCount = await ProcessNextBatchAsync(scope, subscription, stoppingToken);
+                        var acquired = await AcquireSubscriptionLockAsync(subscriptionType, checkpointScope, stoppingToken);
 
-                        if (processedCount == 0)
+                        if (acquired == null)
                         {
-                            logger.LogInformation(
-                                "No new events to process for subscription {Subscription}",
-                                name);
-                            await Task.Delay(_options.PollingInterval, stoppingToken);
+                            continue;
                         }
+
+                        await using (acquired)
+                        {
+                            using var scope = _serviceProvider.CreateScope();
+                            var processedCount = await ProcessNextBatchAsync(scope, subscription, stoppingToken, checkpointScope);
+                            processedAny = processedAny || processedCount > 0;
+                        }
+
+                        logger.LogInformation(
+                            "Released lock for subscription {Subscription} in checkpoint scope {Scope}",
+                            name,
+                            checkpointScope);
                     }
 
-                    logger.LogInformation("Released lock for subscription {Subscription}", name);
+                    if (!processedAny)
+                    {
+                        logger.LogInformation(
+                            "No new events to process for subscription {Subscription}",
+                            name);
+                        await Task.Delay(_options.PollingInterval, stoppingToken);
+                    }
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
@@ -102,7 +117,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
     /// <returns>True when an event was processed.</returns>
     internal async Task<bool> ProcessNextEventAsync(IServiceScope scope, ISubscription subscriptionImpl, CancellationToken stoppingToken)
     {
-        return await ProcessNextBatchAsync(scope, subscriptionImpl, stoppingToken, 1, 1) > 0;
+        return await ProcessNextBatchAsync(scope, subscriptionImpl, stoppingToken, CheckpointScopeKey.Global, 1, 1) > 0;
     }
 
     /// <summary>
@@ -118,6 +133,37 @@ public sealed class SubscriptionDaemon<TDbContext>(
             scope,
             subscriptionImpl,
             stoppingToken,
+            CheckpointScopeKey.Global,
+            Math.Max(1, _options.BatchSize),
+            Math.Max(1, _options.CheckpointFrequency));
+    }
+
+    internal Task<int> ProcessNextBatchAsync(
+        IServiceScope scope,
+        ISubscription subscriptionImpl,
+        CancellationToken stoppingToken,
+        Guid tenantId)
+    {
+        return ProcessNextBatchAsync(
+            scope,
+            subscriptionImpl,
+            stoppingToken,
+            CheckpointScopeKey.Tenant(tenantId),
+            Math.Max(1, _options.BatchSize),
+            Math.Max(1, _options.CheckpointFrequency));
+    }
+
+    private Task<int> ProcessNextBatchAsync(
+        IServiceScope scope,
+        ISubscription subscriptionImpl,
+        CancellationToken stoppingToken,
+        CheckpointScopeKey checkpointScope)
+    {
+        return ProcessNextBatchAsync(
+            scope,
+            subscriptionImpl,
+            stoppingToken,
+            checkpointScope,
             Math.Max(1, _options.BatchSize),
             Math.Max(1, _options.CheckpointFrequency));
     }
@@ -126,6 +172,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
         IServiceScope scope,
         ISubscription subscriptionImpl,
         CancellationToken stoppingToken,
+        CheckpointScopeKey checkpointScope,
         int batchSize,
         int checkpointFrequency)
     {
@@ -137,7 +184,11 @@ public sealed class SubscriptionDaemon<TDbContext>(
         try
         {
             var subscriptionSet = dbContext.Set<DbSubscription>();
-            var subscription = await subscriptionSet.FindAsync([name], stoppingToken);
+            var subscription = await subscriptionSet.FirstOrDefaultAsync(
+                s => s.SubscriptionAssemblyQualifiedName == name &&
+                    s.CheckpointScope == checkpointScope.Scope &&
+                    s.TenantId == checkpointScope.TenantId,
+                stoppingToken);
             var createdSubscription = false;
 
             if (subscription is null)
@@ -145,10 +196,15 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 subscription = new DbSubscription
                 {
                     SubscriptionAssemblyQualifiedName = name,
+                    CheckpointScope = checkpointScope.Scope,
+                    TenantId = checkpointScope.TenantId
                 };
                 subscriptionSet.Add(subscription);
                 createdSubscription = true;
-                logger.LogInformation("Created new subscription entity for {Subscription}", name);
+                logger.LogInformation(
+                    "Created new subscription entity for {Subscription} in checkpoint scope {Scope}",
+                    name,
+                    checkpointScope);
             }
 
             if (!CanProcess(subscription, name))
@@ -162,7 +218,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 return 0;
             }
 
-            var nextEvents = await dbContext.Events
+            var nextEvents = await ApplyCheckpointScope(dbContext.Events, checkpointScope)
                 .Where(e => e.Sequence > subscription.Sequence)
                 .OrderBy(e => e.Sequence)
                 .Take(batchSize)
@@ -272,7 +328,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
     internal async Task<IAsyncDisposable?> AcquireSubscriptionLockAsync<TSub>(CancellationToken cancellationToken)
         where TSub : ISubscription
     {
-        return await AcquireSubscriptionLockAsync(typeof(TSub), cancellationToken);
+        return await AcquireSubscriptionLockAsync(typeof(TSub), CheckpointScopeKey.Global, cancellationToken);
     }
 
     /// <summary>
@@ -283,33 +339,94 @@ public sealed class SubscriptionDaemon<TDbContext>(
     /// <returns>The lock handle or null when lock acquisition fails.</returns>
     private async Task<IAsyncDisposable?> AcquireSubscriptionLockAsync(Type subType, CancellationToken cancellationToken)
     {
-        var name = subType.AssemblyQualifiedName!;
+        return await AcquireSubscriptionLockAsync(subType, CheckpointScopeKey.Global, cancellationToken);
+    }
+
+    private async Task<IAsyncDisposable?> AcquireSubscriptionLockAsync(
+        Type subType,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken cancellationToken)
+    {
+        var subscriptionName = subType.AssemblyQualifiedName!;
+        var lockName = $"{subscriptionName}{checkpointScope.LockSuffix}";
 
 
         try
         {
-            logger.LogInformation("Attempting to acquire lock for subscription {Subscription}", name);
+            logger.LogInformation(
+                "Attempting to acquire lock for subscription {Subscription} in checkpoint scope {Scope}",
+                subscriptionName,
+                checkpointScope);
             var acquired = await _distributedLockProvider
-                  .AcquireLockAsync(name, TimeSpan.FromSeconds(2), cancellationToken: cancellationToken);
+                  .AcquireLockAsync(lockName, TimeSpan.FromSeconds(2), cancellationToken: cancellationToken);
 
             if (acquired == null)
             {
                 logger.LogInformation(
-                    "Could not acquire lock for subscription {Subscription}, another instance may be running.",
-                    name);
+                    "Could not acquire lock for subscription {Subscription} in checkpoint scope {Scope}, another instance may be running.",
+                    subscriptionName,
+                    checkpointScope);
                 return null;
             }
 
-            logger.LogInformation("Acquired lock for subscription {Subscription}", name);
+            logger.LogInformation(
+                "Acquired lock for subscription {Subscription} in checkpoint scope {Scope}",
+                subscriptionName,
+                checkpointScope);
             return acquired as IAsyncDisposable ?? acquired;
         }
         catch (TimeoutException)
         {
             logger.LogInformation(
-                    "Could not acquire lock for subscription {Subscription}, another instance may be running.",
-                    name);
+                    "Could not acquire lock for subscription {Subscription} in checkpoint scope {Scope}, another instance may be running.",
+                    subscriptionName,
+                    checkpointScope);
             return null;
         }
+    }
+
+    private async Task<IReadOnlyList<CheckpointScopeKey>> GetCheckpointScopesAsync(
+        string subscriptionName,
+        CancellationToken cancellationToken)
+    {
+        if (_options.CheckpointScope == CheckpointScope.Global)
+        {
+            return [CheckpointScopeKey.Global];
+        }
+
+        using var scope = _serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
+
+        var eventTenantIds = await dbContext.Events
+            .AsNoTracking()
+            .Select(e => e.TenantId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var checkpointTenantIds = await dbContext.Set<DbSubscription>()
+            .AsNoTracking()
+            .Where(s =>
+                s.SubscriptionAssemblyQualifiedName == subscriptionName &&
+                s.CheckpointScope == CheckpointScope.Tenant)
+            .Select(s => s.TenantId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        return eventTenantIds
+            .Concat(checkpointTenantIds)
+            .Distinct()
+            .OrderBy(tenantId => tenantId)
+            .Select(CheckpointScopeKey.Tenant)
+            .ToArray();
+    }
+
+    private static IQueryable<DbEvent> ApplyCheckpointScope(
+        IQueryable<DbEvent> query,
+        CheckpointScopeKey checkpointScope)
+    {
+        return checkpointScope.IsTenant
+            ? query.Where(e => e.TenantId == checkpointScope.TenantId)
+            : query;
     }
 
     private bool CanProcess(DbSubscription subscription, string name)

--- a/src/EventStoreCore/SubscriptionManager.cs
+++ b/src/EventStoreCore/SubscriptionManager.cs
@@ -40,11 +40,24 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
     }
 
     /// <inheritdoc />
-    public async Task<SubscriptionStatusDto?> GetStatusAsync(string subscriptionName, CancellationToken ct = default)
+    public Task<SubscriptionStatusDto?> GetStatusAsync(string subscriptionName, CancellationToken ct = default)
     {
-        var record = await _dbContext.Set<DbSubscription>()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(s => s.SubscriptionAssemblyQualifiedName == subscriptionName, ct);
+        return GetStatusAsync(subscriptionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<SubscriptionStatusDto?> GetStatusAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return GetStatusAsync(subscriptionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task<SubscriptionStatusDto?> GetStatusAsync(
+        string subscriptionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var record = await FindStatusAsync(subscriptionName, checkpointScope, asNoTracking: true)
+            .FirstOrDefaultAsync(ct);
 
         if (record == null)
         {
@@ -53,25 +66,11 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
                 return null;
             }
 
-            var totalEvents = await _dbContext.Events.LongCountAsync(ct);
-            return new SubscriptionStatusDto(
-                subscriptionName,
-                0,
-                SubscriptionState.Active,
-                totalEvents,
-                CalculateProgress(0, totalEvents),
-                null,
-                null,
-                0,
-                null,
-                null,
-                null);
+            var totalEvents = await CountEventsAsync(checkpointScope, ct);
+            return CreateDefaultStatus(subscriptionName, checkpointScope, totalEvents);
         }
 
-        var lastProcessedAt = await GetLastProcessedAtAsync(record.Sequence, ct);
-        var totalCount = await _dbContext.Events.LongCountAsync(ct);
-
-        return record.ToDto(totalCount, lastProcessedAt);
+        return await ToStatusDtoAsync(record, ct);
     }
 
     /// <inheritdoc />
@@ -81,33 +80,22 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
             .AsNoTracking()
             .ToListAsync(ct);
 
-        var totalEvents = await _dbContext.Events.LongCountAsync(ct);
-        var lastProcessedLookup = await GetLastProcessedLookupAsync(records, ct);
-
         var result = new List<SubscriptionStatusDto>();
 
         foreach (var record in records)
         {
-            lastProcessedLookup.TryGetValue(record.Sequence, out var lastProcessedAt);
-            result.Add(record.ToDto(totalEvents, lastProcessedAt));
+            result.Add(await ToStatusDtoAsync(record, ct));
         }
 
+        var globalTotalEvents = await CountEventsAsync(CheckpointScopeKey.Global, ct);
         foreach (var subscriptionName in _subscriptionNames)
         {
-            if (!records.Any(r => r.SubscriptionAssemblyQualifiedName == subscriptionName))
+            if (!records.Any(r =>
+                r.SubscriptionAssemblyQualifiedName == subscriptionName &&
+                r.CheckpointScope == CheckpointScope.Global &&
+                r.TenantId == Guid.Empty))
             {
-                result.Add(new SubscriptionStatusDto(
-                    subscriptionName,
-                    0,
-                    SubscriptionState.Active,
-                    totalEvents,
-                    CalculateProgress(0, totalEvents),
-                    null,
-                    null,
-                    0,
-                    null,
-                    null,
-                    null));
+                result.Add(CreateDefaultStatus(subscriptionName, CheckpointScopeKey.Global, globalTotalEvents));
             }
         }
 
@@ -115,9 +103,50 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
     }
 
     /// <inheritdoc />
-    public async Task PauseAsync(string subscriptionName, CancellationToken ct = default)
+    public async Task<IReadOnlyList<SubscriptionStatusDto>> GetAllStatusesAsync(Guid tenantId, CancellationToken ct = default)
     {
-        var status = await GetExistingStatusAsync(subscriptionName, ct);
+        var checkpointScope = CheckpointScopeKey.Tenant(tenantId);
+        var records = await _dbContext.Set<DbSubscription>()
+            .AsNoTracking()
+            .Where(s =>
+                s.CheckpointScope == checkpointScope.Scope &&
+                s.TenantId == checkpointScope.TenantId)
+            .ToListAsync(ct);
+
+        var result = new List<SubscriptionStatusDto>();
+
+        foreach (var record in records)
+        {
+            result.Add(await ToStatusDtoAsync(record, ct));
+        }
+
+        var totalEvents = await CountEventsAsync(checkpointScope, ct);
+        foreach (var subscriptionName in _subscriptionNames)
+        {
+            if (!records.Any(r => r.SubscriptionAssemblyQualifiedName == subscriptionName))
+            {
+                result.Add(CreateDefaultStatus(subscriptionName, checkpointScope, totalEvents));
+            }
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public Task PauseAsync(string subscriptionName, CancellationToken ct = default)
+    {
+        return PauseAsync(subscriptionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task PauseAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return PauseAsync(subscriptionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task PauseAsync(string subscriptionName, CheckpointScopeKey checkpointScope, CancellationToken ct)
+    {
+        var status = await GetExistingStatusAsync(subscriptionName, checkpointScope, ct);
 
         if (status.State is SubscriptionState.Faulted or SubscriptionState.DeadLettered)
         {
@@ -132,13 +161,27 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         status.State = SubscriptionState.Paused;
         await _dbContext.SaveChangesAsync(ct);
 
-        _logger.LogInformation("Paused subscription {Subscription}", subscriptionName);
+        _logger.LogInformation(
+            "Paused subscription {Subscription} in checkpoint scope {Scope}",
+            subscriptionName,
+            checkpointScope);
     }
 
     /// <inheritdoc />
-    public async Task ResumeAsync(string subscriptionName, CancellationToken ct = default)
+    public Task ResumeAsync(string subscriptionName, CancellationToken ct = default)
     {
-        var status = await GetExistingStatusAsync(subscriptionName, ct);
+        return ResumeAsync(subscriptionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task ResumeAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return ResumeAsync(subscriptionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task ResumeAsync(string subscriptionName, CheckpointScopeKey checkpointScope, CancellationToken ct)
+    {
+        var status = await GetExistingStatusAsync(subscriptionName, checkpointScope, ct);
 
         if (status.State != SubscriptionState.Paused)
         {
@@ -148,13 +191,30 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         status.State = SubscriptionState.Active;
         await _dbContext.SaveChangesAsync(ct);
 
-        _logger.LogInformation("Resumed subscription {Subscription}", subscriptionName);
+        _logger.LogInformation(
+            "Resumed subscription {Subscription} in checkpoint scope {Scope}",
+            subscriptionName,
+            checkpointScope);
     }
 
     /// <inheritdoc />
-    public async Task RetryFailedEventAsync(string subscriptionName, CancellationToken ct = default)
+    public Task RetryFailedEventAsync(string subscriptionName, CancellationToken ct = default)
     {
-        var status = await GetExistingStatusAsync(subscriptionName, ct);
+        return RetryFailedEventAsync(subscriptionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task RetryFailedEventAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return RetryFailedEventAsync(subscriptionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task RetryFailedEventAsync(
+        string subscriptionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var status = await GetExistingStatusAsync(subscriptionName, checkpointScope, ct);
 
         if (status.State is not (SubscriptionState.Faulted or SubscriptionState.DeadLettered))
         {
@@ -165,13 +225,30 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         status.State = SubscriptionState.Active;
         await _dbContext.SaveChangesAsync(ct);
 
-        _logger.LogInformation("Retrying failed event for subscription {Subscription}", subscriptionName);
+        _logger.LogInformation(
+            "Retrying failed event for subscription {Subscription} in checkpoint scope {Scope}",
+            subscriptionName,
+            checkpointScope);
     }
 
     /// <inheritdoc />
-    public async Task SkipFailedEventAsync(string subscriptionName, CancellationToken ct = default)
+    public Task SkipFailedEventAsync(string subscriptionName, CancellationToken ct = default)
     {
-        var status = await GetExistingStatusAsync(subscriptionName, ct);
+        return SkipFailedEventAsync(subscriptionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task SkipFailedEventAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return SkipFailedEventAsync(subscriptionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task SkipFailedEventAsync(
+        string subscriptionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var status = await GetExistingStatusAsync(subscriptionName, checkpointScope, ct);
 
         if (status.State is not (SubscriptionState.Faulted or SubscriptionState.DeadLettered) || !status.FailedEventSequence.HasValue)
         {
@@ -184,24 +261,38 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         await _dbContext.SaveChangesAsync(ct);
 
         _logger.LogInformation(
-            "Skipped failed event at sequence {Sequence} for subscription {Subscription}",
+            "Skipped failed event at sequence {Sequence} for subscription {Subscription} in checkpoint scope {Scope}",
             status.Sequence,
-            subscriptionName);
+            subscriptionName,
+            checkpointScope);
     }
 
     /// <inheritdoc />
-    public async Task<SubscriptionFailedEventDto?> GetFailedEventAsync(string subscriptionName, CancellationToken ct = default)
+    public Task<SubscriptionFailedEventDto?> GetFailedEventAsync(string subscriptionName, CancellationToken ct = default)
     {
-        var status = await _dbContext.Set<DbSubscription>()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(s => s.SubscriptionAssemblyQualifiedName == subscriptionName, ct);
+        return GetFailedEventAsync(subscriptionName, CheckpointScopeKey.Global, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<SubscriptionFailedEventDto?> GetFailedEventAsync(string subscriptionName, Guid tenantId, CancellationToken ct = default)
+    {
+        return GetFailedEventAsync(subscriptionName, CheckpointScopeKey.Tenant(tenantId), ct);
+    }
+
+    private async Task<SubscriptionFailedEventDto?> GetFailedEventAsync(
+        string subscriptionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        var status = await FindStatusAsync(subscriptionName, checkpointScope, asNoTracking: true)
+            .FirstOrDefaultAsync(ct);
 
         if (status?.State is not (SubscriptionState.Faulted or SubscriptionState.DeadLettered) || !status.FailedEventSequence.HasValue)
         {
             return null;
         }
 
-        var dbEvent = await _dbContext.Events
+        var dbEvent = await ApplyCheckpointScope(_dbContext.Events, checkpointScope)
             .AsNoTracking()
             .FirstOrDefaultAsync(e => e.Sequence == status.FailedEventSequence, ct);
 
@@ -222,15 +313,40 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
             eventTypeName,
             dbEvent.Data,
             dbEvent.Timestamp,
-            status.LastError ?? "Unknown error");
+            status.LastError ?? "Unknown error")
+        {
+            CheckpointScope = checkpointScope.Scope,
+            TenantId = checkpointScope.IsTenant ? checkpointScope.TenantId : null
+        };
     }
 
     /// <inheritdoc />
-    public async Task ReplayAsync(
+    public Task ReplayAsync(
         string subscriptionName,
         long? startSequence = null,
         DateTimeOffset? fromTimestamp = null,
         CancellationToken ct = default)
+    {
+        return ReplayAsync(subscriptionName, CheckpointScopeKey.Global, startSequence, fromTimestamp, ct);
+    }
+
+    /// <inheritdoc />
+    public Task ReplayAsync(
+        string subscriptionName,
+        Guid tenantId,
+        long? startSequence = null,
+        DateTimeOffset? fromTimestamp = null,
+        CancellationToken ct = default)
+    {
+        return ReplayAsync(subscriptionName, CheckpointScopeKey.Tenant(tenantId), startSequence, fromTimestamp, ct);
+    }
+
+    private async Task ReplayAsync(
+        string subscriptionName,
+        CheckpointScopeKey checkpointScope,
+        long? startSequence,
+        DateTimeOffset? fromTimestamp,
+        CancellationToken ct)
     {
         if (startSequence.HasValue && fromTimestamp.HasValue)
         {
@@ -242,22 +358,25 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
             throw new InvalidOperationException($"Subscription '{subscriptionName}' is not registered.");
         }
 
-        await using var lockHandle = await _lockProvider.AcquireLockAsync(subscriptionName, cancellationToken: ct);
+        var lockName = $"{subscriptionName}{checkpointScope.LockSuffix}";
+        await using var lockHandle = await _lockProvider.AcquireLockAsync(lockName, cancellationToken: ct);
 
-        var record = await _dbContext.Set<DbSubscription>()
-            .FirstOrDefaultAsync(s => s.SubscriptionAssemblyQualifiedName == subscriptionName, ct);
+        var record = await FindStatusAsync(subscriptionName, checkpointScope, asNoTracking: false)
+            .FirstOrDefaultAsync(ct);
 
         if (record == null)
         {
             record = new DbSubscription
             {
                 SubscriptionAssemblyQualifiedName = subscriptionName,
+                CheckpointScope = checkpointScope.Scope,
+                TenantId = checkpointScope.TenantId,
                 Sequence = 0
             };
             _dbContext.Set<DbSubscription>().Add(record);
         }
 
-        var targetSequence = await ResolveReplayPositionAsync(startSequence, fromTimestamp, ct);
+        var targetSequence = await ResolveReplayPositionAsync(checkpointScope, startSequence, fromTimestamp, ct);
         record.Sequence = targetSequence;
         record.State = SubscriptionState.Active;
         ResetFailureState(record);
@@ -265,19 +384,14 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         await _dbContext.SaveChangesAsync(ct);
 
         _logger.LogInformation(
-            "Reset subscription {Subscription} to sequence {Sequence} for replay",
+            "Reset subscription {Subscription} in checkpoint scope {Scope} to sequence {Sequence} for replay",
             subscriptionName,
+            checkpointScope,
             record.Sequence);
     }
 
-    /// <summary>
-    /// Resolves the sequence position for a replay request.
-    /// </summary>
-    /// <param name="startSequence">Explicit start sequence, if provided.</param>
-    /// <param name="fromTimestamp">Timestamp to start from, if provided.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The sequence position to persist.</returns>
     private async Task<long> ResolveReplayPositionAsync(
+        CheckpointScopeKey checkpointScope,
         long? startSequence,
         DateTimeOffset? fromTimestamp,
         CancellationToken ct)
@@ -289,7 +403,7 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
 
         if (fromTimestamp.HasValue)
         {
-            var firstSequence = await _dbContext.Events
+            var firstSequence = await ApplyCheckpointScope(_dbContext.Events, checkpointScope)
                 .AsNoTracking()
                 .Where(e => e.Timestamp >= fromTimestamp.Value)
                 .OrderBy(e => e.Sequence)
@@ -301,18 +415,70 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
                 return Math.Max(firstSequence.Value - 1, 0);
             }
 
-            var maxSequence = await _dbContext.Events.MaxAsync(e => (long?)e.Sequence, ct) ?? 0;
-            return maxSequence;
+            return await ApplyCheckpointScope(_dbContext.Events, checkpointScope)
+                .MaxAsync(e => (long?)e.Sequence, ct) ?? 0;
         }
 
         return 0;
     }
 
-    private async Task<DbSubscription> GetExistingStatusAsync(string subscriptionName, CancellationToken ct)
+    private async Task<DbSubscription> GetExistingStatusAsync(
+        string subscriptionName,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
     {
-        return await _dbContext.Set<DbSubscription>()
-            .FirstOrDefaultAsync(s => s.SubscriptionAssemblyQualifiedName == subscriptionName, ct)
+        return await FindStatusAsync(subscriptionName, checkpointScope, asNoTracking: false)
+            .FirstOrDefaultAsync(ct)
             ?? throw new InvalidOperationException($"Subscription '{subscriptionName}' not found.");
+    }
+
+    private IQueryable<DbSubscription> FindStatusAsync(
+        string subscriptionName,
+        CheckpointScopeKey checkpointScope,
+        bool asNoTracking)
+    {
+        var query = _dbContext.Set<DbSubscription>()
+            .Where(s =>
+                s.SubscriptionAssemblyQualifiedName == subscriptionName &&
+                s.CheckpointScope == checkpointScope.Scope &&
+                s.TenantId == checkpointScope.TenantId);
+
+        return asNoTracking ? query.AsNoTracking() : query;
+    }
+
+    private async Task<SubscriptionStatusDto> ToStatusDtoAsync(DbSubscription record, CancellationToken ct)
+    {
+        var checkpointScope = new CheckpointScopeKey(record.CheckpointScope, record.TenantId);
+        var totalEvents = await CountEventsAsync(checkpointScope, ct);
+        var lastProcessedAt = await GetLastProcessedAtAsync(record.Sequence, checkpointScope, ct);
+        var processedEvents = checkpointScope.IsTenant
+            ? await CountProcessedEventsAsync(record.Sequence, checkpointScope, ct)
+            : (long?)null;
+
+        return record.ToDto(totalEvents, lastProcessedAt, processedEvents);
+    }
+
+    private static SubscriptionStatusDto CreateDefaultStatus(
+        string subscriptionName,
+        CheckpointScopeKey checkpointScope,
+        long totalEvents)
+    {
+        return new SubscriptionStatusDto(
+            subscriptionName,
+            0,
+            SubscriptionState.Active,
+            totalEvents,
+            CalculateProgress(0, totalEvents),
+            null,
+            null,
+            0,
+            null,
+            null,
+            null)
+        {
+            CheckpointScope = checkpointScope.Scope,
+            TenantId = checkpointScope.IsTenant ? checkpointScope.TenantId : null
+        };
     }
 
     private static void ResetFailureState(DbSubscription status)
@@ -340,51 +506,48 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         return Math.Round((double)position / totalEvents * 100, 2);
     }
 
-    /// <summary>
-    /// Gets the timestamp of the last processed event at a given position.
-    /// </summary>
-    /// <param name="position">The event sequence position.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The timestamp of the event, or null when not available.</returns>
-    private async Task<DateTimeOffset?> GetLastProcessedAtAsync(long position, CancellationToken ct)
+    private Task<long> CountEventsAsync(CheckpointScopeKey checkpointScope, CancellationToken ct)
+    {
+        return ApplyCheckpointScope(_dbContext.Events, checkpointScope).LongCountAsync(ct);
+    }
+
+    private Task<long> CountProcessedEventsAsync(
+        long position,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        if (position <= 0)
+        {
+            return Task.FromResult(0L);
+        }
+
+        return ApplyCheckpointScope(_dbContext.Events, checkpointScope)
+            .LongCountAsync(e => e.Sequence <= position, ct);
+    }
+
+    private async Task<DateTimeOffset?> GetLastProcessedAtAsync(
+        long position,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
     {
         if (position <= 0)
         {
             return null;
         }
 
-        return await _dbContext.Events
+        return await ApplyCheckpointScope(_dbContext.Events, checkpointScope)
             .AsNoTracking()
             .Where(e => e.Sequence == position)
             .Select(e => (DateTimeOffset?)e.Timestamp)
             .FirstOrDefaultAsync(ct);
     }
 
-    /// <summary>
-    /// Builds a lookup for last processed timestamps by sequence number.
-    /// </summary>
-    /// <param name="records">Subscription records to inspect.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A lookup of sequence to timestamp.</returns>
-    private async Task<Dictionary<long, DateTimeOffset>> GetLastProcessedLookupAsync(
-        IReadOnlyCollection<DbSubscription> records,
-        CancellationToken ct)
+    private static IQueryable<DbEvent> ApplyCheckpointScope(
+        IQueryable<DbEvent> query,
+        CheckpointScopeKey checkpointScope)
     {
-        var positions = records
-            .Select(r => r.Sequence)
-            .Where(sequence => sequence > 0)
-            .Distinct()
-            .ToArray();
-
-        if (positions.Length == 0)
-        {
-            return new Dictionary<long, DateTimeOffset>();
-        }
-
-        return await _dbContext.Events
-            .AsNoTracking()
-            .Where(e => positions.Contains(e.Sequence))
-            .ToDictionaryAsync(e => e.Sequence, e => e.Timestamp, ct);
+        return checkpointScope.IsTenant
+            ? query.Where(e => e.TenantId == checkpointScope.TenantId)
+            : query;
     }
 }
-

--- a/src/EventStoreCore/SubscriptionOptions.cs
+++ b/src/EventStoreCore/SubscriptionOptions.cs
@@ -1,3 +1,5 @@
+using EventStoreCore.Abstractions;
+
 /// <summary>
 /// Configuration options for subscription processing.
 /// </summary>
@@ -27,6 +29,11 @@ public sealed class SubscriptionOptions
     /// Maximum retry attempts before giving up in the daemon loop.
     /// </summary>
     public int MaxRetryAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Determines whether subscription checkpoints are shared globally or stored separately per tenant.
+    /// </summary>
+    public CheckpointScope CheckpointScope { get; set; } = CheckpointScope.Global;
 
     /// <summary>
     /// Delay between retry attempts when processing fails.

--- a/tests/EventStoreCore.Tests/CloudEventSubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/CloudEventSubscriptionTests.cs
@@ -1,6 +1,7 @@
 using Azure.Messaging;
 using EventStoreCore.CloudEvents;
 using EventStoreCore;
+using EventStoreCore.Abstractions;
 
 using EventStoreCore.Postgres;
 
@@ -88,8 +89,13 @@ public class CloudEventSubscriptionTests(PostgresFixture fixture) : IClassFixtur
         var processed = await subscriptionDeamon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
         var processed2 = await subscriptionDeamon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
 
+        var subscriptionName = typeof(CloudEventSubscription<TestSub>).AssemblyQualifiedName!;
         var subscriptionEntity = await eventStoreDbContext.Set<DbSubscription>()
-            .FindAsync(new object[] { typeof(CloudEventSubscription<TestSub>).AssemblyQualifiedName! }, TestContext.Current.CancellationToken);
+            .FirstOrDefaultAsync(s =>
+                s.SubscriptionAssemblyQualifiedName == subscriptionName &&
+                s.CheckpointScope == CheckpointScope.Global &&
+                s.TenantId == Guid.Empty,
+                TestContext.Current.CancellationToken);
 
         Assert.NotNull(subscriptionEntity);
         Assert.Equal(lastWrittenSequence, subscriptionEntity.Sequence);

--- a/tests/EventStoreCore.Tests/Daemons/ProjectionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/ProjectionDaemonExecutionTests.cs
@@ -68,7 +68,7 @@ public class ProjectionDaemonExecutionTests
         return db;
     }
 
-    private static ProjectionRegistration BuildRegistration()
+    private static ProjectionRegistration BuildRegistration(Guid? throwForTenantId = null)
     {
         var options = new ProjectionOptions();
         options.Handles<ProjectionEvent>();
@@ -85,6 +85,11 @@ public class ProjectionDaemonExecutionTests
             {
                 if (@event is IEvent<ProjectionEvent> evt)
                 {
+                    if (evt.TenantId == throwForTenantId)
+                    {
+                        throw new InvalidOperationException("Projection failed for tenant.");
+                    }
+
                     var entity = (ProjectionSnapshot)snapshot;
                     entity.Id = evt.StreamId;
                     entity.Name = evt.Data.Name;
@@ -161,5 +166,132 @@ public class ProjectionDaemonExecutionTests
             .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
 
         Assert.True(status == null || status.Position >= 0);
+    }
+
+    [Fact]
+    public async Task ProcessProjectionAsync_TenantScopedCheckpoint_CreatesIndependentStatuses()
+    {
+        var db = BuildDbContext();
+        var registration = BuildRegistration();
+        var lockProvider = new FakeLockProvider();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var streamA = Guid.NewGuid();
+        var streamB = Guid.NewGuid();
+
+        db.Events.AddRange(
+            CreateEvent(tenantA, streamA, 1, "Tenant A"),
+            CreateEvent(tenantB, streamB, 2, "Tenant B"));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var provider = new ServiceCollection()
+            .AddSingleton(db)
+            .AddSingleton(registration)
+            .BuildServiceProvider();
+
+        var daemon = new ProjectionDaemon<ExecutionDbContext>(
+            NullLogger<ProjectionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            lockProvider,
+            Options.Create(new ProjectionDaemonOptions
+            {
+                CheckpointScope = CheckpointScope.Tenant,
+                AutoRebuildOnVersionChange = false
+            }));
+
+        var method = typeof(ProjectionDaemon<ExecutionDbContext>).GetMethod(
+            "ProcessProjectionAsync",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        var task = (Task)method!.Invoke(daemon, new object[] { registration, TestContext.Current.CancellationToken })!;
+        await task;
+
+        var statuses = await db.Set<DbProjectionStatus>()
+            .OrderBy(s => s.TenantId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        var snapshots = await db.Set<ProjectionSnapshot>()
+            .OrderBy(s => s.Name)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, statuses.Count);
+        Assert.All(statuses, status => Assert.Equal(CheckpointScope.Tenant, status.CheckpointScope));
+        Assert.Contains(statuses, status => status.TenantId == tenantA && status.Position == 1);
+        Assert.Contains(statuses, status => status.TenantId == tenantB && status.Position == 2);
+        Assert.Equal(2, snapshots.Count);
+        Assert.Contains(snapshots, snapshot => snapshot.Id == streamA && snapshot.Name == "Tenant A");
+        Assert.Contains(snapshots, snapshot => snapshot.Id == streamB && snapshot.Name == "Tenant B");
+    }
+
+    [Fact]
+    public async Task ProcessProjectionAsync_TenantScopedCheckpoint_ContinuesAfterPoisonTenant()
+    {
+        var db = BuildDbContext();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var streamA = Guid.NewGuid();
+        var streamB = Guid.NewGuid();
+        var registration = BuildRegistration(tenantA);
+
+        db.Events.AddRange(
+            CreateEvent(tenantA, streamA, 1, "Tenant A"),
+            CreateEvent(tenantB, streamB, 2, "Tenant B"));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var provider = new ServiceCollection()
+            .AddSingleton(db)
+            .AddSingleton(registration)
+            .BuildServiceProvider();
+
+        var daemon = new ProjectionDaemon<ExecutionDbContext>(
+            NullLogger<ProjectionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new ProjectionDaemonOptions
+            {
+                CheckpointScope = CheckpointScope.Tenant,
+                AutoRebuildOnVersionChange = false
+            }));
+
+        var method = typeof(ProjectionDaemon<ExecutionDbContext>).GetMethod(
+            "ProcessProjectionAsync",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        var task = (Task)method!.Invoke(daemon, new object[] { registration, TestContext.Current.CancellationToken })!;
+        await task;
+
+        var statuses = await db.Set<DbProjectionStatus>()
+            .ToListAsync(TestContext.Current.CancellationToken);
+        var snapshot = await db.Set<ProjectionSnapshot>()
+            .SingleAsync(TestContext.Current.CancellationToken);
+
+        Assert.Contains(statuses, status =>
+            status.TenantId == tenantA &&
+            status.State == ProjectionState.Faulted &&
+            status.FailedEventSequence == 1);
+        Assert.Contains(statuses, status =>
+            status.TenantId == tenantB &&
+            status.State == ProjectionState.Active &&
+            status.Position == 2);
+        Assert.Equal(streamB, snapshot.Id);
+        Assert.Equal("Tenant B", snapshot.Name);
+    }
+
+    private static DbEvent CreateEvent(Guid tenantId, Guid streamId, long sequence, string name)
+    {
+        return new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = streamId,
+            TenantId = tenantId,
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Sequence = sequence,
+            Type = typeof(ProjectionEvent).AssemblyQualifiedName!,
+            Data = $$"""{"Name":"{{name}}"}"""
+        };
     }
 }

--- a/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
@@ -89,6 +89,29 @@ public class SubscriptionDaemonExecutionTests
         }
     }
 
+    private sealed class TenantPoisonSubscription : ISubscription
+    {
+        private readonly Guid _poisonTenantId;
+
+        public TenantPoisonSubscription(Guid poisonTenantId)
+        {
+            _poisonTenantId = poisonTenantId;
+        }
+
+        public List<Guid> HandledTenantIds { get; } = [];
+
+        public Task Handle(IEvent @event, CancellationToken ct)
+        {
+            if (@event.TenantId == _poisonTenantId)
+            {
+                throw new InvalidOperationException("Tenant event failed.");
+            }
+
+            HandledTenantIds.Add(@event.TenantId);
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class FakeLockProvider : IDistributedLockProvider
     {
         public bool ReturnNullHandle { get; set; }
@@ -252,8 +275,7 @@ public class SubscriptionDaemonExecutionTests
 
         var processed = await daemon.ProcessNextBatchAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
 
-        var subscriptionEntity = await db.Set<DbSubscription>()
-            .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
+        var subscriptionEntity = await FindSubscriptionAsync(db, subscription.GetType().AssemblyQualifiedName!, CheckpointScope.Global, Guid.Empty);
 
         Assert.Equal(2, processed);
         Assert.Equal(2, subscription.HandledCount);
@@ -318,8 +340,7 @@ public class SubscriptionDaemonExecutionTests
             options);
 
         var processed = await daemon.ProcessNextBatchAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
-        var subscriptionEntity = await db.Set<DbSubscription>()
-            .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
+        var subscriptionEntity = await FindSubscriptionAsync(db, subscription.GetType().AssemblyQualifiedName!, CheckpointScope.Global, Guid.Empty);
 
         Assert.Equal(1, processed);
         Assert.Equal(2, subscription.HandledCount);
@@ -350,8 +371,7 @@ public class SubscriptionDaemonExecutionTests
         await EnsureSequenceAsync(db);
 
         var processed = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
-        var status = await db.Set<DbSubscription>()
-            .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
+        var status = await FindSubscriptionAsync(db, subscription.GetType().AssemblyQualifiedName!, CheckpointScope.Global, Guid.Empty);
 
         Assert.False(processed);
         Assert.NotNull(status);
@@ -384,8 +404,7 @@ public class SubscriptionDaemonExecutionTests
         await EnsureSequenceAsync(db);
 
         var processed = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
-        var status = await db.Set<DbSubscription>()
-            .FindAsync([subscription.GetType().AssemblyQualifiedName!], TestContext.Current.CancellationToken);
+        var status = await FindSubscriptionAsync(db, subscription.GetType().AssemblyQualifiedName!, CheckpointScope.Global, Guid.Empty);
 
         Assert.False(processed);
         Assert.NotNull(status);
@@ -418,6 +437,56 @@ public class SubscriptionDaemonExecutionTests
 
         Assert.False(processed);
         Assert.False(subscription.Handled);
+    }
+
+    [Fact]
+    public async Task ProcessNextBatchAsync_TenantScopedCheckpoint_IsolatesPoisonTenant()
+    {
+        var db = BuildDbContext();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var subscription = new TenantPoisonSubscription(tenantA);
+        var provider = BuildProvider(db, subscription);
+        var daemon = new SubscriptionDaemon<ExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new SubscriptionOptions
+            {
+                CheckpointScope = CheckpointScope.Tenant,
+                MaxRetryAttempts = 1,
+                RetryDelay = TimeSpan.FromSeconds(5)
+            }));
+
+        db.Events.AddRange(
+            CreateEvent(tenantA, 1),
+            CreateEvent(tenantB, 2));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var processedA = await daemon.ProcessNextBatchAsync(
+            provider.CreateScope(),
+            subscription,
+            TestContext.Current.CancellationToken,
+            tenantA);
+        var processedB = await daemon.ProcessNextBatchAsync(
+            provider.CreateScope(),
+            subscription,
+            TestContext.Current.CancellationToken,
+            tenantB);
+
+        var name = subscription.GetType().AssemblyQualifiedName!;
+        var tenantAStatus = await FindSubscriptionAsync(db, name, CheckpointScope.Tenant, tenantA);
+        var tenantBStatus = await FindSubscriptionAsync(db, name, CheckpointScope.Tenant, tenantB);
+
+        Assert.Equal(0, processedA);
+        Assert.Equal(1, processedB);
+        Assert.NotNull(tenantAStatus);
+        Assert.NotNull(tenantBStatus);
+        Assert.Equal(SubscriptionState.DeadLettered, tenantAStatus!.State);
+        Assert.Equal(1, tenantAStatus.FailedEventSequence);
+        Assert.Equal(SubscriptionState.Active, tenantBStatus!.State);
+        Assert.Equal(2, tenantBStatus.Sequence);
+        Assert.Contains(tenantB, subscription.HandledTenantIds);
     }
 
     private static async Task EnsureSequenceAsync(ExecutionDbContext db)
@@ -454,5 +523,34 @@ public class SubscriptionDaemonExecutionTests
         var db = new CountingExecutionDbContext(options);
         db.Database.EnsureCreated();
         return db;
+    }
+
+    private static async Task<DbSubscription?> FindSubscriptionAsync(
+        ExecutionDbContext db,
+        string name,
+        CheckpointScope checkpointScope,
+        Guid tenantId)
+    {
+        return await db.Set<DbSubscription>()
+            .FirstOrDefaultAsync(s =>
+                s.SubscriptionAssemblyQualifiedName == name &&
+                s.CheckpointScope == checkpointScope &&
+                s.TenantId == tenantId,
+                TestContext.Current.CancellationToken);
+    }
+
+    private static DbEvent CreateEvent(Guid tenantId, long sequence)
+    {
+        return new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            TenantId = tenantId,
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Sequence = sequence,
+            Type = typeof(object).AssemblyQualifiedName!,
+            Data = "{}"
+        };
     }
 }

--- a/tests/EventStoreCore.Tests/MassTransitSubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/MassTransitSubscriptionTests.cs
@@ -111,8 +111,13 @@ public class MassTransitSubscriptionTests(PostgresFixture fixture) : IClassFixtu
 
         Assert.True(await consumer.Consumed.Any<TestIntegrationEvent>(TestContext.Current.CancellationToken));
       
+        var subscriptionName = subscription.GetType().AssemblyQualifiedName!;
         var subscriptionEntity = await eventStoreDbContext.Set<DbSubscription>()
-          .FindAsync([subscription.GetType().AssemblyQualifiedName], TestContext.Current.CancellationToken);
+          .FirstOrDefaultAsync(s =>
+              s.SubscriptionAssemblyQualifiedName == subscriptionName &&
+              s.CheckpointScope == EventStoreCore.Abstractions.CheckpointScope.Global &&
+              s.TenantId == Guid.Empty,
+              TestContext.Current.CancellationToken);
 
         Assert.NotNull(subscriptionEntity);
         Assert.Equal(writtenSequence, subscriptionEntity.Sequence);

--- a/tests/EventStoreCore.Tests/ProjectionManagerTests.cs
+++ b/tests/EventStoreCore.Tests/ProjectionManagerTests.cs
@@ -93,11 +93,15 @@ public class ProjectionManagerTests(PostgresFixture fixture) : IClassFixture<Pos
         ProjectionState state = ProjectionState.Active,
         long position = 0,
         string? lastError = null,
-        long? failedEventSequence = null)
+        long? failedEventSequence = null,
+        CheckpointScope checkpointScope = CheckpointScope.Global,
+        Guid? tenantId = null)
     {
         var status = new DbProjectionStatus
         {
             ProjectionName = projectionName,
+            CheckpointScope = checkpointScope,
+            TenantId = tenantId ?? Guid.Empty,
             Version = 1,
             State = state,
             Position = position,
@@ -225,6 +229,74 @@ public class ProjectionManagerTests(PostgresFixture fixture) : IClassFixture<Pos
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => manager.RebuildAsync("NonExistent.Projection", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RebuildAsync_ResetsTenantScopedCheckpointsAfterClearingProjectionData()
+    {
+        var provider = BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        var projectionName = typeof(TestProjection).FullName!;
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        await db.Set<TestSnapshot>().ExecuteDeleteAsync(TestContext.Current.CancellationToken);
+        await db.Set<DbProjectionStatus>()
+            .Where(s => s.ProjectionName == projectionName)
+            .ExecuteDeleteAsync(TestContext.Current.CancellationToken);
+
+        db.Set<TestSnapshot>().Add(new TestSnapshot { Id = Guid.NewGuid(), Value = "old" });
+        await CreateProjectionStatusAsync(
+            db,
+            projectionName,
+            ProjectionState.Active,
+            position: 10,
+            checkpointScope: CheckpointScope.Tenant,
+            tenantId: tenantA);
+        await CreateProjectionStatusAsync(
+            db,
+            projectionName,
+            ProjectionState.Faulted,
+            position: 20,
+            lastError: "boom",
+            failedEventSequence: 21,
+            checkpointScope: CheckpointScope.Tenant,
+            tenantId: tenantB);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manager = scope.ServiceProvider.GetRequiredService<IProjectionManager>();
+
+        await manager.RebuildAsync(projectionName, TestContext.Current.CancellationToken);
+
+        var snapshots = await db.Set<TestSnapshot>()
+            .AsNoTracking()
+            .ToListAsync(TestContext.Current.CancellationToken);
+        var statuses = await db.Set<DbProjectionStatus>()
+            .AsNoTracking()
+            .Where(s => s.ProjectionName == projectionName)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(snapshots);
+        Assert.Contains(statuses, status =>
+            status.CheckpointScope == CheckpointScope.Global &&
+            status.TenantId == Guid.Empty &&
+            status.State == ProjectionState.Rebuilding &&
+            status.Position == 0);
+        Assert.Contains(statuses, status =>
+            status.CheckpointScope == CheckpointScope.Tenant &&
+            status.TenantId == tenantA &&
+            status.State == ProjectionState.Rebuilding &&
+            status.Position == 0);
+        Assert.Contains(statuses, status =>
+            status.CheckpointScope == CheckpointScope.Tenant &&
+            status.TenantId == tenantB &&
+            status.State == ProjectionState.Rebuilding &&
+            status.Position == 0 &&
+            status.LastError == null &&
+            status.FailedEventSequence == null);
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/SubscriptionManagerTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionManagerTests.cs
@@ -83,8 +83,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
 
         await manager.ReplayAsync(name, startSequence: 2, ct: TestContext.Current.CancellationToken);
 
-        var subscription = await db.Set<DbSubscription>()
-            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+        var subscription = await FindGlobalSubscriptionAsync(db, name);
 
         Assert.NotNull(subscription);
         Assert.Equal(1, subscription!.Sequence);
@@ -117,8 +116,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
 
         await manager.ReplayAsync(name, fromTimestamp: dbEvents[1].Timestamp, ct: TestContext.Current.CancellationToken);
 
-        var subscription = await db.Set<DbSubscription>()
-            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+        var subscription = await FindGlobalSubscriptionAsync(db, name);
 
         Assert.NotNull(subscription);
         Assert.Equal(dbEvents[1].Sequence - 1, subscription!.Sequence);
@@ -143,8 +141,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
         var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
         await manager.PauseAsync(name, TestContext.Current.CancellationToken);
 
-        var subscription = await db.Set<DbSubscription>()
-            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+        var subscription = await FindGlobalSubscriptionAsync(db, name);
 
         Assert.Equal(SubscriptionState.Paused, subscription!.State);
     }
@@ -169,8 +166,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
         var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
         await manager.ResumeAsync(name, TestContext.Current.CancellationToken);
 
-        var subscription = await db.Set<DbSubscription>()
-            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+        var subscription = await FindGlobalSubscriptionAsync(db, name);
 
         Assert.Equal(SubscriptionState.Active, subscription!.State);
     }
@@ -200,8 +196,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
         var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
         await manager.RetryFailedEventAsync(name, TestContext.Current.CancellationToken);
 
-        var subscription = await db.Set<DbSubscription>()
-            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+        var subscription = await FindGlobalSubscriptionAsync(db, name);
 
         Assert.Equal(SubscriptionState.Active, subscription!.State);
         Assert.Equal(0, subscription.AttemptCount);
@@ -235,8 +230,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
         var manager = scope.ServiceProvider.GetRequiredService<ISubscriptionManager>();
         await manager.SkipFailedEventAsync(name, TestContext.Current.CancellationToken);
 
-        var subscription = await db.Set<DbSubscription>()
-            .FindAsync(new object[] { name }, TestContext.Current.CancellationToken);
+        var subscription = await FindGlobalSubscriptionAsync(db, name);
 
         Assert.Equal(SubscriptionState.Active, subscription!.State);
         Assert.Equal(2, subscription.Sequence);
@@ -275,5 +269,15 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
         Assert.NotNull(failedEvent);
         Assert.Equal(dbEvent.Sequence, failedEvent!.Sequence);
         Assert.Equal("boom", failedEvent.SubscriptionError);
+    }
+
+    private static Task<DbSubscription?> FindGlobalSubscriptionAsync(EventStoreDbContext db, string name)
+    {
+        return db.Set<DbSubscription>()
+            .FirstOrDefaultAsync(s =>
+                s.SubscriptionAssemblyQualifiedName == name &&
+                s.CheckpointScope == CheckpointScope.Global &&
+                s.TenantId == Guid.Empty,
+                TestContext.Current.CancellationToken);
     }
 }

--- a/tests/EventStoreCore.Tests/SubscriptionOptionsTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionOptionsTests.cs
@@ -1,4 +1,5 @@
 using EventStoreCore;
+using EventStoreCore.Abstractions;
 
 namespace EventStoreCore.Tests;
 
@@ -14,6 +15,7 @@ public class SubscriptionOptionsTests
         Assert.Equal(TimeSpan.FromSeconds(10), options.PollingInterval);
         Assert.Equal(TimeSpan.FromMinutes(5), options.LockTimeout);
         Assert.Equal(3, options.MaxRetryAttempts);
+        Assert.Equal(CheckpointScope.Global, options.CheckpointScope);
         Assert.Equal(TimeSpan.FromSeconds(10), options.RetryDelay);
     }
 }

--- a/tests/EventStoreCore.Tests/SubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionTests.cs
@@ -170,8 +170,9 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
 
         var processed = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription, TestContext.Current.CancellationToken);
 
-        var subscriptionEntity = await eventStoreDbContext.Set<DbSubscription>()
-            .FindAsync(new object[] { subscription.GetType().AssemblyQualifiedName! }, TestContext.Current.CancellationToken);
+        var subscriptionEntity = await FindGlobalSubscriptionAsync(
+            eventStoreDbContext,
+            subscription.GetType().AssemblyQualifiedName!);
 
 
         Assert.NotNull(subscriptionEntity);
@@ -206,11 +207,13 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         var processed1 = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription1, TestContext.Current.CancellationToken);
         var processed2 = await daemon.ProcessNextEventAsync(provider.CreateScope(), subscription2, TestContext.Current.CancellationToken);
 
-        var subscriptionEntity1 = await eventStoreDbContext.Set<DbSubscription>()
-            .FindAsync(new object[] { subscription1.GetType().AssemblyQualifiedName! }, TestContext.Current.CancellationToken);
+        var subscriptionEntity1 = await FindGlobalSubscriptionAsync(
+            eventStoreDbContext,
+            subscription1.GetType().AssemblyQualifiedName!);
 
-        var subscriptionEntity2 = await eventStoreDbContext.Set<DbSubscription>()
-            .FindAsync(new object[] { subscription2.GetType().AssemblyQualifiedName! }, TestContext.Current.CancellationToken);
+        var subscriptionEntity2 = await FindGlobalSubscriptionAsync(
+            eventStoreDbContext,
+            subscription2.GetType().AssemblyQualifiedName!);
 
         Assert.NotNull(subscriptionEntity1);
         Assert.NotNull(subscriptionEntity2);
@@ -257,7 +260,9 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         var failedSubscriptionRow = await eventStoreDbContext.Set<DbSubscription>()
             .AsNoTracking()
             .FirstOrDefaultAsync(
-                e => e.SubscriptionAssemblyQualifiedName == subscriptionName,
+                e => e.SubscriptionAssemblyQualifiedName == subscriptionName &&
+                    e.CheckpointScope == CheckpointScope.Global &&
+                    e.TenantId == Guid.Empty,
                 TestContext.Current.CancellationToken);
 
         Assert.False(firstProcessed);
@@ -274,7 +279,9 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         var succeededSubscriptionRow = await eventStoreDbContext.Set<DbSubscription>()
             .AsNoTracking()
             .SingleAsync(
-                e => e.SubscriptionAssemblyQualifiedName == subscriptionName,
+                e => e.SubscriptionAssemblyQualifiedName == subscriptionName &&
+                    e.CheckpointScope == CheckpointScope.Global &&
+                    e.TenantId == Guid.Empty,
                 TestContext.Current.CancellationToken);
 
         Assert.True(processed);
@@ -319,6 +326,16 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         Assert.All(DeduplicatingScopedSubscription.DeliveredEventIds, id => Assert.Equal(DeduplicatingScopedSubscription.DeliveredEventIds[0], id));
         Assert.Single(processedEventIds);
         Assert.Equal(DeduplicatingScopedSubscription.DeliveredEventIds[0], processedEventIds[0]);
+    }
+
+    private static Task<DbSubscription?> FindGlobalSubscriptionAsync(EventStoreDbContext db, string name)
+    {
+        return db.Set<DbSubscription>()
+            .FirstOrDefaultAsync(s =>
+                s.SubscriptionAssemblyQualifiedName == name &&
+                s.CheckpointScope == CheckpointScope.Global &&
+                s.TenantId == Guid.Empty,
+                TestContext.Current.CancellationToken);
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds opt-in global vs tenant-scoped checkpoint semantics for subscription and projection daemons.
- Persists checkpoint scope/tenant on subscription and projection status rows and updates daemon queries, locks, managers, endpoints, and SDK methods.
- Documents tenant checkpoint behavior, migration notes, and the projection rebuild caveat.

## Tests
- dotnet test tests\EventStoreCore.Tests\EventStoreCore.Tests.csproj -v minimal

Closes #28