### PR TITLE
Prevent projection daemon from processing inline projections

### DIFF
--- a/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
+++ b/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
@@ -30,7 +30,7 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
         var projectionName = typeof(TProjection).FullName ?? typeof(TProjection).Name;
 
         services.AddSingleton<ProjectionRegistration>(sp =>
-            CreateProjectionRegistration<TProjection, TSnapshot>(projectionName, version, options));
+            CreateProjectionRegistration<TProjection, TSnapshot>(projectionName, mode, version, options));
 
         if (mode == ProjectionMode.Inline)
         {
@@ -101,6 +101,7 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
 
     private static ProjectionRegistration CreateProjectionRegistration<TProjection, TSnapshot>(
         string projectionName,
+        ProjectionMode mode,
         int version,
         ProjectionOptions options)
         where TProjection : IProjection<TSnapshot>, new()
@@ -135,6 +136,7 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
         return new ProjectionRegistration
         {
             Name = projectionName,
+            Mode = mode,
             Version = version,
             ProjectionType = typeof(TProjection),
             SnapshotType = typeof(TSnapshot),

--- a/src/EventStoreCore/ProjectionDaemon.cs
+++ b/src/EventStoreCore/ProjectionDaemon.cs
@@ -42,7 +42,9 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
         _serviceProvider = serviceProvider;
         _distributedLockProvider = distributedLockProvider;
         _options = options.Value;
-        _projections = serviceProvider.GetServices<ProjectionRegistration>().ToList();
+        _projections = serviceProvider.GetServices<ProjectionRegistration>()
+            .Where(projection => projection.Mode == ProjectionMode.Eventual)
+            .ToList();
     }
 
     /// <inheritdoc />

--- a/src/EventStoreCore/ProjectionRegistration.cs
+++ b/src/EventStoreCore/ProjectionRegistration.cs
@@ -5,7 +5,7 @@ namespace EventStoreCore;
 
 
 /// <summary>
-/// Internal registration information for a projection used by the daemon.
+/// Internal registration information for a projection.
 /// </summary>
 internal sealed class ProjectionRegistration
 {
@@ -13,6 +13,11 @@ internal sealed class ProjectionRegistration
     /// The unique name of the projection (typically the fully qualified type name).
     /// </summary>
     public required string Name { get; init; }
+
+    /// <summary>
+    /// The configured execution mode.
+    /// </summary>
+    public required ProjectionMode Mode { get; init; }
 
     /// <summary>
     /// The version of the projection from the attribute or options.

--- a/tests/EventStoreCore.Tests/Coverage/ProjectionDaemonCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/ProjectionDaemonCoverageTests.cs
@@ -41,6 +41,7 @@ public class ProjectionDaemonCoverageTests
         return new ProjectionRegistration
         {
             Name = "Projection",
+            Mode = ProjectionMode.Eventual,
             Version = version,
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
@@ -180,6 +181,7 @@ public class ProjectionDaemonCoverageTests
         var registration = new ProjectionRegistration
         {
             Name = "Projection",
+            Mode = ProjectionMode.Eventual,
             Version = 1,
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
@@ -251,6 +253,7 @@ public class ProjectionDaemonCoverageTests
         var registration = new ProjectionRegistration
         {
             Name = "Projection",
+            Mode = ProjectionMode.Eventual,
             Version = 1,
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
@@ -399,6 +402,7 @@ public class ProjectionDaemonCoverageTests
         var registration = new ProjectionRegistration
         {
             Name = "Projection",
+            Mode = ProjectionMode.Eventual,
             Version = 1,
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),

--- a/tests/EventStoreCore.Tests/Daemons/DaemonHarnessTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/DaemonHarnessTests.cs
@@ -141,6 +141,7 @@ public class DaemonHarnessTests
         return new ProjectionRegistration
         {
             Name = "Projection",
+            Mode = ProjectionMode.Eventual,
             Version = version,
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),

--- a/tests/EventStoreCore.Tests/Daemons/ProjectionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/ProjectionDaemonExecutionTests.cs
@@ -76,6 +76,7 @@ public class ProjectionDaemonExecutionTests
         return new ProjectionRegistration
         {
             Name = "ExecutionProjection",
+            Mode = ProjectionMode.Eventual,
             Version = 1,
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),

--- a/tests/EventStoreCore.Tests/ProjectionDaemonDependencyInjectionTests.cs
+++ b/tests/EventStoreCore.Tests/ProjectionDaemonDependencyInjectionTests.cs
@@ -100,7 +100,7 @@ public class ProjectionDaemonDependencyInjectionTests
     }
 
     [Fact]
-    public void ProjectionDaemon_FindsInlineAndEventualProjections()
+    public void ProjectionDaemon_OnlyFindsEventualProjections()
     {
         var services = new ServiceCollection();
         services.AddDbContext<TestDbContext>(options =>
@@ -126,8 +126,8 @@ public class ProjectionDaemonDependencyInjectionTests
         var daemon = provider.GetRequiredService<ProjectionDaemon<TestDbContext>>();
         var projections = daemon.Projections;
 
-        Assert.Equal(2, projections.Count);
-        Assert.Contains(projections, projection => projection.ProjectionType == typeof(InlineProjection));
-        Assert.Contains(projections, projection => projection.ProjectionType == typeof(EventualProjection));
+        var projection = Assert.Single(projections);
+        Assert.Equal(ProjectionMode.Eventual, projection.Mode);
+        Assert.Equal(typeof(EventualProjection), projection.ProjectionType);
     }
 }


### PR DESCRIPTION
## Summary

- carry the configured `ProjectionMode` into projection registrations
- restrict `ProjectionDaemon` processing to eventual projections
- add regression coverage proving inline projections are excluded from the daemon

## Root cause

Projection registrations did not retain their execution mode, so the daemon processed both inline and eventual projections. For inline projections, the daemon could race the `ProjectionInterceptor` while both initialized the same projection-status row, causing a duplicate primary-key failure.

## Impact

Applications can safely register a projection daemon alongside inline projections. Inline projections remain available to projection management APIs but are no longer processed a second time by the daemon.

## Validation

- `dotnet test tests/EventStoreCore.Tests/EventStoreCore.Tests.csproj --filter FullyQualifiedName~ProjectionDaemon --no-restore --no-build`
- 16 tests passed

Closes #48