### PR TITLE
Fix API review bugs across event store integrations

### DIFF
--- a/src/EventStoreCore.CloudEvents/CloudEventTransformer.cs
+++ b/src/EventStoreCore.CloudEvents/CloudEventTransformer.cs
@@ -12,6 +12,13 @@ internal sealed class CloudEventTransformer(IOptions<CloudEventTransformerOption
         if (options is not null && options.Value._mappings.TryGetValue(@event.EventType, out var transform))
         {
             cloudEvent = transform(@event);
+            if (!options.Value._preservedCloudEventIds.Contains(@event.EventType))
+            {
+                cloudEvent.Id = @event.Id.ToString("D");
+            }
+            cloudEvent.ExtensionAttributes.TryAdd("streamid", @event.StreamId.ToString("D"));
+            cloudEvent.ExtensionAttributes.TryAdd("tenantid", @event.TenantId.ToString("D"));
+            cloudEvent.ExtensionAttributes.TryAdd("streamversion", @event.Version.ToString());
             return true;
         }
 

--- a/src/EventStoreCore.CloudEvents/CloudEventTransformerOptions.cs
+++ b/src/EventStoreCore.CloudEvents/CloudEventTransformerOptions.cs
@@ -9,16 +9,31 @@ namespace EventStoreCore.CloudEvents;
 public sealed class CloudEventTransformerOptions
 {
     internal Dictionary<Type, Func<IEvent, CloudEvent>> _mappings = new();
+    internal HashSet<Type> _preservedCloudEventIds = [];
 
     /// <summary>
     /// Registers a custom CloudEvent mapping for the given event type.
     /// </summary>
     /// <typeparam name="TEvent">The event payload type.</typeparam>
     /// <param name="transform">Transformation function.</param>
-    public void MapEvent<TEvent>(Func<IEvent<TEvent>, CloudEvent> transform)
+    /// <param name="preserveCloudEventId">
+    /// Whether to preserve the ID returned by <paramref name="transform"/>.
+    /// The default replaces it with the stable EventStore event ID.
+    /// </param>
+    public void MapEvent<TEvent>(
+        Func<IEvent<TEvent>, CloudEvent> transform,
+        bool preserveCloudEventId = false)
         where TEvent : class
     {
         _mappings[typeof(TEvent)] = (ievent) => transform((IEvent<TEvent>)ievent);
+        if (preserveCloudEventId)
+        {
+            _preservedCloudEventIds.Add(typeof(TEvent));
+        }
+        else
+        {
+            _preservedCloudEventIds.Remove(typeof(TEvent));
+        }
     }
 
     /// <summary>

--- a/src/EventStoreCore.CloudEvents/EventStoreCore.CloudEvents.csproj
+++ b/src/EventStoreCore.CloudEvents/EventStoreCore.CloudEvents.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.50.0" />
     <ProjectReference Include="..\EventStoreCore\EventStoreCore.csproj" />
   </ItemGroup>
 

--- a/src/EventStoreCore.MassTransit/MassTransitSubscription.cs
+++ b/src/EventStoreCore.MassTransit/MassTransitSubscription.cs
@@ -56,12 +56,22 @@ internal class MassTransitSubscription : ISubscription
 
             if(eventData is null)
             {
-                logger.LogError("Transform returned null for {EventType} (output type: {OutType})", @event.EventType, outType);
-                continue;
+                throw new InvalidOperationException(
+                    $"Transform returned null for event type '{@event.EventType}' (output type: '{outType}').");
             }
 
             logger.LogDebug("Publishing transformed event for {EventType}", @event.EventType);
-            await bus.Publish(eventData, outType, ct);
+            await bus.Publish(
+                eventData,
+                outType,
+                context =>
+                {
+                    context.MessageId = @event.Id;
+                    context.Headers.Set("EventStore-StreamId", @event.StreamId);
+                    context.Headers.Set("EventStore-TenantId", @event.TenantId);
+                    context.Headers.Set("EventStore-StreamVersion", @event.Version);
+                },
+                ct);
             logger.LogDebug("Published transformed event successfully");
         }
 

--- a/src/EventStoreCore.SDK/IEventStoreEndpointsClient.cs
+++ b/src/EventStoreCore.SDK/IEventStoreEndpointsClient.cs
@@ -31,9 +31,9 @@ public interface IEventStoreEndpointsClient
     /// </summary>
     /// <param name="name">The projection name.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The projection status, or null when not found.</returns>
+    /// <returns>The HTTP response. A missing projection is represented by a 404 status.</returns>
     [Get("/projections/{name}")]
-    Task<ProjectionStatusDto?> GetProjectionAsync(string name, CancellationToken ct = default);
+    Task<ApiResponse<ProjectionStatusDto>> GetProjectionAsync(string name, CancellationToken ct = default);
 
     /// <summary>
     /// Gets the tenant-scoped status of a specific projection.
@@ -41,9 +41,9 @@ public interface IEventStoreEndpointsClient
     /// <param name="name">The projection name.</param>
     /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The projection status, or null when not found.</returns>
+    /// <returns>The HTTP response. A missing projection is represented by a 404 status.</returns>
     [Get("/projections/{name}")]
-    Task<ProjectionStatusDto?> GetProjectionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+    Task<ApiResponse<ProjectionStatusDto>> GetProjectionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Triggers a rebuild of the specified projection.
@@ -92,9 +92,9 @@ public interface IEventStoreEndpointsClient
     /// </summary>
     /// <param name="name">The projection name.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The failed event details, or null when not found.</returns>
+    /// <returns>The HTTP response. Missing failed-event details are represented by a 404 status.</returns>
     [Get("/projections/{name}/failed-event")]
-    Task<FailedEventDto?> GetFailedEventAsync(string name, CancellationToken ct = default);
+    Task<ApiResponse<FailedEventDto>> GetFailedEventAsync(string name, CancellationToken ct = default);
 
     /// <summary>
     /// Gets details about the failed event for a tenant-scoped faulted projection.
@@ -102,9 +102,9 @@ public interface IEventStoreEndpointsClient
     /// <param name="name">The projection name.</param>
     /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The failed event details, or null when not found.</returns>
+    /// <returns>The HTTP response. Missing failed-event details are represented by a 404 status.</returns>
     [Get("/projections/{name}/failed-event")]
-    Task<FailedEventDto?> GetFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+    Task<ApiResponse<FailedEventDto>> GetFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Retries processing the failed event.
@@ -162,9 +162,9 @@ public interface IEventStoreEndpointsClient
     /// </summary>
     /// <param name="name">The subscription name.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The subscription status, or null when not found.</returns>
+    /// <returns>The HTTP response. A missing subscription is represented by a 404 status.</returns>
     [Get("/subscriptions/{name}")]
-    Task<SubscriptionStatusDto?> GetSubscriptionAsync(string name, CancellationToken ct = default);
+    Task<ApiResponse<SubscriptionStatusDto>> GetSubscriptionAsync(string name, CancellationToken ct = default);
 
     /// <summary>
     /// Gets the tenant-scoped status of a specific subscription.
@@ -172,9 +172,9 @@ public interface IEventStoreEndpointsClient
     /// <param name="name">The subscription name.</param>
     /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The subscription status, or null when not found.</returns>
+    /// <returns>The HTTP response. A missing subscription is represented by a 404 status.</returns>
     [Get("/subscriptions/{name}")]
-    Task<SubscriptionStatusDto?> GetSubscriptionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+    Task<ApiResponse<SubscriptionStatusDto>> GetSubscriptionForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Pauses processing of the specified subscription.
@@ -215,9 +215,9 @@ public interface IEventStoreEndpointsClient
     /// </summary>
     /// <param name="name">The subscription name.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The failed event details, or null when not found.</returns>
+    /// <returns>The HTTP response. Missing failed-event details are represented by a 404 status.</returns>
     [Get("/subscriptions/{name}/failed-event")]
-    Task<SubscriptionFailedEventDto?> GetSubscriptionFailedEventAsync(string name, CancellationToken ct = default);
+    Task<ApiResponse<SubscriptionFailedEventDto>> GetSubscriptionFailedEventAsync(string name, CancellationToken ct = default);
 
     /// <summary>
     /// Gets details about the failed event for a tenant-scoped faulted or dead-lettered subscription.
@@ -225,9 +225,9 @@ public interface IEventStoreEndpointsClient
     /// <param name="name">The subscription name.</param>
     /// <param name="tenantId">The tenant identifier for the checkpoint scope.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The failed event details, or null when not found.</returns>
+    /// <returns>The HTTP response. Missing failed-event details are represented by a 404 status.</returns>
     [Get("/subscriptions/{name}/failed-event")]
-    Task<SubscriptionFailedEventDto?> GetSubscriptionFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
+    Task<ApiResponse<SubscriptionFailedEventDto>> GetSubscriptionFailedEventForTenantAsync(string name, [Query] Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Retries processing the failed subscription event.

--- a/src/EventStoreCore/DbContextEventStore.cs
+++ b/src/EventStoreCore/DbContextEventStore.cs
@@ -52,6 +52,8 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
         ArgumentNullException.ThrowIfNull(events);
 
         var eventList = events.ToArray();
+        ValidateEventPayloads(eventList, nameof(events));
+        var unrelatedChanges = CaptureUnrelatedChanges();
         var stream = await db.Set<DbStream>()
             .Where(x => x.TenantId == tenantId && x.StreamType == streamType)
             .Include(x => x.Events)
@@ -88,6 +90,7 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
         };
 
         new DbContextStream(stream, db).Append(eventList);
+        SuppressUnrelatedChanges(unrelatedChanges);
 
         try
         {
@@ -96,6 +99,11 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
         }
         catch (DbUpdateException ex) when (IsEventStoreWriteConflict(ex))
         {
+            foreach (var entry in ex.Entries.Where(entry => entry.Entity is DbEvent or DbStream))
+            {
+                entry.State = EntityState.Detached;
+            }
+
             var actualVersion = await GetActualVersionAsync(streamType, streamId, tenantId, cancellationToken);
 
             throw CreateConcurrencyException(
@@ -106,6 +114,10 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
                 actualVersion,
                 "Append failed because another writer modified the stream concurrently.",
                 ex);
+        }
+        finally
+        {
+            RestoreUnrelatedChanges(unrelatedChanges);
         }
     }
 
@@ -181,6 +193,7 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
             .Include(x => x.Events.Where(x => x.Version <= version))
             .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
         if (stream is null) return null;
+        stream.CurrentVersion = Math.Min(version, stream.CurrentVersion);
         return new DbContextStream(stream);
     }
 
@@ -212,6 +225,7 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
             .Include(x => x.Events.Where(x => x.Version > snapshotVersion && x.Version <= version))
             .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
         if (stream is null) return null;
+        stream.CurrentVersion = Math.Min(version, stream.CurrentVersion);
         return new DbContextStream<T>(stream, db, DeserializeSnapshot<T>(snapshot));
     }
 
@@ -276,6 +290,10 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
     /// <inheritdoc />
     public IStream StartStream(string streamType, Guid streamId, Guid tenantId, params IEnumerable<object> events)
     {
+        ArgumentNullException.ThrowIfNull(events);
+        var eventList = events.ToArray();
+        ValidateEventPayloads(eventList, nameof(events));
+
         var dbStream = new DbStream
         {
             Id = streamId,
@@ -288,7 +306,7 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
         db.Add(dbStream);
         var stream = new DbContextStream(dbStream, db);
 
-        stream.Append(events);
+        stream.Append(eventList);
         return stream;
     }
 
@@ -307,10 +325,14 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
     /// <inheritdoc />
     public IStream<T> StartStream<T>(string streamType, Guid streamId, Guid tenantId, params IEnumerable<object> events) where T : IState, new()
     {
+        ArgumentNullException.ThrowIfNull(events);
+        var eventList = events.ToArray();
+        ValidateEventPayloads(eventList, nameof(events));
+
         var dbStream = CreateStream(streamType, streamId, tenantId);
         var stream = new DbContextStream<T>(dbStream, db);
 
-        stream.Append(events);
+        stream.Append(eventList);
         return stream;
     }
 
@@ -338,13 +360,57 @@ public sealed class DbContextEventStore(DbContext db) : IEventStore
 
     private async Task<long?> GetActualVersionAsync(string streamType, Guid streamId, Guid tenantId, CancellationToken cancellationToken)
     {
-        db.ChangeTracker.Clear();
-
         return await db.Set<DbStream>()
             .AsNoTracking()
             .Where(stream => stream.Id == streamId && stream.StreamType == streamType && stream.TenantId == tenantId)
             .Select(stream => (long?)stream.CurrentVersion)
             .SingleOrDefaultAsync(cancellationToken);
+    }
+
+    private IReadOnlyList<SuppressedEntry> CaptureUnrelatedChanges()
+    {
+        return db.ChangeTracker.Entries()
+            .Where(entry =>
+                entry.Entity is not DbEvent and not DbStream &&
+                entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+            .Select(entry => new SuppressedEntry(entry.Entity, entry.State))
+            .ToArray();
+    }
+
+    private void SuppressUnrelatedChanges(IEnumerable<SuppressedEntry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            db.Entry(entry.Entity).State = entry.State == EntityState.Added
+                ? EntityState.Detached
+                : EntityState.Unchanged;
+        }
+    }
+
+    private void RestoreUnrelatedChanges(IEnumerable<SuppressedEntry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            var trackedEntry = db.Entry(entry.Entity);
+            trackedEntry.State = entry.State;
+        }
+    }
+
+    private sealed record SuppressedEntry(object Entity, EntityState State);
+
+    private static void ValidateEventPayloads(IEnumerable<object> events, string parameterName)
+    {
+        foreach (var @event in events)
+        {
+            ArgumentNullException.ThrowIfNull(@event, parameterName);
+            var eventType = @event.GetType();
+            if (eventType.IsValueType)
+            {
+                throw new ArgumentException(
+                    $"Event payload type '{eventType.FullName}' is a value type. Event payloads must be reference types.",
+                    parameterName);
+            }
+        }
     }
 
     private static bool IsUniqueConstraintViolation(Exception exception)

--- a/src/EventStoreCore/DbContextStream.cs
+++ b/src/EventStoreCore/DbContextStream.cs
@@ -71,10 +71,21 @@ public class DbContextStream : IStream
     /// <inheritdoc />
     public void Append(params IEnumerable<object> events)
     {
+        ArgumentNullException.ThrowIfNull(events);
+
         var previousVersion = _dbStream.CurrentVersion;
         foreach (var @event in events)
         {
+            ArgumentNullException.ThrowIfNull(@event);
+
             var eventType = @event.GetType();
+            if (eventType.IsValueType)
+            {
+                throw new ArgumentException(
+                    $"Event payload type '{eventType.FullName}' is a value type. Event payloads must be reference types.",
+                    nameof(events));
+            }
+
             var typeName = _registry?.ResolveName(eventType) ?? EventTypeNameHelper.ToSnakeCase(eventType);
             var dbEvent = new DbEvent
             {

--- a/src/EventStoreCore/DbProjectionStatus.cs
+++ b/src/EventStoreCore/DbProjectionStatus.cs
@@ -70,10 +70,13 @@ public sealed class DbProjectionStatus
     /// <summary>
     /// Converts this entity to a DTO for external consumption.
     /// </summary>
-    public ProjectionStatusDto ToDto()
+    /// <param name="totalEvents">The current number of events in this checkpoint scope.</param>
+    /// <param name="processedEvents">The number of events at or before <see cref="Position" />.</param>
+    public ProjectionStatusDto ToDto(long? totalEvents = null, long? processedEvents = null)
     {
-        var progress = CheckpointScope == Abstractions.CheckpointScope.Global && TotalEvents.HasValue && TotalEvents.Value > 0
-            ? Math.Round((double)Position / TotalEvents.Value * 100, 2)
+        var effectiveTotal = totalEvents ?? TotalEvents;
+        var progress = effectiveTotal.HasValue && effectiveTotal.Value > 0
+            ? Math.Min(100, Math.Round((double)(processedEvents ?? Position) / effectiveTotal.Value * 100, 2))
             : (double?)null;
 
         return new ProjectionStatusDto(
@@ -81,7 +84,7 @@ public sealed class DbProjectionStatus
             Version,
             State,
             Position,
-            TotalEvents,
+            effectiveTotal,
             progress,
             LastProcessedAt,
             LastError,

--- a/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
+++ b/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
@@ -41,7 +41,7 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
         }
         else
         {
-            services.AddSingleton<ISubscription>(sp => new EventualProjectionSubscription<TDbContext, TProjection, TSnapshot>(options, sp));
+            services.AddSingleton<ISubscription>(_ => new EventualProjectionSubscription<TDbContext, TProjection, TSnapshot>(options));
         }
     }
 
@@ -58,10 +58,12 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
         Action<SubscriptionOptions>? configure = null)
     {
         services.TryAddSingleton(factory);
-        services.Configure<SubscriptionOptions>(opts =>
-        {
-            configure?.Invoke(opts);
-        });
+        services.AddOptions<SubscriptionOptions>()
+            .Configure(opts => configure?.Invoke(opts))
+            .Validate(
+                opts => opts.LockTimeout >= TimeSpan.Zero || opts.LockTimeout == Timeout.InfiniteTimeSpan,
+                $"{nameof(SubscriptionOptions.LockTimeout)} must be non-negative or Timeout.InfiniteTimeSpan.")
+            .ValidateOnStart();
         services.TryAddSingleton<SubscriptionDaemon<TDbContext>>();
         services.TryAddScoped<ISubscriptionManager>(sp =>
         {
@@ -81,10 +83,12 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
     {
         services.TryAddSingleton(lockProviderFactory);
 
-        services.Configure<ProjectionDaemonOptions>(opts =>
-        {
-            configure?.Invoke(opts);
-        });
+        services.AddOptions<ProjectionDaemonOptions>()
+            .Configure(opts => configure?.Invoke(opts))
+            .Validate(
+                opts => opts.LockTimeout >= TimeSpan.Zero || opts.LockTimeout == Timeout.InfiniteTimeSpan,
+                $"{nameof(ProjectionDaemonOptions.LockTimeout)} must be non-negative or Timeout.InfiniteTimeSpan.")
+            .ValidateOnStart();
 
         services.TryAddSingleton<ProjectionDaemon<TDbContext>>();
         services.AddHostedService(sp => sp.GetRequiredService<ProjectionDaemon<TDbContext>>());
@@ -95,7 +99,8 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
             var lockProvider = sp.GetRequiredService<IDistributedLockProvider>();
             var projections = sp.GetServices<ProjectionRegistration>();
             var logger = sp.GetRequiredService<ILogger<ProjectionManager<TDbContext>>>();
-            return new ProjectionManager<TDbContext>(dbContext, lockProvider, projections, logger);
+            var options = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ProjectionDaemonOptions>>();
+            return new ProjectionManager<TDbContext>(dbContext, lockProvider, projections, logger, sp, options);
         });
     }
 
@@ -107,9 +112,9 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
         where TProjection : IProjection<TSnapshot>, new()
         where TSnapshot : class, new()
     {
-        Func<DbContext, CancellationToken, Task> clearAction = async (db, ct) =>
+        Func<DbContext, IServiceProvider, CancellationToken, Task> clearAction = async (db, serviceProvider, ct) =>
         {
-            var context = new ProjectionContext(db, null!);
+            var context = new ProjectionContext(db, serviceProvider);
             await TProjection.ClearAsync(context, ct);
         };
 

--- a/src/EventStoreCore/EventStoreBuilderEfCoreExtensions.cs
+++ b/src/EventStoreCore/EventStoreBuilderEfCoreExtensions.cs
@@ -14,13 +14,23 @@ public static class EventStoreBuilderEfCoreExtensions
     private static (IProjectionRegistrar Projections, ISubscriptionDaemonRegistrar Daemon, IProjectionDaemonRegistrar ProjectionDaemon) GetProvider<TDbContext>(IEventStoreBuilder builder)
         where TDbContext : DbContext
     {
-        if (builder.Provider is IProjectionRegistrar proj &&
+        if (builder.Provider is IEfCoreEventStoreBuilder<TDbContext> &&
+            builder.Provider is IProjectionRegistrar proj &&
             builder.Provider is ISubscriptionDaemonRegistrar daemon &&
             builder.Provider is IProjectionDaemonRegistrar projectionDaemon)
         {
             return (proj, daemon, projectionDaemon);
         }
-        throw new InvalidOperationException("No EF Core provider is registered. Call ExistingDbContext<TDbContext>() first.");
+        var configuredType = builder.Provider?.GetType().GetInterfaces()
+            .FirstOrDefault(type =>
+                type.IsGenericType &&
+                type.GetGenericTypeDefinition() == typeof(IEfCoreEventStoreBuilder<>))
+            ?.GetGenericArguments()[0];
+
+        throw configuredType is null
+            ? new InvalidOperationException("No EF Core provider is registered. Call ExistingDbContext<TDbContext>() first.")
+            : new InvalidOperationException(
+                $"The EF Core provider is configured for DbContext '{configuredType.FullName}', not '{typeof(TDbContext).FullName}'.");
     }
 
     /// <summary>
@@ -32,6 +42,12 @@ public static class EventStoreBuilderEfCoreExtensions
     public static IEfCoreEventStoreBuilder<TDbContext> ExistingDbContext<TDbContext>(this IEventStoreBuilder builder)
         where TDbContext : DbContext
     {
+        if (builder.Provider is not null)
+        {
+            throw new InvalidOperationException(
+                $"An event-store provider is already configured as '{builder.Provider.GetType().FullName}'. Configure exactly one EF Core DbContext.");
+        }
+
         var efBuilder = new EfCoreEventEventStoreBuilder<TDbContext>(builder.Services);
 
         builder.Services.AddSingleton<ISchedulerEventApplicationStore, EfCoreSchedulerEventApplicationStore<TDbContext>>();

--- a/src/EventStoreCore/EventualProjectionSubscription.cs
+++ b/src/EventStoreCore/EventualProjectionSubscription.cs
@@ -16,17 +16,14 @@ public sealed class EventualProjectionSubscription<TDbContext, TProjection, TSna
     where TSnapshot : class, new()
 {
     private readonly ProjectionOptions _options;
-    private readonly IServiceProvider _services;
 
     /// <summary>
     /// Creates a subscription that executes projections via the daemon pipeline.
     /// </summary>
     /// <param name="options">Projection options.</param>
-    /// <param name="services">Service provider for resolving dependencies.</param>
-    public EventualProjectionSubscription(ProjectionOptions options, IServiceProvider services)
+    public EventualProjectionSubscription(ProjectionOptions options)
     {
         _options = options;
-        _services = services;
     }
 
     /// <summary>
@@ -45,9 +42,14 @@ public sealed class EventualProjectionSubscription<TDbContext, TProjection, TSna
     /// Handles an event using the projection and DbContext scope.
     /// </summary>
     /// <param name="dbContext">The DbContext scope used for persistence.</param>
+    /// <param name="services">The application service provider for the active daemon scope.</param>
     /// <param name="event">The event to process.</param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task HandleAsync(DbContext dbContext, IEvent @event, CancellationToken ct)
+    public async Task HandleAsync(
+        DbContext dbContext,
+        IServiceProvider services,
+        IEvent @event,
+        CancellationToken ct)
     {
         if (!_options.IsHandeled(@event.EventType))
         {
@@ -61,7 +63,7 @@ public sealed class EventualProjectionSubscription<TDbContext, TProjection, TSna
             .Set<TSnapshot>()
             .FindAsync([key], ct);
 
-        var projectionContext = new ProjectionContext(dbContext, _services);
+        var projectionContext = new ProjectionContext(dbContext, services);
 
         if (snapshot is null)
         {

--- a/src/EventStoreCore/IScopedSubscription.cs
+++ b/src/EventStoreCore/IScopedSubscription.cs
@@ -13,8 +13,9 @@ public interface IScopedSubscription : ISubscription
     /// Processes an event using the provided DbContext scope.
     /// </summary>
     /// <param name="dbContext">The DbContext scope for persistence.</param>
+    /// <param name="services">The application service provider for the active scope.</param>
     /// <param name="event">The event to handle.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task HandleAsync(DbContext dbContext, IEvent @event, CancellationToken ct);
+    Task HandleAsync(DbContext dbContext, IServiceProvider services, IEvent @event, CancellationToken ct);
 }
 

--- a/src/EventStoreCore/ProjectionDaemon.cs
+++ b/src/EventStoreCore/ProjectionDaemon.cs
@@ -125,7 +125,7 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
         {
             lockHandle = await _distributedLockProvider.TryAcquireLockAsync(
                 lockName,
-                TimeSpan.FromSeconds(2),
+                ValidateLockTimeout(_options.LockTimeout),
                 ct);
 
             if (lockHandle == null)
@@ -155,18 +155,18 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
                     "Projection {Projection} version changed from {OldVersion} to {NewVersion}, triggering rebuild",
                     projection.Name, status.Version, projection.Version);
 
-                await InitiateRebuildAsync(dbContext, projection, status, ct);
+                await InitiateRebuildAsync(dbContext, scope.ServiceProvider, projection, status, ct);
             }
 
             // Process based on current state
             switch (status.State)
             {
                 case ProjectionState.Active:
-                    await ProcessEventsAsync(dbContext, projection, status, ct);
+                    await ProcessEventsAsync(dbContext, scope.ServiceProvider, projection, status, ct);
                     break;
 
                 case ProjectionState.Rebuilding:
-                    await ContinueRebuildAsync(dbContext, projection, status, ct);
+                    await ContinueRebuildAsync(dbContext, scope.ServiceProvider, projection, status, ct);
                     break;
 
                 case ProjectionState.Paused:
@@ -186,6 +186,17 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
                 _logger.LogDebug("Released lock for projection {Projection}", projection.Name);
             }
         }
+    }
+
+    private static TimeSpan ValidateLockTimeout(TimeSpan timeout)
+    {
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(ProjectionDaemonOptions.LockTimeout)} must be non-negative or Timeout.InfiniteTimeSpan.");
+        }
+
+        return timeout;
     }
 
     /// <summary>
@@ -232,11 +243,13 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     /// Initiates a projection rebuild by clearing data and resetting status.
     /// </summary>
     /// <param name="dbContext">The DbContext used for persistence.</param>
+    /// <param name="services">The application service provider for the active daemon scope.</param>
     /// <param name="projection">The projection registration.</param>
     /// <param name="status">The current projection status.</param>
     /// <param name="ct">Cancellation token.</param>
     internal async Task InitiateRebuildAsync(
         TDbContext dbContext,
+        IServiceProvider services,
         ProjectionRegistration projection,
         DbProjectionStatus status,
         CancellationToken ct)
@@ -262,7 +275,7 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
 
         // Clear projection data
         _logger.LogInformation("Clearing data for projection {Projection}", projection.Name);
-        await projection.ClearAction(dbContext, ct);
+        await projection.ClearAction(dbContext, services, ct);
         await dbContext.SaveChangesAsync(ct);
 
         _logger.LogInformation("Rebuild initiated for projection {Projection}, replaying {Total} events", 
@@ -273,16 +286,18 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     /// Continues a rebuild by processing the next batch of events.
     /// </summary>
     /// <param name="dbContext">The DbContext used for persistence.</param>
+    /// <param name="services">The application service provider for the active daemon scope.</param>
     /// <param name="projection">The projection registration.</param>
     /// <param name="status">The current projection status.</param>
     /// <param name="ct">Cancellation token.</param>
     private async Task ContinueRebuildAsync(
         TDbContext dbContext,
+        IServiceProvider services,
         ProjectionRegistration projection,
         DbProjectionStatus status,
         CancellationToken ct)
     {
-        var processed = await ProcessBatchAsync(dbContext, projection, status, ct);
+        var processed = await ProcessBatchAsync(dbContext, services, projection, status, ct);
 
 
         if (!processed)
@@ -303,16 +318,18 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     /// Processes new events for an active projection.
     /// </summary>
     /// <param name="dbContext">The DbContext used for persistence.</param>
+    /// <param name="services">The application service provider for the active daemon scope.</param>
     /// <param name="projection">The projection registration.</param>
     /// <param name="status">The current projection status.</param>
     /// <param name="ct">Cancellation token.</param>
     private async Task ProcessEventsAsync(
         TDbContext dbContext,
+        IServiceProvider services,
         ProjectionRegistration projection,
         DbProjectionStatus status,
         CancellationToken ct)
     {
-        var processed = await ProcessBatchAsync(dbContext, projection, status, ct);
+        var processed = await ProcessBatchAsync(dbContext, services, projection, status, ct);
 
 
         if (!processed)
@@ -332,6 +349,7 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     /// <returns>True when events were processed; false when no events were available.</returns>
     private async Task<bool> ProcessBatchAsync(
         TDbContext dbContext,
+        IServiceProvider services,
         ProjectionRegistration projection,
         DbProjectionStatus status,
         CancellationToken ct)
@@ -392,7 +410,7 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
                 var isNew = dbContext.Entry(snapshot).State == EntityState.Detached;
 
                 // Apply the event
-                await projection.EvolveAction(dbContext, _serviceProvider, snapshot, @event, ct);
+                await projection.EvolveAction(dbContext, services, snapshot, @event, ct);
 
                 // Add snapshot if it was new
                 if (isNew)

--- a/src/EventStoreCore/ProjectionDaemonOptions.cs
+++ b/src/EventStoreCore/ProjectionDaemonOptions.cs
@@ -21,7 +21,8 @@ public sealed class ProjectionDaemonOptions
     public TimeSpan PollingInterval { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
-    /// Maximum time to hold a distributed lock for a projection.
+    /// Maximum time to wait to acquire a distributed lock for a projection.
+    /// The acquired lock is held until its handle is disposed.
     /// Default is 5 minutes.
     /// </summary>
     public TimeSpan LockTimeout { get; set; } = TimeSpan.FromMinutes(5);

--- a/src/EventStoreCore/ProjectionInterceptor.cs
+++ b/src/EventStoreCore/ProjectionInterceptor.cs
@@ -38,6 +38,17 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
     }
 
     /// <inheritdoc />
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        return SavingChangesAsync(eventData, result)
+            .AsTask()
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <inheritdoc />
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,
         InterceptionResult<int> result,
@@ -72,6 +83,7 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
             var dbEventEntries = db.ChangeTracker.Entries<DbEvent>()
                 .Where(e => e.State is EntityState.Added &&
                     e.Entity.StreamId == stream.Entity.Id &&
+                    e.Entity.StreamType == stream.Entity.StreamType &&
                     e.Entity.TenantId == stream.Entity.TenantId)
                 .OrderBy(e => e.Entity.Version)
                 .ToArray();
@@ -222,6 +234,26 @@ public sealed class ProjectionInterceptor<TProjection, TSnapshot> : SaveChangesI
         }
 
         return result;
+    }
+
+    /// <inheritdoc />
+    public override int SavedChanges(
+        SaveChangesCompletedEventData eventData,
+        int result)
+    {
+        return SavedChangesAsync(eventData, result)
+            .AsTask()
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <inheritdoc />
+    public override void SaveChangesFailed(DbContextErrorEventData eventData)
+    {
+        if (eventData.Context is DbContext db)
+        {
+            PendingEvents.Remove(db);
+        }
     }
 
     /// <inheritdoc />

--- a/src/EventStoreCore/ProjectionManager.cs
+++ b/src/EventStoreCore/ProjectionManager.cs
@@ -2,6 +2,7 @@ using EventStoreCore.Abstractions;
 using Medallion.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace EventStoreCore;
 
@@ -17,6 +18,8 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
     private readonly IDistributedLockProvider _lockProvider;
     private readonly IEnumerable<ProjectionRegistration> _projections;
     private readonly ILogger<ProjectionManager<TDbContext>> _logger;
+    private readonly IServiceProvider _services;
+    private readonly ProjectionDaemonOptions _options;
 
     /// <summary>
     /// Creates a new projection manager.
@@ -25,16 +28,22 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
     /// <param name="lockProvider">The distributed lock provider.</param>
     /// <param name="projections">Registered projection metadata.</param>
     /// <param name="logger">The logger instance.</param>
+    /// <param name="services">The active application service scope.</param>
+    /// <param name="options">Projection daemon configuration.</param>
     internal ProjectionManager(
         TDbContext dbContext,
         IDistributedLockProvider lockProvider,
         IEnumerable<ProjectionRegistration> projections,
-        ILogger<ProjectionManager<TDbContext>> logger)
+        ILogger<ProjectionManager<TDbContext>> logger,
+        IServiceProvider services,
+        IOptions<ProjectionDaemonOptions> options)
     {
         _dbContext = dbContext;
         _lockProvider = lockProvider;
         _projections = projections;
         _logger = logger;
+        _services = services;
+        _options = options.Value;
     }
 
     /// <inheritdoc />
@@ -65,7 +74,7 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
                 : CreateDefaultStatus(projectionName, registration.Version, checkpointScope);
         }
 
-        return status.ToDto();
+        return await ToStatusDtoAsync(status, ct);
     }
 
     /// <inheritdoc />
@@ -75,9 +84,11 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
             .AsNoTracking()
             .ToListAsync(ct);
 
-        var result = statuses
-            .Select(status => status.ToDto())
-            .ToList();
+        var result = new List<ProjectionStatusDto>();
+        foreach (var status in statuses)
+        {
+            result.Add(await ToStatusDtoAsync(status, ct));
+        }
 
         foreach (var registration in _projections)
         {
@@ -104,9 +115,11 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
                 s.TenantId == checkpointScope.TenantId)
             .ToListAsync(ct);
 
-        var result = statuses
-            .Select(status => status.ToDto())
-            .ToList();
+        var result = new List<ProjectionStatusDto>();
+        foreach (var status in statuses)
+        {
+            result.Add(await ToStatusDtoAsync(status, ct));
+        }
 
         foreach (var registration in _projections)
         {
@@ -124,29 +137,38 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
     {
         var registration = _projections.FirstOrDefault(p => p.Name == projectionName)
             ?? throw new InvalidOperationException($"Projection '{projectionName}' is not registered.");
+        if (registration.Mode != ProjectionMode.Eventual)
+        {
+            throw new InvalidOperationException(
+                $"Projection '{projectionName}' runs inline and cannot be rebuilt by the eventual projection daemon.");
+        }
 
-        var lockName = $"projection:{projectionName}";
+        var lockName = _options.CheckpointScope == CheckpointScope.Global
+            ? $"projection:{projectionName}"
+            : $"projection-rebuild:{projectionName}";
 
         await using var lockHandle = await _lockProvider.AcquireLockAsync(lockName, cancellationToken: ct);
 
         _logger.LogInformation("Initiating manual rebuild for projection {Projection}", projectionName);
 
-        var existingTenantScopeIds = await _dbContext.Set<DbProjectionStatus>()
-            .AsNoTracking()
-            .Where(s =>
-                s.ProjectionName == projectionName &&
-                s.CheckpointScope == CheckpointScope.Tenant)
-            .Select(s => s.TenantId)
-            .Distinct()
-            .ToListAsync(ct);
+        var existingTenantScopeIds = _options.CheckpointScope == CheckpointScope.Tenant
+            ? await _dbContext.Set<DbProjectionStatus>()
+                .AsNoTracking()
+                .Where(s =>
+                    s.ProjectionName == projectionName &&
+                    s.CheckpointScope == CheckpointScope.Tenant)
+                .Select(s => s.TenantId)
+                .Distinct()
+                .ToListAsync(ct)
+            : [];
 
-        var eventTenantScopeIds = existingTenantScopeIds.Count == 0
-            ? []
-            : await _dbContext.Events
+        var eventTenantScopeIds = _options.CheckpointScope == CheckpointScope.Tenant
+            ? await _dbContext.Events
                 .AsNoTracking()
                 .Select(e => e.TenantId)
                 .Distinct()
-                .ToListAsync(ct);
+                .ToListAsync(ct)
+            : [];
 
         var tenantScopeIds = existingTenantScopeIds
             .Concat(eventTenantScopeIds)
@@ -164,16 +186,15 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
             }
 
             var statuses = await _dbContext.Set<DbProjectionStatus>()
-                .Where(s => s.ProjectionName == projectionName)
+                .Where(s =>
+                    s.ProjectionName == projectionName &&
+                    s.CheckpointScope == _options.CheckpointScope)
                 .ToListAsync(ct);
 
-            var globalStatus = statuses.FirstOrDefault(s =>
-                s.CheckpointScope == CheckpointScope.Global &&
-                s.TenantId == Guid.Empty);
-
-            if (globalStatus == null)
+            if (_options.CheckpointScope == CheckpointScope.Global &&
+                statuses.All(s => s.TenantId != Guid.Empty))
             {
-                globalStatus = new DbProjectionStatus
+                var globalStatus = new DbProjectionStatus
                 {
                     ProjectionName = projectionName,
                     CheckpointScope = CheckpointScope.Global,
@@ -181,6 +202,25 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
                 };
                 _dbContext.Set<DbProjectionStatus>().Add(globalStatus);
                 statuses.Add(globalStatus);
+            }
+            else if (_options.CheckpointScope == CheckpointScope.Tenant)
+            {
+                foreach (var tenantId in tenantScopeIds)
+                {
+                    if (statuses.Any(s => s.TenantId == tenantId))
+                    {
+                        continue;
+                    }
+
+                    var tenantStatus = new DbProjectionStatus
+                    {
+                        ProjectionName = projectionName,
+                        CheckpointScope = CheckpointScope.Tenant,
+                        TenantId = tenantId
+                    };
+                    _dbContext.Set<DbProjectionStatus>().Add(tenantStatus);
+                    statuses.Add(tenantStatus);
+                }
             }
 
             var rebuildStartedAt = DateTimeOffset.UtcNow;
@@ -191,7 +231,7 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
 
             await _dbContext.SaveChangesAsync(ct);
 
-            await registration.ClearAction(_dbContext, ct);
+            await registration.ClearAction(_dbContext, _services, ct);
             await _dbContext.SaveChangesAsync(ct);
 
             _logger.LogInformation(
@@ -495,5 +535,19 @@ public sealed class ProjectionManager<TDbContext> : IProjectionManager
         return checkpointScope.IsTenant
             ? query.Where(e => e.TenantId == checkpointScope.TenantId)
             : query;
+    }
+
+    private async Task<ProjectionStatusDto> ToStatusDtoAsync(
+        DbProjectionStatus status,
+        CancellationToken ct)
+    {
+        var checkpointScope = new CheckpointScopeKey(status.CheckpointScope, status.TenantId);
+        var events = ApplyCheckpointScope(_dbContext.Events.AsNoTracking(), checkpointScope);
+        var totalEvents = await events.LongCountAsync(ct);
+        var processedEvents = status.Position <= 0
+            ? 0
+            : await events.LongCountAsync(e => e.Sequence <= status.Position, ct);
+
+        return status.ToDto(totalEvents, processedEvents);
     }
 }

--- a/src/EventStoreCore/ProjectionRegistration.cs
+++ b/src/EventStoreCore/ProjectionRegistration.cs
@@ -42,7 +42,7 @@ internal sealed class ProjectionRegistration
     /// <summary>
     /// Action to clear all projection data via IProjection.ClearAsync.
     /// </summary>
-    public required Func<DbContext, CancellationToken, Task> ClearAction { get; init; }
+    public required Func<DbContext, IServiceProvider, CancellationToken, Task> ClearAction { get; init; }
 
     /// <summary>
     /// Action to evolve a snapshot with an event via IProjection.Evolve.

--- a/src/EventStoreCore/SubscriptionDaemon.cs
+++ b/src/EventStoreCore/SubscriptionDaemon.cs
@@ -241,14 +241,25 @@ public sealed class SubscriptionDaemon<TDbContext>(
 
             foreach (var nextEvent in nextEvents)
             {
+                var savepointName = $"before_event_{nextEvent.Sequence}";
+                if (transaction.SupportsSavepoints)
+                {
+                    await transaction.CreateSavepointAsync(savepointName, stoppingToken);
+                }
+
                 try
                 {
                     subscription.LastAttemptAt = DateTimeOffset.UtcNow;
                     var @event = nextEvent.ToEvent(registry);
 
+                    var isScopedSubscription = subscriptionImpl is IScopedSubscription;
                     if (subscriptionImpl is IScopedSubscription scoped)
                     {
-                        await scoped.HandleAsync(dbContext, @event, stoppingToken);
+                        await scoped.HandleAsync(
+                            dbContext,
+                            scope.ServiceProvider,
+                            @event,
+                            stoppingToken);
                     }
                     else
                     {
@@ -264,10 +275,21 @@ public sealed class SubscriptionDaemon<TDbContext>(
                     subscription.NextAttemptAt = null;
                     subscription.FailedEventSequence = null;
 
-                    if (processedCount % checkpointFrequency == 0)
+                    var shouldCheckpoint = processedCount % checkpointFrequency == 0;
+                    if (shouldCheckpoint)
                     {
                         subscription.Sequence = nextEvent.Sequence;
+                    }
+
+                    // Persist handler mutations inside the batch transaction before establishing
+                    // the next event savepoint. They remain invisible until the batch commits.
+                    if (isScopedSubscription || shouldCheckpoint)
+                    {
                         await dbContext.SaveChangesAsync(stoppingToken);
+                    }
+                    if (transaction.SupportsSavepoints)
+                    {
+                        await transaction.ReleaseSavepointAsync(savepointName, stoppingToken);
                     }
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -282,7 +304,30 @@ public sealed class SubscriptionDaemon<TDbContext>(
                         nextEvent.Sequence,
                         name);
 
-                    if (lastProcessedSequence is long persistedSequence && subscription.Sequence != persistedSequence)
+                    if (transaction.SupportsSavepoints)
+                    {
+                        await transaction.RollbackToSavepointAsync(savepointName, stoppingToken);
+                    }
+                    dbContext.ChangeTracker.Clear();
+
+                    subscription = await subscriptionSet.FirstOrDefaultAsync(
+                        s => s.SubscriptionAssemblyQualifiedName == name &&
+                            s.CheckpointScope == checkpointScope.Scope &&
+                            s.TenantId == checkpointScope.TenantId,
+                        stoppingToken)
+                        ?? new DbSubscription
+                        {
+                            SubscriptionAssemblyQualifiedName = name,
+                            CheckpointScope = checkpointScope.Scope,
+                            TenantId = checkpointScope.TenantId
+                        };
+
+                    if (dbContext.Entry(subscription).State == EntityState.Detached)
+                    {
+                        subscriptionSet.Add(subscription);
+                    }
+
+                    if (lastProcessedSequence is long persistedSequence)
                     {
                         subscription.Sequence = persistedSequence;
                     }
@@ -358,7 +403,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 subscriptionName,
                 checkpointScope);
             var acquired = await _distributedLockProvider
-                  .AcquireLockAsync(lockName, TimeSpan.FromSeconds(2), cancellationToken: cancellationToken);
+                  .AcquireLockAsync(lockName, ValidateLockTimeout(_options.LockTimeout), cancellationToken: cancellationToken);
 
             if (acquired == null)
             {
@@ -383,6 +428,17 @@ public sealed class SubscriptionDaemon<TDbContext>(
                     checkpointScope);
             return null;
         }
+    }
+
+    private static TimeSpan ValidateLockTimeout(TimeSpan timeout)
+    {
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(SubscriptionOptions.LockTimeout)} must be non-negative or Timeout.InfiniteTimeSpan.");
+        }
+
+        return timeout;
     }
 
     private async Task<IReadOnlyList<CheckpointScopeKey>> GetCheckpointScopesAsync(

--- a/src/EventStoreCore/SubscriptionManager.cs
+++ b/src/EventStoreCore/SubscriptionManager.cs
@@ -451,9 +451,7 @@ public sealed class SubscriptionManager<TDbContext> : ISubscriptionManager
         var checkpointScope = new CheckpointScopeKey(record.CheckpointScope, record.TenantId);
         var totalEvents = await CountEventsAsync(checkpointScope, ct);
         var lastProcessedAt = await GetLastProcessedAtAsync(record.Sequence, checkpointScope, ct);
-        var processedEvents = checkpointScope.IsTenant
-            ? await CountProcessedEventsAsync(record.Sequence, checkpointScope, ct)
-            : (long?)null;
+        var processedEvents = await CountProcessedEventsAsync(record.Sequence, checkpointScope, ct);
 
         return record.ToDto(totalEvents, lastProcessedAt, processedEvents);
     }

--- a/src/EventStoreCore/SubscriptionOptions.cs
+++ b/src/EventStoreCore/SubscriptionOptions.cs
@@ -1,5 +1,7 @@
 using EventStoreCore.Abstractions;
 
+namespace EventStoreCore;
+
 /// <summary>
 /// Configuration options for subscription processing.
 /// </summary>
@@ -21,7 +23,8 @@ public sealed class SubscriptionOptions
     public TimeSpan PollingInterval { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// Maximum time to hold a distributed lock for a subscription.
+    /// Maximum time to wait to acquire a distributed lock for a subscription.
+    /// The acquired lock is held until its handle is disposed.
     /// </summary>
     public TimeSpan LockTimeout { get; set; } = TimeSpan.FromMinutes(5);
 

--- a/tests/EventStoreCore.Tests/Coverage/CloudEventTransformerCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/CloudEventTransformerCoverageTests.cs
@@ -61,5 +61,32 @@ public class CloudEventTransformerCoverageTests
         Assert.True(result);
         Assert.NotNull(cloudEvent);
         Assert.Equal("type", cloudEvent.Type);
+        Assert.Equal(dbEvent.EventId.ToString("D"), cloudEvent.Id);
+        Assert.Equal(dbEvent.StreamId.ToString("D"), cloudEvent.ExtensionAttributes["streamid"]);
+        Assert.Equal(dbEvent.TenantId.ToString("D"), cloudEvent.ExtensionAttributes["tenantid"]);
+        Assert.Equal(dbEvent.Version.ToString(), cloudEvent.ExtensionAttributes["streamversion"]);
+    }
+
+    [Fact]
+    public void TryTransform_PreservesExplicitCloudEventIdWhenConfigured()
+    {
+        const string customId = "custom-id";
+        var transformerOptions = new CloudEventTransformerOptions();
+        transformerOptions.MapEvent<SampleEvent>(
+            e => new CloudEvent("source", "type", e.Data) { Id = customId },
+            preserveCloudEventId: true);
+        var transformer = new CloudEventTransformer(Options.Create(transformerOptions));
+        var @event = new Event<SampleEvent>(new DbEvent
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Version = 1,
+            Type = typeof(SampleEvent).AssemblyQualifiedName!,
+            Data = "{\"Name\":\"Test\"}"
+        });
+
+        Assert.True(transformer.TryTransform(@event, out var cloudEvent));
+        Assert.Equal(customId, cloudEvent.Id);
     }
 }

--- a/tests/EventStoreCore.Tests/Coverage/MassTransitSubscriptionCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/MassTransitSubscriptionCoverageTests.cs
@@ -58,7 +58,7 @@ public class MassTransitSubscriptionCoverageTests
     }
 
     [Fact]
-    public async Task Handle_LogsAndSkipsWhenTransformReturnsNull()
+    public async Task Handle_ThrowsWhenTransformReturnsNull()
     {
         var transformerOptions = new EventTransformerOptions();
         transformerOptions.AddEvent<SampleEvent, SampleMessage>(_ => null!);
@@ -78,10 +78,10 @@ public class MassTransitSubscriptionCoverageTests
         };
         var @event = new Event<SampleEvent>(dbEvent);
 
-        await subscription.Handle(@event, TestContext.Current.CancellationToken);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            subscription.Handle(@event, TestContext.Current.CancellationToken));
 
-        await bus.DidNotReceiveWithAnyArgs()
-            .Publish(Arg.Any<object>(), Arg.Any<Type>(), Arg.Any<CancellationToken>());
+        Assert.Contains("Transform returned null", exception.Message);
     }
 
     [Fact]
@@ -108,6 +108,10 @@ public class MassTransitSubscriptionCoverageTests
         await subscription.Handle(@event, TestContext.Current.CancellationToken);
 
         await bus.Received(1)
-            .Publish(Arg.Any<SampleMessage>(), Arg.Any<Type>(), Arg.Any<CancellationToken>());
+            .Publish(
+                Arg.Any<SampleMessage>(),
+                Arg.Any<Type>(),
+                Arg.Any<IPipe<PublishContext>>(),
+                Arg.Any<CancellationToken>());
     }
 }

--- a/tests/EventStoreCore.Tests/Coverage/ProjectionDaemonCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/ProjectionDaemonCoverageTests.cs
@@ -46,7 +46,7 @@ public class ProjectionDaemonCoverageTests
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
             Options = options,
-            ClearAction = async (db, ct) =>
+            ClearAction = async (db, _, ct) =>
             {
                 var set = db.Set<ProjectionSnapshot>();
                 foreach (var snapshot in set)
@@ -146,9 +146,10 @@ public class ProjectionDaemonCoverageTests
         db.Set<ProjectionSnapshot>().Add(new ProjectionSnapshot { Id = Guid.NewGuid(), Name = "Old" });
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
+        var provider = new ServiceCollection().AddSingleton(db).BuildServiceProvider();
         var daemon = new ProjectionDaemon<ProjectionDbContext>(
             NullLogger<ProjectionDaemon<ProjectionDbContext>>.Instance,
-            new ServiceCollection().AddSingleton(db).BuildServiceProvider(),
+            provider,
             Substitute.For<IDistributedLockProvider>(),
             Options.Create(new ProjectionDaemonOptions()));
 
@@ -158,7 +159,12 @@ public class ProjectionDaemonCoverageTests
             projectionSet.Remove(snapshot);
         }
 
-        await daemon.InitiateRebuildAsync(db, registration, status, TestContext.Current.CancellationToken);
+        await daemon.InitiateRebuildAsync(
+            db,
+            provider,
+            registration,
+            status,
+            TestContext.Current.CancellationToken);
 
         var updated = await db.Set<DbProjectionStatus>().SingleAsync(TestContext.Current.CancellationToken);
         var snapshotCount = await db.Set<ProjectionSnapshot>().CountAsync(TestContext.Current.CancellationToken);
@@ -186,7 +192,7 @@ public class ProjectionDaemonCoverageTests
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
             Options = options,
-            ClearAction = (_, _) => Task.CompletedTask,
+            ClearAction = (_, _, _) => Task.CompletedTask,
             EvolveAction = (_, _, _, _, _) => throw new InvalidOperationException("boom"),
             GetOrCreateSnapshotAction = (_, _, _) => Task.FromResult<object>(new ProjectionSnapshot()),
             AddSnapshotAction = (_, _) => { }
@@ -232,7 +238,7 @@ public class ProjectionDaemonCoverageTests
 
         Assert.NotNull(processBatchMethod);
 
-        var task = (Task)processBatchMethod!.Invoke(daemon, new object[] { db, registration, status, TestContext.Current.CancellationToken })!;
+        var task = (Task)processBatchMethod!.Invoke(daemon, new object[] { db, provider, registration, status, TestContext.Current.CancellationToken })!;
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
 
         var updated = await db.Set<DbProjectionStatus>().SingleAsync(TestContext.Current.CancellationToken);
@@ -258,7 +264,7 @@ public class ProjectionDaemonCoverageTests
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
             Options = options,
-            ClearAction = (_, _) => Task.CompletedTask,
+            ClearAction = (_, _, _) => Task.CompletedTask,
             EvolveAction = (_, _, snapshot, @event, _) =>
             {
                 evolved = true;
@@ -328,7 +334,7 @@ public class ProjectionDaemonCoverageTests
         var processBatchMethod = typeof(ProjectionDaemon<ProjectionDbContext>)
             .GetMethod("ProcessBatchAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
 
-        var task = (Task<bool>)processBatchMethod.Invoke(daemon, new object[] { db, registration, status, TestContext.Current.CancellationToken })!;
+        var task = (Task<bool>)processBatchMethod.Invoke(daemon, new object[] { db, provider, registration, status, TestContext.Current.CancellationToken })!;
         var result = await task;
 
         Assert.True(result);
@@ -384,7 +390,7 @@ public class ProjectionDaemonCoverageTests
         var processBatchMethod = typeof(ProjectionDaemon<ProjectionDbContext>)
             .GetMethod("ProcessBatchAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
 
-        var task = (Task)processBatchMethod.Invoke(daemon, new object[] { db, registration, status, TestContext.Current.CancellationToken })!;
+        var task = (Task)processBatchMethod.Invoke(daemon, new object[] { db, provider, registration, status, TestContext.Current.CancellationToken })!;
         await Assert.ThrowsAsync<EventMaterializationException>(async () => await task);
     }
 
@@ -407,7 +413,7 @@ public class ProjectionDaemonCoverageTests
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
             Options = options,
-            ClearAction = (_, _) => Task.CompletedTask,
+            ClearAction = (_, _, _) => Task.CompletedTask,
             EvolveAction = (_, _, snapshot, @event, _) =>
             {
                 evolved = true;
@@ -475,7 +481,7 @@ public class ProjectionDaemonCoverageTests
         var processBatchMethod = typeof(ProjectionDaemon<ProjectionDbContext>)
             .GetMethod("ProcessBatchAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
 
-        var task = (Task<bool>)processBatchMethod.Invoke(daemon, new object[] { db, registration, status, TestContext.Current.CancellationToken })!;
+        var task = (Task<bool>)processBatchMethod.Invoke(daemon, new object[] { db, provider, registration, status, TestContext.Current.CancellationToken })!;
         var result = await task;
 
         Assert.True(result);

--- a/tests/EventStoreCore.Tests/Daemons/DaemonHarnessTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/DaemonHarnessTests.cs
@@ -46,7 +46,7 @@ public class DaemonHarnessTests
 
         public Task Handle(IEvent @event, CancellationToken ct) => Task.CompletedTask;
 
-        public Task HandleAsync(DbContext dbContext, IEvent @event, CancellationToken ct)
+        public Task HandleAsync(DbContext dbContext, IServiceProvider services, IEvent @event, CancellationToken ct)
         {
             Handled = true;
             return Task.CompletedTask;
@@ -146,7 +146,7 @@ public class DaemonHarnessTests
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
             Options = options,
-            ClearAction = async (db, ct) =>
+            ClearAction = async (db, _, ct) =>
             {
                 var set = db.Set<ProjectionSnapshot>();
                 foreach (var snapshot in set)

--- a/tests/EventStoreCore.Tests/Daemons/ProjectionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/ProjectionDaemonExecutionTests.cs
@@ -81,7 +81,7 @@ public class ProjectionDaemonExecutionTests
             ProjectionType = typeof(ProjectionSnapshot),
             SnapshotType = typeof(ProjectionSnapshot),
             Options = options,
-            ClearAction = (_, _) => Task.CompletedTask,
+            ClearAction = (_, _, _) => Task.CompletedTask,
             EvolveAction = async (_, _, snapshot, @event, _) =>
             {
                 if (@event is IEvent<ProjectionEvent> evt)

--- a/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
@@ -89,6 +89,26 @@ public class SubscriptionDaemonExecutionTests
         }
     }
 
+    private sealed class MutatingThrowingScopedSubscription : IScopedSubscription
+    {
+        public Task Handle(IEvent @event, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task HandleAsync(
+            DbContext dbContext,
+            IServiceProvider services,
+            IEvent @event,
+            CancellationToken ct)
+        {
+            dbContext.Set<DbProjectionStatus>().Add(new DbProjectionStatus
+            {
+                ProjectionName = "must-not-commit",
+                Position = @event.Version
+            });
+            throw new InvalidOperationException("Scoped handler failed after mutation.");
+        }
+    }
+
     private sealed class TenantPoisonSubscription : ISubscription
     {
         private readonly Guid _poisonTenantId;
@@ -115,6 +135,7 @@ public class SubscriptionDaemonExecutionTests
     private sealed class FakeLockProvider : IDistributedLockProvider
     {
         public bool ReturnNullHandle { get; set; }
+        public TimeSpan? LastAcquireTimeout { get; set; }
 
         public IDistributedLock CreateLock(string name) => new FakeLock(this, name);
     }
@@ -134,6 +155,7 @@ public class SubscriptionDaemonExecutionTests
 
         public ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
+            _provider.LastAcquireTimeout = timeout;
             return new ValueTask<IDistributedSynchronizationHandle>(new FakeHandle());
         }
 
@@ -348,6 +370,58 @@ public class SubscriptionDaemonExecutionTests
         Assert.Equal(SubscriptionState.Faulted, subscriptionEntity!.State);
         Assert.Equal(1, subscriptionEntity.Sequence);
         Assert.Equal(2, subscriptionEntity.FailedEventSequence);
+    }
+
+    [Fact]
+    public async Task AcquireSubscriptionLockAsync_UsesConfiguredTimeout()
+    {
+        var db = BuildDbContext();
+        var subscription = new RecordingSubscription();
+        var provider = BuildProvider(db, subscription);
+        var lockProvider = new FakeLockProvider();
+        var configuredTimeout = TimeSpan.FromSeconds(17);
+        var daemon = new SubscriptionDaemon<ExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            lockProvider,
+            Options.Create(new SubscriptionOptions { LockTimeout = configuredTimeout }));
+
+        await using var handle = await daemon.AcquireSubscriptionLockAsync<RecordingSubscription>(
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(configuredTimeout, lockProvider.LastAcquireTimeout);
+    }
+
+    [Fact]
+    public async Task ProcessNextBatchAsync_RollsBackFailingScopedHandlerMutations()
+    {
+        var db = BuildDbContext();
+        var subscription = new MutatingThrowingScopedSubscription();
+        var provider = BuildProvider(db, subscription);
+        var daemon = new SubscriptionDaemon<ExecutionDbContext>(
+            NullLogger<SubscriptionDaemon<ExecutionDbContext>>.Instance,
+            provider,
+            new FakeLockProvider(),
+            Options.Create(new SubscriptionOptions()));
+
+        db.Streams.StartStream(Guid.NewGuid(), events: [new object()]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await EnsureSequencesAsync(db);
+
+        var processed = await daemon.ProcessNextBatchAsync(
+            provider.CreateScope(),
+            subscription,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, processed);
+        Assert.False(await db.Set<DbProjectionStatus>()
+            .AnyAsync(x => x.ProjectionName == "must-not-commit", TestContext.Current.CancellationToken));
+        var status = await FindSubscriptionAsync(
+            db,
+            subscription.GetType().AssemblyQualifiedName!,
+            CheckpointScope.Global,
+            Guid.Empty);
+        Assert.Equal(SubscriptionState.Faulted, status!.State);
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/DbProjectionStatusTests.cs
+++ b/tests/EventStoreCore.Tests/DbProjectionStatusTests.cs
@@ -168,8 +168,23 @@ public class DbProjectionStatusTests
         // Act
         var dto = status.ToDto();
 
-        // Assert - progress can exceed 100%
-        Assert.Equal(150.0, dto.ProgressPercentage);
+        // Assert - externally reported progress is always bounded.
+        Assert.Equal(100.0, dto.ProgressPercentage);
+    }
+
+    [Fact]
+    public void ToDto_UsesProcessedEventCountWhenSequencesContainGaps()
+    {
+        var status = new DbProjectionStatus
+        {
+            ProjectionName = "GappedProjection",
+            Position = 100,
+            TotalEvents = 4
+        };
+
+        var dto = status.ToDto(totalEvents: 4, processedEvents: 2);
+
+        Assert.Equal(50.0, dto.ProgressPercentage);
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/EndpointClientTests.cs
+++ b/tests/EventStoreCore.Tests/EndpointClientTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using EventStoreCore.SDK;
+using Refit;
+
+namespace EventStoreCore.Tests;
+
+public sealed class EndpointClientTests
+{
+    [Fact]
+    public async Task LookupMethodsExposeNotFoundResponsesWithoutThrowing()
+    {
+        using var httpClient = new HttpClient(new StubHandler(HttpStatusCode.NotFound))
+        {
+            BaseAddress = new Uri("https://event-store.test")
+        };
+        var client = RestService.For<IEventStoreEndpointsClient>(httpClient);
+
+        using var projection = await client.GetProjectionAsync(
+            "missing",
+            TestContext.Current.CancellationToken);
+        using var subscription = await client.GetSubscriptionAsync(
+            "missing",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, projection.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, subscription.StatusCode);
+        Assert.False(projection.IsSuccessful);
+        Assert.False(subscription.IsSuccessful);
+    }
+
+    private sealed class StubHandler(HttpStatusCode statusCode) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(statusCode)
+            {
+                RequestMessage = request
+            });
+        }
+    }
+}

--- a/tests/EventStoreCore.Tests/EventStoreBuilderPostgresExtensionsTests.cs
+++ b/tests/EventStoreCore.Tests/EventStoreBuilderPostgresExtensionsTests.cs
@@ -2,6 +2,7 @@ using EventStoreCore;
 using EventStoreCore.Abstractions;
 using EventStoreCore.Testing;
 using Medallion.Threading;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -20,8 +21,13 @@ public class EventStoreBuilderPostgresExtensionsTests
         public void IgnoreUnknown() { }
     }
 
-    private sealed class FakeRegistrar : IProjectionRegistrar, ISubscriptionDaemonRegistrar, IProjectionDaemonRegistrar
+    private sealed class FakeRegistrar :
+        IEfCoreEventStoreBuilder<EventStoreFixture.EventStoreDbContext>,
+        IProjectionRegistrar,
+        ISubscriptionDaemonRegistrar,
+        IProjectionDaemonRegistrar
     {
+        public IServiceCollection Services { get; } = new ServiceCollection();
         public Func<IServiceProvider, IDistributedLockProvider>? AddedFactory { get; private set; }
         public ProjectionMode? AddedMode { get; private set; }
         public Action<IProjectionOptions>? AddedConfigure { get; private set; }
@@ -196,6 +202,29 @@ public class EventStoreBuilderPostgresExtensionsTests
         Assert.Equal(123, options.BatchSize);
     }
 
+    [Fact]
+    public void BuilderExtensions_RejectMismatchedDbContextType()
+    {
+        var services = new ServiceCollection();
+        var builder = new EventStoreBuilder(services);
+        builder.ExistingDbContext<ContextA>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            builder.AddProjection<ContextB, DummyProjection, DummySnapshot>());
+
+        Assert.Contains(typeof(ContextA).FullName!, exception.Message);
+        Assert.Contains(typeof(ContextB).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public void ExistingDbContext_RejectsRepeatedProviderConfiguration()
+    {
+        var builder = new EventStoreBuilder(new ServiceCollection());
+        builder.ExistingDbContext<ContextA>();
+
+        Assert.Throws<InvalidOperationException>(() => builder.ExistingDbContext<ContextA>());
+    }
+
 
     private class DummyProjection : IProjection<DummySnapshot>
     {
@@ -207,4 +236,7 @@ public class EventStoreBuilderPostgresExtensionsTests
     private class DummySnapshot
     {
     }
+
+    private sealed class ContextA(DbContextOptions<ContextA> options) : DbContext(options);
+    private sealed class ContextB(DbContextOptions<ContextB> options) : DbContext(options);
 }

--- a/tests/EventStoreCore.Tests/EventStoreCore.Tests.csproj
+++ b/tests/EventStoreCore.Tests/EventStoreCore.Tests.csproj
@@ -52,6 +52,7 @@
     <ProjectReference Include="..\..\src\EventStoreCore.EventGrid\EventStoreCore.EventGrid.csproj" />
     <ProjectReference Include="..\..\src\EventStoreCore.MassTransit\EventStoreCore.MassTransit.csproj" />
     <ProjectReference Include="..\..\src\EventStoreCore.Postgres\EventStoreCore.Postgres.csproj" />
+    <ProjectReference Include="..\..\src\EventStoreCore.SDK\EventStoreCore.SDK.csproj" />
     <ProjectReference Include="..\..\src\EventStoreCore.SqlServer\EventStoreCore.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\EventStoreCore.Testing\EventStoreCore.Testing.csproj" />
     <ProjectReference Include="..\..\src\EventStoreCore\EventStoreCore.csproj" />

--- a/tests/EventStoreCore.Tests/EventStoreTests.cs
+++ b/tests/EventStoreCore.Tests/EventStoreTests.cs
@@ -198,7 +198,8 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
         await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         var stream = await eventStore.FetchForReadingAsync(id, version: 2, cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(stream);
-        Assert.Equal(2, stream!.Events.Count);
+        Assert.Equal(2, stream!.Version);
+        Assert.Equal(2, stream.Events.Count);
 
         // Verify that the events are the first two events
         Assert.IsType<IEvent<TestEvent>>(stream.Events[0], exactMatch: false);
@@ -397,7 +398,8 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
                 TestContext.Current.CancellationToken);
 
             Assert.NotNull(stream);
-            Assert.Empty(stream!.Events);
+            Assert.Equal(2, stream!.Version);
+            Assert.Empty(stream.Events);
             Assert.Equal("two", stream.State.Name);
             Assert.Equal(2, stream.State.ApplyCount);
         }
@@ -604,6 +606,46 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
         Assert.NotNull(readStream);
         Assert.Equal(2, readStream!.Events.Count);
         Assert.Equal(2, await GetCurrentVersionAsync(verifyContext, streamId));
+    }
+
+    [Fact]
+    public async Task AppendAsync_DoesNotCommitUnrelatedTrackedChanges()
+    {
+        var streamId = Guid.NewGuid();
+        var snapshot = new ProjectionTests.UserSnapshot
+        {
+            UserId = Guid.NewGuid(),
+            Name = "pending"
+        };
+
+        using var dbContext = eventStoreFixture.CreateNewContext();
+        dbContext.Add(snapshot);
+
+        await dbContext.Streams.AppendAsync(
+            streamId,
+            ExpectedVersion.NoStream,
+            [new TestEvent()],
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(EntityState.Added, dbContext.Entry(snapshot).State);
+
+        using var verifyContext = eventStoreFixture.CreateNewContext();
+        Assert.False(await verifyContext.Set<ProjectionTests.UserSnapshot>()
+            .AnyAsync(x => x.UserId == snapshot.UserId, TestContext.Current.CancellationToken));
+        Assert.NotNull(await verifyContext.Streams.FetchForReadingAsync(
+            streamId,
+            TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void StartStream_RejectsValueTypeEventPayloads()
+    {
+        using var dbContext = eventStoreFixture.CreateNewContext();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            dbContext.Streams.StartStream(Guid.NewGuid(), events: [42]));
+
+        Assert.Contains("reference types", exception.Message);
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/MassTransitSubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/MassTransitSubscriptionTests.cs
@@ -19,9 +19,11 @@ public class MassTransitSubscriptionTests(PostgresFixture fixture) : IClassFixtu
     public class SingleEventConsumer : IConsumer<TestIntegrationEvent>
     {
         public static List<TestIntegrationEvent> HandledEvents { get; } = new();
+        public static Guid? LastMessageId { get; private set; }
         public Task Consume(ConsumeContext<TestIntegrationEvent> context)
         {
             HandledEvents.Add(context.Message);
+            LastMessageId = context.MessageId;
             return Task.CompletedTask;
         }
     }
@@ -98,6 +100,10 @@ public class MassTransitSubscriptionTests(PostgresFixture fixture) : IClassFixtu
             .Where(e => e.StreamId == streamId)
             .Select(e => e.Sequence)
             .SingleAsync(TestContext.Current.CancellationToken);
+        var writtenEventId = await eventStoreDbContext.Events
+            .Where(e => e.StreamId == streamId)
+            .Select(e => e.EventId)
+            .SingleAsync(TestContext.Current.CancellationToken);
 
         var harness = provider.GetTestHarness();
         await harness.Start();
@@ -123,6 +129,7 @@ public class MassTransitSubscriptionTests(PostgresFixture fixture) : IClassFixtu
         Assert.Equal(writtenSequence, subscriptionEntity.Sequence);
         Assert.True(processed, "No event was processed");
         Assert.Single(SingleEventConsumer.HandledEvents);
+        Assert.Equal(writtenEventId, SingleEventConsumer.LastMessageId);
         Assert.IsType<TestIntegrationEvent>(SingleEventConsumer.HandledEvents[0]);
 
 

--- a/tests/EventStoreCore.Tests/ProjectionManagerTests.cs
+++ b/tests/EventStoreCore.Tests/ProjectionManagerTests.cs
@@ -64,7 +64,8 @@ public class ProjectionManagerTests(PostgresFixture fixture) : IClassFixture<Pos
 
     #endregion
 
-    private ServiceProvider BuildServiceProvider()
+    private ServiceProvider BuildServiceProvider(
+        CheckpointScope checkpointScope = CheckpointScope.Global)
     {
         var services = new ServiceCollection();
         services.AddDbContext<TestDbContext>(options =>
@@ -77,7 +78,9 @@ public class ProjectionManagerTests(PostgresFixture fixture) : IClassFixture<Pos
             {
                 p.Handles<TestEvent>();
             });
-            c.AddProjectionDaemon<TestDbContext>(_ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString));
+            c.AddProjectionDaemon<TestDbContext>(
+                _ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString),
+                options => options.CheckpointScope = checkpointScope);
         });
 
         services.AddLogging();
@@ -175,7 +178,15 @@ public class ProjectionManagerTests(PostgresFixture fixture) : IClassFixture<Pos
             // Use reflection to create instance since constructor is internal
             var type = typeof(ProjectionManager<>).MakeGenericType(typeof(EventStoreDbContext));
             var ctor = type.GetConstructors(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)[0];
-            return (IProjectionManager)ctor.Invoke(new object[] { db, lockProvider, Enumerable.Empty<ProjectionRegistration>(), logger });
+            return (IProjectionManager)ctor.Invoke(new object[]
+            {
+                db,
+                lockProvider,
+                Enumerable.Empty<ProjectionRegistration>(),
+                logger,
+                sp,
+                Microsoft.Extensions.Options.Options.Create(new ProjectionDaemonOptions())
+            });
         });
 
         var provider = services.BuildServiceProvider();
@@ -234,7 +245,7 @@ public class ProjectionManagerTests(PostgresFixture fixture) : IClassFixture<Pos
     [Fact]
     public async Task RebuildAsync_ResetsTenantScopedCheckpointsAfterClearingProjectionData()
     {
-        var provider = BuildServiceProvider();
+        var provider = BuildServiceProvider(CheckpointScope.Tenant);
         using var scope = provider.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
         await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
@@ -280,11 +291,9 @@ public class ProjectionManagerTests(PostgresFixture fixture) : IClassFixture<Pos
             .ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Empty(snapshots);
-        Assert.Contains(statuses, status =>
+        Assert.DoesNotContain(statuses, status =>
             status.CheckpointScope == CheckpointScope.Global &&
-            status.TenantId == Guid.Empty &&
-            status.State == ProjectionState.Rebuilding &&
-            status.Position == 0);
+            status.State == ProjectionState.Rebuilding);
         Assert.Contains(statuses, status =>
             status.CheckpointScope == CheckpointScope.Tenant &&
             status.TenantId == tenantA &&

--- a/tests/EventStoreCore.Tests/ProjectionTests.cs
+++ b/tests/EventStoreCore.Tests/ProjectionTests.cs
@@ -270,6 +270,70 @@ public class ProjectionTests(PostgresFixture fixture) : IClassFixture<PostgresFi
         Assert.Equal("Mary Jane", snapshot.Name);
     }
 
+    public sealed class StreamTypeSnapshot
+    {
+        public string Id { get; set; } = string.Empty;
+        public int ApplyCount { get; set; }
+    }
+
+    public sealed class StreamTypeProjection : IProjection<StreamTypeSnapshot>
+    {
+        public static Task Evolve(
+            StreamTypeSnapshot snapshot,
+            IEvent @event,
+            IProjectionContext context,
+            CancellationToken ct)
+        {
+            var typed = (IEvent<UserCreated>)@event;
+            snapshot.Id = typed.Data.Name;
+            snapshot.ApplyCount++;
+            return Task.CompletedTask;
+        }
+
+        public static Task ClearAsync(IProjectionContext context, CancellationToken ct) =>
+            context.DbContext.Set<StreamTypeSnapshot>().ExecuteDeleteAsync(ct);
+    }
+
+    public sealed class StreamTypeProjectionDbContext(
+        DbContextOptions<StreamTypeProjectionDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.UseEventStore();
+            modelBuilder.Entity<StreamTypeSnapshot>().HasKey(x => x.Id);
+        }
+    }
+
+    [Fact]
+    public void InlineProjectionRunsForSynchronousSaveChanges()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<EventStoreDbContext>(options => options.UseNpgsql(fixture.ConnectionString));
+        services.AddEventStore(c =>
+        {
+            c.ExistingDbContext<EventStoreDbContext>();
+            c.AddProjection<EventStoreDbContext, UserProjection, UserSnapshot>(
+                ProjectionMode.Inline,
+                p => p.Handles<UserCreated>());
+        });
+        services.AddLogging();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EventStoreDbContext>();
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+
+        var streamId = Guid.NewGuid();
+        db.Streams.StartStream(streamId, events: [new UserCreated { Name = "sync" }]);
+        db.SaveChanges();
+
+        var snapshot = db.Set<UserSnapshot>().Single(x => x.UserId == streamId);
+        Assert.Equal("sync", snapshot.Name);
+        Assert.NotNull(db.Set<DbProjectionStatus>()
+            .SingleOrDefault(x => x.ProjectionName == typeof(UserProjection).FullName));
+    }
+
     [Fact]
     public async Task InlineProjectionUpdatesStatus()
     {
@@ -447,6 +511,41 @@ public class ProjectionTests(PostgresFixture fixture) : IClassFixture<PostgresFi
         Assert.Equal(tenantA, snapshotA.TenantId);
         Assert.Equal("Tenant B", snapshotB.Name);
         Assert.Equal(tenantB, snapshotB.TenantId);
+    }
+
+    [Fact]
+    public async Task InlineProjectionMatchesStreamTypeWhenStreamIdsOverlap()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<StreamTypeProjectionDbContext>(
+            options => options.UseNpgsql(fixture.ConnectionString));
+        services.AddEventStore(c =>
+        {
+            c.ExistingDbContext<StreamTypeProjectionDbContext>();
+            c.AddProjection<StreamTypeProjectionDbContext, StreamTypeProjection, StreamTypeSnapshot>(
+                ProjectionMode.Inline,
+                p => p.Handles<UserCreated>(e => e.Data.Name));
+        });
+        services.AddLogging();
+
+        using var provider = services.BuildServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<StreamTypeProjectionDbContext>();
+        await db.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        db.Streams.StartStream("orders", streamId, events: [new UserCreated { Name = "orders" }]);
+        db.Streams.StartStream("audit", streamId, events: [new UserCreated { Name = "audit" }]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var snapshots = await db.Set<StreamTypeSnapshot>()
+            .AsNoTracking()
+            .OrderBy(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, snapshots.Count);
+        Assert.All(snapshots, snapshot => Assert.Equal(1, snapshot.ApplyCount));
     }
 
     [Fact]

--- a/tests/EventStoreCore.Tests/SubscriptionLockTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionLockTests.cs
@@ -30,7 +30,9 @@ public class SubscriptionLockTests(PostgresFixture fixture) : IClassFixture<Post
         {
             c.ExistingDbContext<TestDbContext>();
 
-            c.AddSubscriptionDaemon<TestDbContext>(_ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString));
+            c.AddSubscriptionDaemon<TestDbContext>(
+                _ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString),
+                options => options.LockTimeout = TimeSpan.FromMilliseconds(100));
             c.AddSubscription<TestSub>();
         });
 
@@ -57,7 +59,9 @@ public class SubscriptionLockTests(PostgresFixture fixture) : IClassFixture<Post
         services1.AddEventStore(c =>
         {
             c.ExistingDbContext<TestDbContext>();
-            c.AddSubscriptionDaemon<TestDbContext>(_ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString));
+            c.AddSubscriptionDaemon<TestDbContext>(
+                _ => new PostgresDistributedSynchronizationProvider(fixture.ConnectionString),
+                options => options.LockTimeout = TimeSpan.FromMilliseconds(100));
             c.AddSubscription<TestSub>();
         });
         services1.AddLogging();

--- a/tests/EventStoreCore.Tests/SubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionTests.cs
@@ -92,7 +92,7 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
             throw new NotSupportedException("Use HandleAsync for scoped subscription execution.");
         }
 
-        public async Task HandleAsync(DbContext dbContext, IEvent @event, CancellationToken ct)
+        public async Task HandleAsync(DbContext dbContext, IServiceProvider services, IEvent @event, CancellationToken ct)
         {
             DeliveredEventIds.Add(@event.Id);
 


### PR DESCRIPTION
## Summary

Fixes the correctness and API consistency bugs found during the full library review across EventStoreCore, CloudEvents, MassTransit, and the SDK.

## What changed

- makes subscription processing transactional per event, uses scoped services correctly, and preserves failed-event state
- fixes projection discovery, synchronous interception, rebuild scoping, checkpoint progress, and lock-timeout behavior
- preserves historical stream versions and prevents internal appends from persisting unrelated tracked entities
- validates unsupported event payloads before mutating or querying a stream
- returns SDK lookup failures as ApiResponse<T> so callers can handle 404 responses
- stabilizes CloudEvent and MassTransit message identity and includes stream metadata
- validates EF Core builder/provider combinations and exposes subscription options from the expected namespace
- adds the missing direct Azure.Core package dependency
- treats null MassTransit transformations as failures so events are not silently checkpointed
- adds regression tests for every corrected behavior

## Validation

- dotnet build EventStoreCore.slnx --no-restore — passed with 0 errors
- dotnet test EventStoreCore.slnx --no-build --no-restore --blame-hang --blame-hang-timeout 3m — 246/246 tests passed
- generated CloudEvents NuGet package contains the direct Azure.Core dependency
- git diff --cached --check — passed

A pre-existing NU1903 advisory remains for SQLitePCLRaw.lib.e_sqlite3 2.1.11 in the test projects.

Closes #24
Closes #47
Closes #48
Closes #51
Closes #52
Closes #53
Closes #54
Closes #55
Closes #56
Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #77