### PR TITLE
Add optional aggregate snapshot support

### DIFF
--- a/src/EventStoreCore.Abstractions/IReadOnlyStream.cs
+++ b/src/EventStoreCore.Abstractions/IReadOnlyStream.cs
@@ -16,7 +16,8 @@ public interface IReadOnlyStream
     long Version { get; }
 
     /// <summary>
-    /// The events in the stream, ordered by version.
+    /// The loaded events, ordered by version.
+    /// Snapshot-backed typed reads may contain only the events after the snapshot used to rebuild <see cref="State" />.
     /// </summary>
     IReadOnlyList<IEvent> Events { get; }
 }

--- a/src/EventStoreCore.Postgres/ModelBuilderExtensions.cs
+++ b/src/EventStoreCore.Postgres/ModelBuilderExtensions.cs
@@ -21,6 +21,12 @@ public static class ModelBuilderExtensions
             entity.Property(e => e.Data)
                 .HasColumnType("jsonb");
         });
+
+        modelBuilder.Entity<DbSnapshot>(entity =>
+        {
+            entity.Property(e => e.Data)
+                .HasColumnType("jsonb");
+        });
     }
 }
 

--- a/src/EventStoreCore.SqlServer/ModelBuilderExtensions.cs
+++ b/src/EventStoreCore.SqlServer/ModelBuilderExtensions.cs
@@ -21,6 +21,12 @@ public static class ModelBuilderExtensions
             entity.Property(e => e.Data)
                 .HasColumnType("nvarchar(max)");
         });
+
+        modelBuilder.Entity<DbSnapshot>(entity =>
+        {
+            entity.Property(e => e.Data)
+                .HasColumnType("nvarchar(max)");
+        });
     }
 }
 

--- a/src/EventStoreCore/DbContextEventStore.cs
+++ b/src/EventStoreCore/DbContextEventStore.cs
@@ -1,5 +1,8 @@
 using EventStoreCore.Abstractions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
 
 namespace EventStoreCore;
 
@@ -9,6 +12,8 @@ namespace EventStoreCore;
 /// <param name="db">The DbContext used for persistence.</param>
 public sealed class DbContextEventStore(DbContext db) : IEventStore
 {
+    private readonly SnapshotRegistry? _snapshots = ResolveSnapshotRegistry(db);
+
     /// <inheritdoc />
     public Task<IReadOnlyStream> AppendAsync(
         Guid streamId,
@@ -143,13 +148,16 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
     /// <inheritdoc />
     public async Task<IReadOnlyStream<T>?> FetchForReadingAsync<T>(string streamType, Guid streamId, Guid tenantId, CancellationToken cancellationToken = default) where T : IState, new()
     {
+        var snapshot = _snapshots?.LoadSnapshot<T>(db, streamType, streamId, tenantId);
+        var snapshotVersion = snapshot?.Version ?? 0;
+
         var stream = await db.Set<DbStream>()
          .AsNoTracking()
          .Where(x => x.TenantId == tenantId && x.StreamType == streamType)
-         .Include(x => x.Events)
+         .Include(x => x.Events.Where(e => e.Version > snapshotVersion))
          .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
         if (stream is null) return null;
-        return new DbContextStream<T>(stream, db);
+        return new DbContextStream<T>(stream, db, DeserializeSnapshot<T>(snapshot));
     }
 
     /// <inheritdoc />
@@ -191,13 +199,20 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
     /// <inheritdoc />
     public async Task<IReadOnlyStream<T>?> FetchForReadingAsync<T>(string streamType, Guid streamId, Guid tenantId, long version, CancellationToken cancellationToken = default) where T : IState, new()
     {
+        var snapshot = _snapshots?.LoadSnapshot<T>(db, streamType, streamId, tenantId);
+        if (snapshot?.Version > version)
+        {
+            snapshot = null;
+        }
+
+        var snapshotVersion = snapshot?.Version ?? 0;
         var stream = await db.Set<DbStream>()
             .AsNoTracking()
             .Where(x => x.TenantId == tenantId && x.StreamType == streamType)
-            .Include(x => x.Events.Where(x => x.Version <= version))
+            .Include(x => x.Events.Where(x => x.Version > snapshotVersion && x.Version <= version))
             .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
         if (stream is null) return null;
-        return new DbContextStream<T>(stream);
+        return new DbContextStream<T>(stream, db, DeserializeSnapshot<T>(snapshot));
     }
 
     /// <inheritdoc />
@@ -383,5 +398,28 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
             message,
             innerException);
     }
+
+    private static SnapshotRegistry? ResolveSnapshotRegistry(DbContext db)
+    {
+        try
+        {
+            var options = db.GetService<IDbContextOptions>();
+            var appProvider = options.Extensions
+                .OfType<CoreOptionsExtension>()
+                .FirstOrDefault()
+                ?.ApplicationServiceProvider;
+
+            return appProvider?.GetService<SnapshotRegistry>();
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static T? DeserializeSnapshot<T>(DbSnapshot? snapshot)
+        where T : IState, new()
+        => snapshot is null ? default : JsonSerializer.Deserialize<T>(snapshot.Data);
+
 }
 

--- a/src/EventStoreCore/DbContextStream.cs
+++ b/src/EventStoreCore/DbContextStream.cs
@@ -1,6 +1,8 @@
 using EventStoreCore.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
 
 namespace EventStoreCore;
 
@@ -10,7 +12,10 @@ namespace EventStoreCore;
 public class DbContextStream : IStream
 {
     private readonly DbStream _dbStream;
+    private readonly DbContext? _db;
+    private IReadOnlyList<IEvent>? _events;
     private readonly EventTypeRegistry? _registry;
+    private readonly SnapshotRegistry? _snapshots;
 
     /// <summary>
     /// Creates a stream wrapper for the provided stream record.
@@ -30,6 +35,7 @@ public class DbContextStream : IStream
     public DbContextStream(DbStream dbStream, DbContext db) : this(dbStream)
     {
         ArgumentNullException.ThrowIfNull(db);
+        _db = db;
 
         var options = db.GetService<IDbContextOptions>();
         var appProvider = options.Extensions
@@ -45,6 +51,7 @@ public class DbContextStream : IStream
         _registry = appProvider.GetService(typeof(EventTypeRegistry)) as EventTypeRegistry
             ?? throw new InvalidOperationException(
                 "EventTypeRegistry is not registered. Call services.AddEventStore() before using the event store.");
+        _snapshots = appProvider.GetService<SnapshotRegistry>();
     }
 
     /// <summary>
@@ -59,14 +66,12 @@ public class DbContextStream : IStream
     public long Version => _dbStream.CurrentVersion;
 
     /// <inheritdoc />
-    public IReadOnlyList<IEvent> Events => _dbStream.Events
-        .OrderBy(e => e.Version)
-        .Select(e => e.ToEvent(_registry))
-        .ToList();
+    public IReadOnlyList<IEvent> Events => _events ??= MaterializeEvents(_dbStream.Events);
 
     /// <inheritdoc />
     public void Append(params IEnumerable<object> events)
     {
+        var previousVersion = _dbStream.CurrentVersion;
         foreach (var @event in events)
         {
             var eventType = @event.GetType();
@@ -88,7 +93,16 @@ public class DbContextStream : IStream
         }
 
         _dbStream.UpdatedTimestamp = DateTimeOffset.UtcNow;
+        _snapshots?.SaveSnapshots(_db!, _dbStream, previousVersion);
+        _events = null;
     }
+
+    protected IReadOnlyList<IEvent> MaterializeEvents(IEnumerable<DbEvent> events)
+        => events
+            .OrderBy(e => e.Version)
+            .Select(e => e.ToEvent(_registry))
+            .ToList();
+
 }
 
 /// <summary>
@@ -97,6 +111,9 @@ public class DbContextStream : IStream
 /// <typeparam name="T">The state type rebuilt from the stream.</typeparam>
 public class DbContextStream<T> : DbContextStream, IStream<T> where T : IState, new()
 {
+    private readonly T? _snapshotState;
+    private readonly IReadOnlyList<IEvent>? _stateEvents;
+
     /// <summary>
     /// Creates a typed stream wrapper for the provided stream record.
     /// </summary>
@@ -114,13 +131,21 @@ public class DbContextStream<T> : DbContextStream, IStream<T> where T : IState, 
     {
     }
 
+    internal DbContextStream(DbStream dbStream, DbContext db, T? snapshotState) : base(dbStream, db)
+    {
+        _snapshotState = snapshotState;
+        _stateEvents = MaterializeEvents(dbStream.Events);
+    }
+
     /// <inheritdoc />
     public T State
     {
         get
         {
-            var state = new T();
-            foreach (var @event in Events)
+            var state = _snapshotState is null
+                ? new T()
+                : JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(_snapshotState)) ?? new T();
+            foreach (var @event in _stateEvents ?? Events)
             {
                 state.Apply(@event);
             }

--- a/src/EventStoreCore/DbSnapshot.cs
+++ b/src/EventStoreCore/DbSnapshot.cs
@@ -1,0 +1,42 @@
+namespace EventStoreCore;
+
+/// <summary>
+/// Represents the latest persisted aggregate snapshot for a stream and state type.
+/// </summary>
+public sealed class DbSnapshot
+{
+    /// <summary>
+    /// The tenant identifier for multi-tenant scenarios.
+    /// </summary>
+    public Guid TenantId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// The stream identifier.
+    /// </summary>
+    public Guid StreamId { get; set; }
+
+    /// <summary>
+    /// The stream type for distinguishing multiple streams with the same ID.
+    /// </summary>
+    public string StreamType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The stable CLR name of the state type stored in the snapshot.
+    /// </summary>
+    public required string StateType { get; set; }
+
+    /// <summary>
+    /// The stream version represented by the snapshot.
+    /// </summary>
+    public long Version { get; set; }
+
+    /// <summary>
+    /// The serialized state payload.
+    /// </summary>
+    public string Data { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When the snapshot was recorded in UTC.
+    /// </summary>
+    public DateTimeOffset Timestamp { get; set; }
+}

--- a/src/EventStoreCore/EventStoreExtensions.cs
+++ b/src/EventStoreCore/EventStoreExtensions.cs
@@ -20,6 +20,7 @@ public static class EventStoreExtensions
            )
     {
         services.TryAddSingleton(sp => new EventTypeRegistry(sp.GetServices<EventTypeRegistration>()));
+        services.TryAddSingleton<SnapshotRegistry>();
 
         EventStoreBuilder builder = new EventStoreBuilder(services);
 

--- a/src/EventStoreCore/ISnapshotBuilder.cs
+++ b/src/EventStoreCore/ISnapshotBuilder.cs
@@ -1,0 +1,28 @@
+using EventStoreCore.Abstractions;
+
+namespace EventStoreCore;
+
+/// <summary>
+/// Configures aggregate snapshots for event streams.
+/// </summary>
+public interface ISnapshotBuilder
+{
+    /// <summary>
+    /// Enables snapshots for a state type and the default stream type.
+    /// </summary>
+    /// <typeparam name="TState">The state type to snapshot.</typeparam>
+    /// <param name="configure">Optional snapshot configuration.</param>
+    /// <returns>The snapshot builder for chaining.</returns>
+    ISnapshotBuilder For<TState>(Action<SnapshotOptions>? configure = null)
+        where TState : IState, new();
+
+    /// <summary>
+    /// Enables snapshots for a state type and stream type.
+    /// </summary>
+    /// <typeparam name="TState">The state type to snapshot.</typeparam>
+    /// <param name="streamType">The stream type whose events hydrate the state.</param>
+    /// <param name="configure">Optional snapshot configuration.</param>
+    /// <returns>The snapshot builder for chaining.</returns>
+    ISnapshotBuilder For<TState>(string streamType, Action<SnapshotOptions>? configure = null)
+        where TState : IState, new();
+}

--- a/src/EventStoreCore/ModelBuilderExtensions.cs
+++ b/src/EventStoreCore/ModelBuilderExtensions.cs
@@ -90,6 +90,37 @@ internal static class ModelBuilderExtensions
 
             entity.HasIndex(e => new { e.TenantId, e.StreamType, e.Timestamp });
         });
+        modelBuilder.Entity<DbSnapshot>(entity =>
+        {
+            entity.ToTable("Snapshots");
+
+            entity.HasKey(e => new { e.StreamId, e.StreamType, e.TenantId, e.StateType });
+
+            entity.Property(e => e.StreamId)
+                .IsRequired();
+
+            entity.Property(e => e.StreamType)
+                .IsRequired();
+
+            entity.Property(e => e.TenantId)
+                .IsRequired();
+
+            entity.Property(e => e.StateType)
+                .IsRequired();
+
+            entity.Property(e => e.Version)
+                .IsRequired();
+
+            entity.Property(e => e.Data)
+                .IsRequired();
+
+            entity.Property(e => e.Timestamp)
+                .IsRequired();
+
+            entity.HasIndex(e => e.TenantId);
+
+            entity.HasIndex(e => new { e.TenantId, e.StreamId, e.StreamType });
+        });
         modelBuilder.Entity<DbSubscription>(entity =>
         {
             entity.ToTable("Subscriptions");

--- a/src/EventStoreCore/SnapshotBuilderExtensions.cs
+++ b/src/EventStoreCore/SnapshotBuilderExtensions.cs
@@ -1,0 +1,58 @@
+using EventStoreCore.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStoreCore;
+
+/// <summary>
+/// Extension methods for configuring aggregate snapshots.
+/// </summary>
+public static class SnapshotBuilderExtensions
+{
+    /// <summary>
+    /// Enables aggregate snapshots for configured stream types.
+    /// Configured snapshots are written during appends that cross the configured interval,
+    /// and typed reads for registered state types rebuild state from the snapshot plus later events.
+    /// </summary>
+    /// <param name="builder">The event store builder.</param>
+    /// <param name="configure">Snapshot configuration.</param>
+    /// <returns>The event store builder for chaining.</returns>
+    public static IEventStoreBuilder UseSnapshots(
+        this IEventStoreBuilder builder,
+        Action<ISnapshotBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        configure(new SnapshotBuilder(builder.Services));
+        return builder;
+    }
+
+    private sealed class SnapshotBuilder(IServiceCollection services) : ISnapshotBuilder
+    {
+        public ISnapshotBuilder For<TState>(Action<SnapshotOptions>? configure = null)
+            where TState : IState, new()
+            => For<TState>(string.Empty, configure);
+
+        public ISnapshotBuilder For<TState>(string streamType, Action<SnapshotOptions>? configure = null)
+            where TState : IState, new()
+        {
+            ArgumentNullException.ThrowIfNull(streamType);
+
+            var options = new SnapshotOptions();
+            configure?.Invoke(options);
+
+            if (options.Interval <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    options.Interval,
+                    "Snapshot interval must be greater than zero.");
+            }
+
+            services.AddSingleton<SnapshotRegistration>(
+                new SnapshotRegistration<TState>(streamType, options.Interval));
+
+            return this;
+        }
+    }
+}

--- a/src/EventStoreCore/SnapshotOptions.cs
+++ b/src/EventStoreCore/SnapshotOptions.cs
@@ -1,0 +1,12 @@
+namespace EventStoreCore;
+
+/// <summary>
+/// Configures aggregate snapshot behavior for a state type.
+/// </summary>
+public sealed class SnapshotOptions
+{
+    /// <summary>
+    /// The stream version interval at which snapshots are written.
+    /// </summary>
+    public int Interval { get; set; } = 100;
+}

--- a/src/EventStoreCore/SnapshotRegistration.cs
+++ b/src/EventStoreCore/SnapshotRegistration.cs
@@ -1,0 +1,84 @@
+using EventStoreCore.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace EventStoreCore;
+
+internal abstract class SnapshotRegistration
+{
+    protected SnapshotRegistration(string streamType, Type stateType, int interval)
+    {
+        StreamType = streamType;
+        StateType = stateType;
+        StateTypeName = stateType.FullName
+            ?? throw new InvalidOperationException($"State type '{stateType.Name}' does not have a full name.");
+        Interval = interval;
+    }
+
+    public string StreamType { get; }
+
+    public Type StateType { get; }
+
+    public string StateTypeName { get; }
+
+    public int Interval { get; }
+
+    public bool ShouldSnapshot(long previousVersion, long currentVersion)
+        => previousVersion / Interval < currentVersion / Interval;
+
+    public abstract void SaveSnapshot(DbContext db, DbStream stream);
+}
+
+internal sealed class SnapshotRegistration<TState> : SnapshotRegistration
+    where TState : IState, new()
+{
+    public SnapshotRegistration(string streamType, int interval)
+        : base(streamType, typeof(TState), interval)
+    {
+    }
+
+    public override void SaveSnapshot(DbContext db, DbStream stream)
+    {
+        var snapshot = db.Set<DbSnapshot>().Find(
+            stream.Id,
+            stream.StreamType,
+            stream.TenantId,
+            StateTypeName);
+
+        var snapshotVersion = snapshot?.Version ?? 0;
+        var snapshotState = snapshot is null ? default : Deserialize(snapshot);
+        var tailStream = new DbStream
+        {
+            Id = stream.Id,
+            StreamType = stream.StreamType,
+            TenantId = stream.TenantId,
+            CurrentVersion = stream.CurrentVersion,
+            CreatedTimestamp = stream.CreatedTimestamp,
+            UpdatedTimestamp = stream.UpdatedTimestamp,
+            Events = stream.Events
+                .Where(e => e.Version > snapshotVersion)
+                .OrderBy(e => e.Version)
+                .ToList()
+        };
+
+        var state = new DbContextStream<TState>(tailStream, db, snapshotState).State;
+        if (snapshot is null)
+        {
+            snapshot = new DbSnapshot
+            {
+                StreamId = stream.Id,
+                StreamType = stream.StreamType,
+                TenantId = stream.TenantId,
+                StateType = StateTypeName
+            };
+            db.Add(snapshot);
+        }
+
+        snapshot.Version = stream.CurrentVersion;
+        snapshot.Data = JsonSerializer.Serialize(state, typeof(TState));
+        snapshot.Timestamp = DateTimeOffset.UtcNow;
+    }
+
+    internal static TState? Deserialize(DbSnapshot snapshot)
+        => JsonSerializer.Deserialize<TState>(snapshot.Data);
+}

--- a/src/EventStoreCore/SnapshotRegistry.cs
+++ b/src/EventStoreCore/SnapshotRegistry.cs
@@ -1,0 +1,63 @@
+using EventStoreCore.Abstractions;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventStoreCore;
+
+internal sealed class SnapshotRegistry
+{
+    private readonly IReadOnlyList<SnapshotRegistration> _registrations;
+
+    public SnapshotRegistry(IEnumerable<SnapshotRegistration> registrations)
+    {
+        _registrations = registrations.ToArray();
+        var duplicate = _registrations
+            .GroupBy(r => new { r.StreamType, r.StateType })
+            .FirstOrDefault(g => g.Count() > 1);
+
+        if (duplicate is not null)
+        {
+            throw new InvalidOperationException(
+                $"Snapshot state '{duplicate.Key.StateType.FullName ?? duplicate.Key.StateType.Name}' is already registered for stream type '{duplicate.Key.StreamType}'.");
+        }
+    }
+
+    public bool HasRegistrations => _registrations.Count > 0;
+
+    public IReadOnlyList<SnapshotRegistration> GetForStreamType(string streamType)
+        => _registrations.Where(r => r.StreamType == streamType).ToArray();
+
+    public SnapshotRegistration? GetForState(string streamType, Type stateType)
+        => _registrations.FirstOrDefault(r => r.StreamType == streamType && r.StateType == stateType);
+
+    public void SaveSnapshots(DbContext db, DbStream stream, long previousVersion)
+    {
+        foreach (var registration in GetForStreamType(stream.StreamType))
+        {
+            if (registration.ShouldSnapshot(previousVersion, stream.CurrentVersion))
+            {
+                registration.SaveSnapshot(db, stream);
+            }
+        }
+    }
+
+    public DbSnapshot? LoadSnapshot<TState>(
+        DbContext db,
+        string streamType,
+        Guid streamId,
+        Guid tenantId)
+        where TState : IState, new()
+    {
+        var registration = GetForState(streamType, typeof(TState));
+        if (registration is null)
+        {
+            return null;
+        }
+
+        return db.Set<DbSnapshot>()
+            .AsNoTracking()
+            .SingleOrDefault(x => x.StreamId == streamId
+                && x.StreamType == streamType
+                && x.TenantId == tenantId
+                && x.StateType == registration.StateTypeName);
+    }
+}

--- a/tests/EventStoreCore.Tests/EventStoreTests.cs
+++ b/tests/EventStoreCore.Tests/EventStoreTests.cs
@@ -5,6 +5,7 @@ using EventStoreCore;
 using EventStoreCore.Postgres;
 
 using EventStoreCore.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EventStoreCore.Tests;
 
@@ -34,6 +35,36 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
         }
     }
 
+    public class SnapshotState : IState
+    {
+        public string Name { get; set; } = "Initial";
+        public int ApplyCount { get; set; }
+
+        public void Apply(IEvent @event)
+        {
+            if (@event is Event<TestEvent> e)
+            {
+                Name = e.Data.Name;
+                ApplyCount++;
+            }
+        }
+    }
+
+    public class SnapshotNameLengthState : IState
+    {
+        public int NameLength { get; set; }
+        public int ApplyCount { get; set; }
+
+        public void Apply(IEvent @event)
+        {
+            if (@event is Event<TestEvent> e)
+            {
+                NameLength = e.Data.Name.Length;
+                ApplyCount++;
+            }
+        }
+    }
+
     private static async Task<long> GetCurrentVersionAsync(
         EventStoreFixture.EventStoreDbContext dbContext,
         Guid streamId,
@@ -47,6 +78,29 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
                 TestContext.Current.CancellationToken);
 
         return stream.CurrentVersion;
+    }
+
+    private ServiceProvider CreateSnapshotProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<EventStoreFixture.EventStoreDbContext>(options => options.UseNpgsql(eventStoreFixture.ConnectionString));
+        services.AddEventStore(c =>
+        {
+            c.ExistingDbContext<EventStoreFixture.EventStoreDbContext>();
+            c.UseSnapshots(snapshots =>
+            {
+                snapshots.For<SnapshotState>("orders", o => o.Interval = 2);
+                snapshots.For<SnapshotNameLengthState>("orders", o => o.Interval = 3);
+            });
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task RecreateAsync(DbContext dbContext)
+    {
+        await dbContext.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+        await dbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -191,6 +245,196 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
         Assert.Equal(2, stream.Version);
         Assert.Equal("Mary Jane", stream.State.Name);
 
+    }
+
+    [Fact]
+    public async Task ConfiguredSnapshotsAreWrittenWhenAppendCrossesInterval()
+    {
+        using var provider = CreateSnapshotProvider();
+        var streamId = Guid.NewGuid();
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            await RecreateAsync(dbContext);
+
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.NoStream,
+                [new TestEvent { Name = "one" }, new TestEvent { Name = "two" }],
+                TestContext.Current.CancellationToken);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            var snapshots = await dbContext.Set<DbSnapshot>()
+                .AsNoTracking()
+                .Where(x => x.StreamId == streamId && x.StreamType == "orders")
+                .ToListAsync(TestContext.Current.CancellationToken);
+
+            var snapshot = Assert.Single(snapshots);
+            Assert.Equal(typeof(SnapshotState).FullName, snapshot.StateType);
+            Assert.Equal(2, snapshot.Version);
+        }
+    }
+
+    [Fact]
+    public async Task ConfiguredSnapshotsSupportMultipleStatesForOneStreamType()
+    {
+        using var provider = CreateSnapshotProvider();
+        var streamId = Guid.NewGuid();
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            await RecreateAsync(dbContext);
+
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.NoStream,
+                [new TestEvent { Name = "one" }, new TestEvent { Name = "two" }],
+                TestContext.Current.CancellationToken);
+
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.Exact(2),
+                [new TestEvent { Name = "three" }],
+                TestContext.Current.CancellationToken);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            var snapshots = await dbContext.Set<DbSnapshot>()
+                .AsNoTracking()
+                .Where(x => x.StreamId == streamId && x.StreamType == "orders")
+                .ToListAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(2, snapshots.Count);
+            Assert.Contains(snapshots, x => x.StateType == typeof(SnapshotState).FullName && x.Version == 2);
+            Assert.Contains(snapshots, x => x.StateType == typeof(SnapshotNameLengthState).FullName && x.Version == 3);
+        }
+    }
+
+    [Fact]
+    public async Task TypedReadUsesConfiguredSnapshotTransparently()
+    {
+        using var provider = CreateSnapshotProvider();
+        var streamId = Guid.NewGuid();
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            await RecreateAsync(dbContext);
+
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.NoStream,
+                [new TestEvent { Name = "one" }, new TestEvent { Name = "two" }],
+                TestContext.Current.CancellationToken);
+
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.Exact(2),
+                [new TestEvent { Name = "three" }],
+                TestContext.Current.CancellationToken);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            var stream = await dbContext.Streams.FetchForReadingAsync<SnapshotState>(
+                "orders",
+                streamId,
+                TestContext.Current.CancellationToken);
+
+            Assert.NotNull(stream);
+            Assert.Single(stream!.Events);
+            Assert.Equal("three", stream.State.Name);
+            Assert.Equal(3, stream.State.ApplyCount);
+        }
+    }
+
+    [Fact]
+    public async Task SnapshotBackedVersionedReadExposesOnlyReplayTail()
+    {
+        using var provider = CreateSnapshotProvider();
+        var streamId = Guid.NewGuid();
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            await RecreateAsync(dbContext);
+
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.NoStream,
+                [new TestEvent { Name = "one" }, new TestEvent { Name = "two" }],
+                TestContext.Current.CancellationToken);
+
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.Exact(2),
+                [new TestEvent { Name = "three" }],
+                TestContext.Current.CancellationToken);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            var stream = await dbContext.Streams.FetchForReadingAsync<SnapshotState>(
+                "orders",
+                streamId,
+                version: 2,
+                TestContext.Current.CancellationToken);
+
+            Assert.NotNull(stream);
+            Assert.Empty(stream!.Events);
+            Assert.Equal("two", stream.State.Name);
+            Assert.Equal(2, stream.State.ApplyCount);
+        }
+    }
+
+    [Fact]
+    public async Task UnregisteredTypedReadFallsBackToFullReplay()
+    {
+        using var provider = CreateSnapshotProvider();
+        var streamId = Guid.NewGuid();
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            await RecreateAsync(dbContext);
+
+            await dbContext.Streams.AppendAsync(
+                "invoices",
+                streamId,
+                ExpectedVersion.NoStream,
+                [new TestEvent { Name = "one" }, new TestEvent { Name = "two" }, new TestEvent { Name = "three" }],
+                TestContext.Current.CancellationToken);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            var stream = await dbContext.Streams.FetchForReadingAsync<SnapshotState>(
+                "invoices",
+                streamId,
+                TestContext.Current.CancellationToken);
+
+            Assert.NotNull(stream);
+            Assert.Equal(3, stream!.Events.Count);
+            Assert.Equal("three", stream.State.Name);
+            Assert.Equal(3, stream.State.ApplyCount);
+        }
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/ExtensionTests.cs
+++ b/tests/EventStoreCore.Tests/ExtensionTests.cs
@@ -3,6 +3,7 @@ using EventStoreCore;
 using EventStoreCore.Postgres;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EventStoreCore.Tests;
 
@@ -24,5 +25,47 @@ public class ExtensionTests
     {
         DbContext? context = null;
         Assert.Throws<ArgumentNullException>(() => context!.Streams);
+    }
+
+    [Fact]
+    public void UseSnapshotsRejectsInvalidInterval()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddEventStore(builder =>
+            {
+                builder.UseSnapshots(snapshots =>
+                {
+                    snapshots.For<TestState>("orders", options => options.Interval = 0);
+                });
+            }));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseSnapshotsRejectsDuplicateStateForSameStreamType()
+    {
+        var services = new ServiceCollection();
+        services.AddEventStore(builder =>
+        {
+            builder.UseSnapshots(snapshots =>
+            {
+                snapshots.For<TestState>("orders");
+                snapshots.For<TestState>("orders");
+            });
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<SnapshotRegistry>());
+    }
+
+    private sealed class TestState : EventStoreCore.Abstractions.IState
+    {
+        public void Apply(EventStoreCore.Abstractions.IEvent @event)
+        {
+        }
     }
 }

--- a/tests/EventStoreCore.Tests/ProviderModelConfigurationTests.cs
+++ b/tests/EventStoreCore.Tests/ProviderModelConfigurationTests.cs
@@ -41,9 +41,13 @@ public class ProviderModelConfigurationTests
         using var context = new PostgresContext(options);
         var entityType = context.Model.FindEntityType(typeof(DbEvent));
         var property = entityType?.FindProperty(nameof(DbEvent.Data));
+        var snapshotEntityType = context.Model.FindEntityType(typeof(DbSnapshot));
+        var snapshotProperty = snapshotEntityType?.FindProperty(nameof(DbSnapshot.Data));
 
         Assert.NotNull(property);
         Assert.Equal("jsonb", property!.GetColumnType());
+        Assert.NotNull(snapshotProperty);
+        Assert.Equal("jsonb", snapshotProperty!.GetColumnType());
     }
 
     [Fact]
@@ -56,9 +60,13 @@ public class ProviderModelConfigurationTests
         using var context = new SqlServerContext(options);
         var entityType = context.Model.FindEntityType(typeof(DbEvent));
         var property = entityType?.FindProperty(nameof(DbEvent.Data));
+        var snapshotEntityType = context.Model.FindEntityType(typeof(DbSnapshot));
+        var snapshotProperty = snapshotEntityType?.FindProperty(nameof(DbSnapshot.Data));
 
         Assert.NotNull(property);
         Assert.Equal("nvarchar(max)", property!.GetColumnType());
+        Assert.NotNull(snapshotProperty);
+        Assert.Equal("nvarchar(max)", snapshotProperty!.GetColumnType());
     }
 
     


### PR DESCRIPTION
## Summary
- Add generic aggregate snapshot storage with provider-specific JSON column mapping for Postgres and SQL Server.
- Add `UseSnapshots` configuration with one or more `TState` registrations per stream type, each with its own interval.
- Automatically update configured snapshots inside append/save flows when an append crosses the configured version interval.
- Make typed reads for registered `(streamType, TState)` pairs seed state from the latest snapshot and replay only later events; unregistered typed reads keep full replay behavior.

## Example
```csharp
services.AddEventStore(builder =>
{
    builder.UseSnapshots(snapshots =>
    {
        snapshots.For<OrderState>("orders", o => o.Interval = 50);
        snapshots.For<OrderSummaryState>("orders", o => o.Interval = 100);
    });
});
```

## Review notes
- Snapshots remain a generic JSON blob cache, not queryable projection schema.
- Multiple states per stream type are supported via the snapshot key `(TenantId, StreamType, StreamId, StateType)`.
- `StateType` is keyed by stable CLR full name rather than assembly-qualified name so assembly version changes do not strand existing snapshots.
- Snapshot writes are staged in the same DbContext append flow, so normal `SaveChanges` commits events and snapshot updates together.
- For snapshot-backed typed reads, `State` is rebuilt from the snapshot plus loaded replay tail. `Events` intentionally exposes that loaded replay tail rather than forcing a full event-history load.

## Tests
- `dotnet build EventStoreCore.slnx`
- `dotnet test tests/EventStoreCore.Tests/EventStoreCore.Tests.csproj --filter "FullyQualifiedName~ExtensionTests|FullyQualifiedName~ProviderModelConfigurationTests"`
- Attempted EventStoreTests/provider behavior coverage, but Docker is unavailable in this environment: `Failed to connect to Docker endpoint at 'npipe://./pipe/docker_engine'`.

Closes #29
