### PR TITLE
Add event aliases and upcasters

### DIFF
--- a/src/EventStoreCore/Event.cs
+++ b/src/EventStoreCore/Event.cs
@@ -22,16 +22,22 @@ public class Event : IEvent
     /// <param name="dbEvent">The database event record.</param>
     /// <param name="eventType">The resolved CLR type.</param>
     public Event(DbEvent dbEvent, Type eventType)
+        : this(dbEvent, eventType, Deserialize(dbEvent, eventType))
+    {
+    }
+
+    internal Event(DbEvent dbEvent, Type eventType, object data)
     {
         ArgumentNullException.ThrowIfNull(dbEvent);
         ArgumentNullException.ThrowIfNull(eventType);
+        ArgumentNullException.ThrowIfNull(data);
         Id = dbEvent.EventId;
         StreamId = dbEvent.StreamId;
         Version = dbEvent.Version;
         Timestamp = dbEvent.Timestamp;
         TenantId = dbEvent.TenantId;
         EventType = eventType;
-        Data = Deserialize(dbEvent, eventType);
+        Data = data;
     }
 
     /// <summary>
@@ -118,6 +124,11 @@ public class Event<T> : Event, IEvent<T> where T : class
     /// <param name="dbEvent">The database event record.</param>
     /// <param name="eventType">The resolved CLR type.</param>
     public Event(DbEvent dbEvent, Type eventType) : base(dbEvent, eventType)
+    {
+        Data = CastData(dbEvent, base.Data);
+    }
+
+    internal Event(DbEvent dbEvent, Type eventType, object data) : base(dbEvent, eventType, data)
     {
         Data = CastData(dbEvent, base.Data);
     }

--- a/src/EventStoreCore/EventExtensions.cs
+++ b/src/EventStoreCore/EventExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using System.Globalization;
 using EventStoreCore.Abstractions;
 
 namespace EventStoreCore;
@@ -29,12 +30,31 @@ public static class EventExtensions
     {
         ArgumentNullException.ThrowIfNull(dbEvent);
 
+        if (registry is not null
+            && !string.IsNullOrWhiteSpace(dbEvent.TypeName)
+            && registry.TryResolveMaterializedEvent(dbEvent, out var registeredType, out var registeredData))
+        {
+            return CreateEvent(dbEvent, registeredType, registeredData);
+        }
+
         var eventType = EventTypeResolver.ResolveEventType(dbEvent, registry);
+        return CreateEvent(dbEvent, eventType, null);
+    }
+
+    private static IEvent CreateEvent(DbEvent dbEvent, Type eventType, object? data)
+    {
         var eventInstanceType = typeof(Event<>).MakeGenericType(eventType);
 
         try
         {
-            var eventInstance = Activator.CreateInstance(eventInstanceType, dbEvent, eventType);
+            var eventInstance = data is null
+                ? Activator.CreateInstance(eventInstanceType, dbEvent, eventType)
+                : Activator.CreateInstance(
+                    eventInstanceType,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    binder: null,
+                    args: [dbEvent, eventType, data],
+                    culture: CultureInfo.InvariantCulture);
             if (eventInstance is null)
             {
                 throw new EventMaterializationException(

--- a/src/EventStoreCore/EventStoreBuilderEventTypeExtensions.cs
+++ b/src/EventStoreCore/EventStoreBuilderEventTypeExtensions.cs
@@ -36,6 +36,24 @@ public static class EventStoreBuilderEventTypeExtensions
     public static IEventStoreBuilder AddEvent<TEvent>(this IEventStoreBuilder builder, string eventTypeName)
         where TEvent : class
     {
+        return AddEvent<TEvent>(builder, eventTypeName, null);
+    }
+
+    /// <summary>
+    /// Registers an event type with a custom logical name and optional aliases or upcasters.
+    /// </summary>
+    /// <typeparam name="TEvent">The event payload type.</typeparam>
+    /// <param name="builder">The event store builder.</param>
+    /// <param name="eventTypeName">The custom event type name.</param>
+    /// <param name="configure">Configures aliases and upcasters for the event type.</param>
+    /// <returns>The builder for chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when the name is null or whitespace.</exception>
+    public static IEventStoreBuilder AddEvent<TEvent>(
+        this IEventStoreBuilder builder,
+        string eventTypeName,
+        Action<IEventTypeBuilder<TEvent>>? configure)
+        where TEvent : class
+    {
         ArgumentNullException.ThrowIfNull(builder);
 
         if (string.IsNullOrWhiteSpace(eventTypeName))
@@ -44,12 +62,16 @@ public static class EventStoreBuilderEventTypeExtensions
         }
 
         RegisterEvent(builder, typeof(TEvent), eventTypeName.Trim());
+        configure?.Invoke(new EventTypeBuilder<TEvent>(builder.Services));
         return builder;
     }
 
     private static void RegisterEvent(IEventStoreBuilder builder, Type eventType, string eventTypeName)
     {
-        builder.Services.TryAddSingleton(sp => new EventTypeRegistry(sp.GetServices<EventTypeRegistration>()));
+        builder.Services.TryAddSingleton(sp => new EventTypeRegistry(
+            sp.GetServices<EventTypeRegistration>(),
+            sp.GetServices<EventTypeAliasRegistration>(),
+            sp.GetServices<EventUpcasterRegistration>()));
         builder.Services.AddSingleton(new EventTypeRegistration(eventType, eventTypeName));
     }
 }

--- a/src/EventStoreCore/EventStoreExtensions.cs
+++ b/src/EventStoreCore/EventStoreExtensions.cs
@@ -19,7 +19,10 @@ public static class EventStoreExtensions
        Action<IEventStoreBuilder>? configure = null
            )
     {
-        services.TryAddSingleton(sp => new EventTypeRegistry(sp.GetServices<EventTypeRegistration>()));
+        services.TryAddSingleton(sp => new EventTypeRegistry(
+            sp.GetServices<EventTypeRegistration>(),
+            sp.GetServices<EventTypeAliasRegistration>(),
+            sp.GetServices<EventUpcasterRegistration>()));
 
         EventStoreBuilder builder = new EventStoreBuilder(services);
 

--- a/src/EventStoreCore/EventTypeBuilder.cs
+++ b/src/EventStoreCore/EventTypeBuilder.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStoreCore;
+
+internal sealed class EventTypeBuilder<TEvent>(IServiceCollection services) : IEventTypeBuilder<TEvent>
+    where TEvent : class
+{
+    public IEventTypeBuilder<TEvent> AddAlias(string eventTypeName)
+    {
+        ValidateEventTypeName(eventTypeName);
+        services.AddSingleton(new EventTypeAliasRegistration(typeof(TEvent), eventTypeName.Trim()));
+        return this;
+    }
+
+    public IEventTypeBuilder<TEvent> AddUpcaster<TOldEvent>(
+        string fromEventTypeName,
+        Func<TOldEvent, TEvent> upcaster)
+        where TOldEvent : class
+    {
+        ValidateEventTypeName(fromEventTypeName);
+        ArgumentNullException.ThrowIfNull(upcaster);
+
+        services.AddSingleton(new EventUpcasterRegistration(
+            typeof(TEvent),
+            fromEventTypeName.Trim(),
+            (dbEvent, targetType) =>
+            {
+                try
+                {
+                    var oldEvent = JsonSerializer.Deserialize<TOldEvent>(dbEvent.Data);
+                    if (oldEvent is null)
+                    {
+                        throw new EventMaterializationException(
+                            $"Could not deserialize event data to upcast source type '{typeof(TOldEvent).FullName ?? typeof(TOldEvent).Name}'.",
+                            dbEvent);
+                    }
+
+                    return upcaster(oldEvent);
+                }
+                catch (EventMaterializationException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new EventMaterializationException(
+                        $"Could not upcast event data from '{fromEventTypeName}' to '{targetType.FullName ?? targetType.Name}'.",
+                        dbEvent,
+                        ex);
+                }
+            }));
+
+        return this;
+    }
+
+    public IEventTypeBuilder<TEvent> AddUpcaster(
+        string fromEventTypeName,
+        Func<JsonObject, TEvent> upcaster)
+    {
+        ValidateEventTypeName(fromEventTypeName);
+        ArgumentNullException.ThrowIfNull(upcaster);
+
+        services.AddSingleton(new EventUpcasterRegistration(
+            typeof(TEvent),
+            fromEventTypeName.Trim(),
+            (dbEvent, targetType) =>
+            {
+                try
+                {
+                    var jsonNode = JsonNode.Parse(dbEvent.Data);
+                    if (jsonNode is not JsonObject jsonObject)
+                    {
+                        throw new EventMaterializationException(
+                            $"Could not deserialize event data to JSON object for upcaster '{fromEventTypeName}'.",
+                            dbEvent);
+                    }
+
+                    return upcaster(jsonObject);
+                }
+                catch (EventMaterializationException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new EventMaterializationException(
+                        $"Could not upcast event data from '{fromEventTypeName}' to '{targetType.FullName ?? targetType.Name}'.",
+                        dbEvent,
+                        ex);
+                }
+            }));
+
+        return this;
+    }
+
+    private static void ValidateEventTypeName(string eventTypeName)
+    {
+        if (string.IsNullOrWhiteSpace(eventTypeName))
+        {
+            throw new ArgumentException("Event type name cannot be empty.", nameof(eventTypeName));
+        }
+    }
+}

--- a/src/EventStoreCore/EventTypeRegistry.cs
+++ b/src/EventStoreCore/EventTypeRegistry.cs
@@ -4,14 +4,34 @@ internal sealed class EventTypeRegistry
 {
     private readonly Dictionary<Type, string> _nameByType = new();
     private readonly Dictionary<string, Type> _typeByName = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _canonicalNameByAlias = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, EventUpcasterRegistration> _upcasterByName = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _nameByAqn = new(StringComparer.Ordinal);
     private readonly Dictionary<string, string> _nameByFullName = new(StringComparer.Ordinal);
 
     internal EventTypeRegistry(IEnumerable<EventTypeRegistration> registrations)
+        : this(registrations, [], [])
+    {
+    }
+
+    internal EventTypeRegistry(
+        IEnumerable<EventTypeRegistration> registrations,
+        IEnumerable<EventTypeAliasRegistration> aliases,
+        IEnumerable<EventUpcasterRegistration> upcasters)
     {
         foreach (var registration in registrations)
         {
             Register(registration.EventType, registration.EventTypeName);
+        }
+
+        foreach (var alias in aliases)
+        {
+            RegisterAlias(alias.EventType, alias.EventTypeName);
+        }
+
+        foreach (var upcaster in upcasters)
+        {
+            RegisterUpcaster(upcaster);
         }
     }
 
@@ -26,6 +46,72 @@ internal sealed class EventTypeRegistry
         typeName = typeName.Trim();
 
         return _typeByName.TryGetValue(typeName, out eventType!);
+    }
+
+    internal bool TryResolveMaterializedEvent(DbEvent dbEvent, out Type eventType, out object? data)
+    {
+        eventType = null!;
+        data = null;
+
+        if (string.IsNullOrWhiteSpace(dbEvent.TypeName))
+        {
+            return false;
+        }
+
+        var eventTypeName = dbEvent.TypeName.Trim();
+
+        if (_upcasterByName.TryGetValue(eventTypeName, out var upcaster))
+        {
+            eventType = upcaster.EventType;
+            data = upcaster.Upcast(dbEvent, eventType);
+            if (data is null)
+            {
+                throw new EventMaterializationException(
+                    $"Upcaster '{eventTypeName}' returned null for event type '{eventType.FullName ?? eventType.Name}'.",
+                    dbEvent);
+            }
+
+            return true;
+        }
+
+        if (_canonicalNameByAlias.TryGetValue(eventTypeName, out var canonicalName))
+        {
+            eventType = _typeByName[canonicalName];
+            return true;
+        }
+
+        if (_typeByName.TryGetValue(eventTypeName, out eventType!))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    internal bool TryResolveMaterializedEventType(string eventTypeName, out Type eventType)
+    {
+        eventType = null!;
+
+        if (string.IsNullOrWhiteSpace(eventTypeName))
+        {
+            return false;
+        }
+
+        eventTypeName = eventTypeName.Trim();
+
+        if (_upcasterByName.TryGetValue(eventTypeName, out var upcaster))
+        {
+            eventType = upcaster.EventType;
+            return true;
+        }
+
+        if (_canonicalNameByAlias.TryGetValue(eventTypeName, out var canonicalName))
+        {
+            eventType = _typeByName[canonicalName];
+            return true;
+        }
+
+        return _typeByName.TryGetValue(eventTypeName, out eventType!);
     }
 
     internal bool TryGetName(Type eventType, out string typeName)
@@ -50,14 +136,16 @@ internal sealed class EventTypeRegistry
 
         assemblyQualifiedName = assemblyQualifiedName.Trim();
 
-        if (_nameByAqn.TryGetValue(assemblyQualifiedName, out typeName))
+        if (_nameByAqn.TryGetValue(assemblyQualifiedName, out var mappedTypeName))
         {
+            typeName = mappedTypeName;
             return true;
         }
 
         var fullName = EventTypeNameHelper.GetFullNameFromAqn(assemblyQualifiedName);
-        if (!string.IsNullOrWhiteSpace(fullName) && _nameByFullName.TryGetValue(fullName, out typeName))
+        if (!string.IsNullOrWhiteSpace(fullName) && _nameByFullName.TryGetValue(fullName, out mappedTypeName))
         {
+            typeName = mappedTypeName;
             return true;
         }
 
@@ -118,6 +206,86 @@ internal sealed class EventTypeRegistry
             _nameByFullName[eventType.FullName!] = eventTypeName;
         }
     }
+
+    private void RegisterAlias(Type eventType, string eventTypeName)
+    {
+        if (!_nameByType.TryGetValue(eventType, out var canonicalName))
+        {
+            throw new InvalidOperationException(
+                $"Event type '{eventType.FullName ?? eventType.Name}' must be registered before alias '{eventTypeName}' can be added.");
+        }
+
+        eventTypeName = NormalizeEventTypeName(eventTypeName);
+
+        if (_typeByName.ContainsKey(eventTypeName))
+        {
+            throw new InvalidOperationException(
+                $"Event type name '{eventTypeName}' is already registered as a canonical event type name.");
+        }
+
+        if (_upcasterByName.ContainsKey(eventTypeName))
+        {
+            throw new InvalidOperationException(
+                $"Event type name '{eventTypeName}' is already registered as an upcaster source.");
+        }
+
+        if (_canonicalNameByAlias.TryGetValue(eventTypeName, out var existingCanonicalName)
+            && !string.Equals(existingCanonicalName, canonicalName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Event type alias '{eventTypeName}' is already registered for '{existingCanonicalName}'.");
+        }
+
+        _canonicalNameByAlias[eventTypeName] = canonicalName;
+    }
+
+    private void RegisterUpcaster(EventUpcasterRegistration upcaster)
+    {
+        if (!_nameByType.ContainsKey(upcaster.EventType))
+        {
+            throw new InvalidOperationException(
+                $"Event type '{upcaster.EventType.FullName ?? upcaster.EventType.Name}' must be registered before upcaster '{upcaster.FromEventTypeName}' can be added.");
+        }
+
+        var fromEventTypeName = NormalizeEventTypeName(upcaster.FromEventTypeName);
+
+        if (_typeByName.ContainsKey(fromEventTypeName))
+        {
+            throw new InvalidOperationException(
+                $"Event type name '{fromEventTypeName}' is already registered as a canonical event type name.");
+        }
+
+        if (_canonicalNameByAlias.ContainsKey(fromEventTypeName))
+        {
+            throw new InvalidOperationException(
+                $"Event type name '{fromEventTypeName}' is already registered as an alias.");
+        }
+
+        if (_upcasterByName.TryGetValue(fromEventTypeName, out var existing))
+        {
+            throw new InvalidOperationException(
+                $"Event type upcaster source '{fromEventTypeName}' is already registered for '{existing.EventType.FullName ?? existing.EventType.Name}'.");
+        }
+
+        _upcasterByName[fromEventTypeName] = upcaster;
+    }
+
+    private static string NormalizeEventTypeName(string eventTypeName)
+    {
+        if (string.IsNullOrWhiteSpace(eventTypeName))
+        {
+            throw new ArgumentException("Event type name cannot be empty.", nameof(eventTypeName));
+        }
+
+        return eventTypeName.Trim();
+    }
 }
 
 internal sealed record EventTypeRegistration(Type EventType, string EventTypeName);
+
+internal sealed record EventTypeAliasRegistration(Type EventType, string EventTypeName);
+
+internal sealed record EventUpcasterRegistration(
+    Type EventType,
+    string FromEventTypeName,
+    Func<DbEvent, Type, object> Upcast);

--- a/src/EventStoreCore/EventTypeResolver.cs
+++ b/src/EventStoreCore/EventTypeResolver.cs
@@ -11,6 +11,13 @@ internal static class EventTypeResolver
             throw new EventMaterializationException("Event type is required.", dbEvent);
         }
 
+        if (registry is not null
+            && !string.IsNullOrWhiteSpace(dbEvent.TypeName)
+            && registry.TryResolveMaterializedEventType(dbEvent.TypeName, out var registeredType))
+        {
+            return registeredType;
+        }
+
         Type? eventType;
         try
         {
@@ -25,20 +32,7 @@ internal static class EventTypeResolver
         }
 
         if (eventType is not null)
-        {
-            if (registry is not null
-                && !string.IsNullOrWhiteSpace(dbEvent.TypeName)
-                && registry.TryGetType(dbEvent.TypeName, out var mappedType)
-                && mappedType != eventType)
-            {
-                throw new EventMaterializationException(
-                    $"Event type name '{dbEvent.TypeName}' is registered for '{mappedType.FullName ?? mappedType.Name}', " +
-                    $"but event record contains '{eventType.FullName ?? eventType.Name}'.",
-                    dbEvent);
-            }
-
             return eventType;
-        }
 
         if (registry is not null
             && !string.IsNullOrWhiteSpace(dbEvent.TypeName)

--- a/src/EventStoreCore/IEventTypeBuilder.cs
+++ b/src/EventStoreCore/IEventTypeBuilder.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Nodes;
+
+namespace EventStoreCore;
+
+/// <summary>
+/// Configures aliases and upcasters for a logical event type.
+/// </summary>
+/// <typeparam name="TEvent">The current event payload type.</typeparam>
+public interface IEventTypeBuilder<TEvent>
+    where TEvent : class
+{
+    /// <summary>
+    /// Adds an alternate logical name that uses the current event payload contract.
+    /// </summary>
+    /// <param name="eventTypeName">The alternate logical event type name.</param>
+    /// <returns>The builder for chaining.</returns>
+    IEventTypeBuilder<TEvent> AddAlias(string eventTypeName);
+
+    /// <summary>
+    /// Adds an upcaster from an older event payload type to the current event payload type.
+    /// </summary>
+    /// <typeparam name="TOldEvent">The older event payload type.</typeparam>
+    /// <param name="fromEventTypeName">The logical event type name stored for the older payload.</param>
+    /// <param name="upcaster">Maps the older payload to the current payload.</param>
+    /// <returns>The builder for chaining.</returns>
+    IEventTypeBuilder<TEvent> AddUpcaster<TOldEvent>(
+        string fromEventTypeName,
+        Func<TOldEvent, TEvent> upcaster)
+        where TOldEvent : class;
+
+    /// <summary>
+    /// Adds an upcaster from an older JSON payload shape to the current event payload type.
+    /// </summary>
+    /// <param name="fromEventTypeName">The logical event type name stored for the older payload.</param>
+    /// <param name="upcaster">Maps the older JSON payload to the current payload.</param>
+    /// <returns>The builder for chaining.</returns>
+    IEventTypeBuilder<TEvent> AddUpcaster(
+        string fromEventTypeName,
+        Func<JsonObject, TEvent> upcaster);
+}

--- a/tests/EventStoreCore.Tests/Coverage/EventExtensionsTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/EventExtensionsTests.cs
@@ -1,4 +1,5 @@
 using EventStoreCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EventStoreCore.Tests;
 
@@ -10,6 +11,18 @@ public class EventExtensionsTests
     }
 
     private sealed class ConflictingEvent
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class CurrentEvent
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public string Currency { get; set; } = string.Empty;
+    }
+
+    private sealed class OldEvent
     {
         public string Name { get; set; } = string.Empty;
     }
@@ -53,7 +66,7 @@ public class EventExtensionsTests
     }
 
     [Fact]
-    public void ToEvent_Throws_WhenTypeNameRegistrationConflicts()
+    public void ToEvent_UsesRegisteredTypeName_WhenClrTypeDiffers()
     {
         var registry = new EventTypeRegistry(new[]
         {
@@ -72,9 +85,136 @@ public class EventExtensionsTests
             Data = "{\"Name\":\"Test\"}"
         };
 
-        var exception = Assert.Throws<EventMaterializationException>(() => dbEvent.ToEvent(registry));
+        var @event = dbEvent.ToEvent(registry);
 
-        Assert.Contains("registered for", exception.Message);
+        Assert.IsType<ConflictingEvent>(@event.Data);
+        Assert.Equal(typeof(ConflictingEvent), @event.EventType);
+    }
+
+    [Fact]
+    public void ToEvent_UsesLogicalTypeName_WhenClrTypeCannotBeLoaded()
+    {
+        var registry = new EventTypeRegistry(new[]
+        {
+            new EventTypeRegistration(typeof(SampleEvent), "sample_event")
+        });
+
+        var dbEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Type = "Missing.Assembly.Type",
+            TypeName = "sample_event",
+            Data = "{\"Name\":\"Test\"}"
+        };
+
+        var @event = dbEvent.ToEvent(registry);
+
+        var data = Assert.IsType<SampleEvent>(@event.Data);
+        Assert.Equal("Test", data.Name);
+        Assert.Equal(typeof(SampleEvent), @event.EventType);
+    }
+
+    [Fact]
+    public void ToEvent_UsesAlias_WhenStoredTypeNameIsOldName()
+    {
+        var registry = new EventTypeRegistry(
+            new[] { new EventTypeRegistration(typeof(SampleEvent), "sample_event") },
+            new[] { new EventTypeAliasRegistration(typeof(SampleEvent), "old_sample_event") },
+            []);
+
+        var dbEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Type = "Missing.Assembly.Type",
+            TypeName = "old_sample_event",
+            Data = "{\"Name\":\"Test\"}"
+        };
+
+        var @event = dbEvent.ToEvent(registry);
+
+        var data = Assert.IsType<SampleEvent>(@event.Data);
+        Assert.Equal("Test", data.Name);
+    }
+
+    [Fact]
+    public void ToEvent_AppliesTypedUpcaster()
+    {
+        var registry = BuildRegistry(c => c.AddEvent<CurrentEvent>("current_event", e => e
+            .AddUpcaster<OldEvent>("old_event", old => new CurrentEvent
+            {
+                Name = old.Name,
+                Currency = "USD"
+            })));
+
+        var dbEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Type = "Missing.Assembly.Type",
+            TypeName = "old_event",
+            Data = "{\"Name\":\"Test\"}"
+        };
+
+        var @event = dbEvent.ToEvent(registry);
+
+        var data = Assert.IsType<CurrentEvent>(@event.Data);
+        Assert.Equal("Test", data.Name);
+        Assert.Equal("USD", data.Currency);
+    }
+
+    [Fact]
+    public void ToEvent_AppliesJsonUpcaster()
+    {
+        var registry = BuildRegistry(c => c.AddEvent<CurrentEvent>("current_event", e => e
+            .AddUpcaster("legacy_event", json => new CurrentEvent
+            {
+                Name = json["legacyName"]!.GetValue<string>(),
+                Currency = "EUR"
+            })));
+
+        var dbEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Type = "Missing.Assembly.Type",
+            TypeName = "legacy_event",
+            Data = "{\"legacyName\":\"Test\"}"
+        };
+
+        var @event = dbEvent.ToEvent(registry);
+
+        var data = Assert.IsType<CurrentEvent>(@event.Data);
+        Assert.Equal("Test", data.Name);
+        Assert.Equal("EUR", data.Currency);
+    }
+
+    [Fact]
+    public void EventTypeRegistry_Throws_WhenUpcasterSourceIsRegisteredTwice()
+    {
+        var services = new ServiceCollection();
+        services.AddEventStore(c => c.AddEvent<CurrentEvent>("current_event", e => e
+            .AddUpcaster<OldEvent>("old_event", old => new CurrentEvent { Name = old.Name })
+            .AddUpcaster<OldEvent>("old_event", old => new CurrentEvent { Name = old.Name })));
+
+        var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<EventTypeRegistry>());
+
+        Assert.Contains("already registered", exception.Message);
     }
 
     [Fact]
@@ -94,5 +234,12 @@ public class EventExtensionsTests
         var exception = Assert.Throws<EventMaterializationException>(() => dbEvent.ToEvent());
 
         Assert.Contains("Event type is required", exception.Message);
+    }
+
+    private static EventTypeRegistry BuildRegistry(Action<IEventStoreBuilder> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddEventStore(configure);
+        return services.BuildServiceProvider().GetRequiredService<EventTypeRegistry>();
     }
 }

--- a/tests/EventStoreCore.Tests/Daemons/DaemonHarnessTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/DaemonHarnessTests.cs
@@ -29,6 +29,11 @@ public class DaemonHarnessTests
         public string Name { get; set; } = string.Empty;
     }
 
+    private sealed class OldProjectionEvent
+    {
+        public string OldName { get; set; } = string.Empty;
+    }
+
     private sealed class ProjectionSnapshot
     {
         public Guid Id { get; set; }
@@ -379,5 +384,68 @@ public class DaemonHarnessTests
         Assert.Equal(1, status.Position);
         Assert.Equal(dbEvent.StreamId, snapshot.Id);
         Assert.Equal("Active", snapshot.Name);
+    }
+
+    [Fact]
+    public async Task ProjectionDaemon_ProcessProjectionAsync_AppliesUpcaster()
+    {
+        var db = BuildDbContext();
+        var registration = BuildProjectionRegistration(version: 1);
+        var lockProvider = new FakeLockProvider();
+
+        var dbEvent = new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Sequence = 1,
+            Type = "Missing.Assembly.Type",
+            TypeName = "old_projection_event",
+            Data = "{\"OldName\":\"Upcasted\"}"
+        };
+        db.Events.Add(dbEvent);
+        db.Set<DbProjectionStatus>().Add(new DbProjectionStatus
+        {
+            ProjectionName = registration.Name,
+            Version = 1,
+            State = ProjectionState.Active,
+            Position = 0
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var provider = BuildProvider(services =>
+        {
+            services.AddSingleton(registration);
+            services.AddSingleton(db);
+            services.AddEventStore(c => c.AddEvent<ProjectionEvent>("projection_event", e => e
+                .AddUpcaster<OldProjectionEvent>("old_projection_event", old => new ProjectionEvent
+                {
+                    Name = old.OldName
+                })));
+        });
+
+        var daemon = new ProjectionDaemon<HarnessDbContext>(
+            NullLogger<ProjectionDaemon<HarnessDbContext>>.Instance,
+            provider,
+            lockProvider,
+            Options.Create(new ProjectionDaemonOptions()));
+
+        var method = typeof(ProjectionDaemon<HarnessDbContext>).GetMethod(
+            "ProcessProjectionAsync",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        var task = (Task)method!.Invoke(daemon, new object[] { registration, TestContext.Current.CancellationToken })!;
+        await task;
+
+        var status = await db.Set<DbProjectionStatus>().SingleAsync(TestContext.Current.CancellationToken);
+        var snapshot = await db.Set<ProjectionSnapshot>().SingleAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, status.Position);
+        Assert.Equal(dbEvent.StreamId, snapshot.Id);
+        Assert.Equal("Upcasted", snapshot.Name);
     }
 }


### PR DESCRIPTION
Closes #25.

## Summary
- add AddEvent<T>(name, configure) with AddAlias and AddUpcaster overloads
- resolve logical TypeName aliases/upcasters before stale CLR Type strings during materialization
- apply typed and JsonObject upcasters across existing stream, projection, and subscription materialization paths
- reject conflicting alias/upcaster registrations and duplicate upcaster sources

## Tests
- dotnet test tests\EventStoreCore.Tests\EventStoreCore.Tests.csproj --no-restore --filter FullyQualifiedName~EventExtensionsTests|FullyQualifiedName~DaemonHarnessTests
- dotnet build EventStoreCore.slnx --no-restore