### PR TITLE
Global event-log reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,50 @@ EventStore now persists a logical event type name in `DbEvent.TypeName`. By defa
 2. Populate `TypeName` for existing rows using your preferred backfill process.
 3. Optionally tighten constraints (remove the default or enforce non-empty values) once values are populated.
 
+## Global event-log reads
+
+Use `IEventLogReader` to consume persisted events across every stream in
+ascending global sequence order. `ExistingDbContext<TDbContext>()` registers a
+scoped reader for dependency injection, and the same reader is available from
+`dbContext.EventLog`.
+
+```csharp
+var options = new EventLogReadOptions
+{
+    AfterSequence = checkpoint,
+    TenantId = tenantId,
+    StreamTypes = ["orders"],
+    EventTypes = ["order_created", "order_cancelled"],
+    MaxCount = 500
+};
+
+await foreach (var @event in eventLogReader.ReadAsync(options, ct))
+{
+    await export.WriteAsync(@event, ct);
+    checkpoint = @event.Sequence;
+}
+```
+
+`AfterSequence` is exclusive. Each read captures the highest currently visible
+unfiltered sequence, bounded by an explicit `ThroughSequence`. Explicit pages
+return the effective bound as `HeadSequence`; pass the page's `NextSequence` as
+the next `AfterSequence` and preserve `HeadSequence` as `ThroughSequence`.
+Async enumeration performs that continuation automatically and excludes events
+allocated a sequence above its initial bound.
+
+The reader materializes aliases and schema upcasters exactly like stream reads.
+It does not persist consumer checkpoints or make side effects atomic with
+checkpoint storage; custom consumers should remain idempotent. Database
+sequences are allocated before their transactions commit, so concurrently
+in-flight appends can become visible out of allocation order. Live consumers
+that require lossless catch-up should reread an overlap and deduplicate by
+`IEvent.Id`; do not treat an empty filtered page's `HeadSequence` as a strict
+commit fence while append transactions are in flight.
+
+Existing databases require an application-owned migration for the new unique
+`Events.Sequence` index and the `(TenantId, Sequence)`,
+`(StreamType, Sequence)`, and `(TypeName, Sequence)` read indexes.
+
 ## Stream types
 
 EventStore supports multiple streams with the same ID but different types, enabling scenarios like:
@@ -561,6 +605,8 @@ EventStoreCore model; they do not create or migrate a separate database.
   event versions within that identity.
 - `EventId` values are generated GUIDs with a uniqueness constraint. Treat them
   as stable deduplication keys, not chronological or sequential values.
+- Global event-log reads use the generated `Events.Sequence` value as their
+  stable cross-stream cursor.
 - Inline projections share the caller's EF Core transaction. Subscriptions and
   eventual projections are at-least-once.
 - Daemon locks and provider-specific database migrations remain

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -6,7 +6,7 @@ EventStoreCore is still pre-1.0. Public API changes may be made between beta rel
 
 The supported contracts are deliberately concentrated in these areas:
 
-- `EventStoreCore.Abstractions`: events, typed and untyped streams, event stores, projections, subscriptions, entity-outbox subscriptions, checkpoint scopes, optimistic-concurrency expectations, and their management DTOs.
+- `EventStoreCore.Abstractions`: events, typed and untyped streams, event stores, global event-log reads, projections, subscriptions, entity-outbox subscriptions, checkpoint scopes, optimistic-concurrency expectations, and their management DTOs.
 - `EventStoreCore`: dependency-injection and EF Core builder interfaces and extension methods, projection and subscription options, snapshot configuration, event type registration, projection context helpers, and public operational exceptions.
 - `EventStoreCore.Postgres` and `EventStoreCore.SqlServer`: provider-specific `ModelBuilder.UseEventStore` extensions.
 - `EventStoreCore.CloudEvents`, `EventStoreCore.EventGrid`, and `EventStoreCore.MassTransit`: transport registration, transformation options, and transport subscription contracts.

--- a/docs/global-event-log-reader.md
+++ b/docs/global-event-log-reader.md
@@ -1,0 +1,58 @@
+# Global event-log reader
+
+`IEventLogReader` provides a provider-neutral catch-up read across all persisted
+streams. Resolve it from dependency injection after
+`ExistingDbContext<TDbContext>()`, or access the same implementation through
+`dbContext.EventLog`.
+
+## Cursor model
+
+- `AfterSequence` is an exclusive lower bound.
+- `ThroughSequence` is an optional inclusive upper bound.
+- A read with no explicit upper bound first captures the highest currently
+  visible unfiltered global sequence.
+- `EventLogPage.HeadSequence` contains that visible high-water mark, lowered by
+  an explicit `ThroughSequence` when supplied.
+- `EventLogPage.NextSequence` is the exclusive lower bound for the next page.
+
+For explicit paging, preserve the first page's `HeadSequence` as
+`ThroughSequence` and move `AfterSequence` to `NextSequence`. `ReadAsync`
+handles this automatically and therefore never includes events appended after
+enumeration starts.
+
+The head is intentionally unfiltered, which is useful for bounded rebuilds and
+exports.
+
+## Filters
+
+Filtering happens in the database before page limits are applied:
+
+- one tenant ID;
+- one or more logical stream types;
+- one or more logical event types.
+
+Null or empty stream/event type collections mean no filter. Results are always
+ordered by ascending global sequence. Materialization uses the configured
+serializer, event aliases, and schema upcasters.
+
+## Delivery responsibility
+
+The reader does not own a durable checkpoint and does not coordinate consumer
+side effects. A custom catch-up consumer should store its checkpoint only after
+its side effect succeeds and remain idempotent if those two writes cannot share
+a transaction.
+
+Database sequences are allocated before the append transaction commits.
+Concurrent transactions can therefore become visible out of allocation order.
+For a live feed, reread a suitable sequence overlap and deduplicate by stable
+`IEvent.Id`. In particular, an empty filtered page does not make
+`HeadSequence` a strict commit fence while append transactions are in flight.
+
+## Database migration
+
+Applications own EF Core migrations. Existing databases should add:
+
+- a unique index on `Events.Sequence`;
+- an index on `(TenantId, Sequence)`;
+- an index on `(StreamType, Sequence)`;
+- an index on `(TypeName, Sequence)`.

--- a/eng/PublicApiBaseline.txt
+++ b/eng/PublicApiBaseline.txt
@@ -18,6 +18,7 @@ EventStoreCore.Abstractions|F:EventStoreCore.Abstractions.SubscriptionState.Dead
 EventStoreCore.Abstractions|F:EventStoreCore.Abstractions.SubscriptionState.Faulted
 EventStoreCore.Abstractions|F:EventStoreCore.Abstractions.SubscriptionState.Paused
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.EventAppendExtensions.WithMetadata(System.Object,EventStoreCore.Abstractions.EventMetadata)
+EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.EventLogPage.#ctor(System.Collections.Generic.IReadOnlyList{EventStoreCore.Abstractions.IEvent},System.Int64,System.Nullable{System.Int64})
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.EventMetadata.#ctor(System.Nullable{System.Guid},System.Nullable{System.Guid},System.String,System.Collections.Generic.IReadOnlyDictionary{System.String,System.String})
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.EventStoreReadExtensions.ReadAsync(EventStoreCore.Abstractions.IEventStore,System.Guid,EventStoreCore.Abstractions.StreamReadOptions,System.Threading.CancellationToken)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.EventStoreReadExtensions.ReadAsync(EventStoreCore.Abstractions.IEventStore,System.Guid,System.Guid,EventStoreCore.Abstractions.StreamReadOptions,System.Threading.CancellationToken)
@@ -31,6 +32,8 @@ EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.EventToAppend.#ctor(Sy
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.ExpectedVersion.Exact(System.Int64)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.ExpectedVersion.ToString
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.FailedEventDto.#ctor(System.Guid,System.Guid,System.Int64,System.Int64,System.String,System.String,System.DateTimeOffset,System.String)
+EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IEventLogReader.ReadAsync(EventStoreCore.Abstractions.EventLogReadOptions,System.Threading.CancellationToken)
+EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IEventLogReader.ReadPageAsync(EventStoreCore.Abstractions.EventLogReadOptions,System.Threading.CancellationToken)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IEventStore.AppendAsync(System.Guid,EventStoreCore.Abstractions.ExpectedVersion,System.Collections.Generic.IEnumerable{System.Object},System.Threading.CancellationToken)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IEventStore.AppendAsync(System.Guid,System.Guid,EventStoreCore.Abstractions.ExpectedVersion,System.Collections.Generic.IEnumerable{System.Object},System.Threading.CancellationToken)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IEventStore.AppendAsync(System.String,System.Guid,EventStoreCore.Abstractions.ExpectedVersion,System.Collections.Generic.IEnumerable{System.Object},System.Threading.CancellationToken)
@@ -144,6 +147,16 @@ EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.StreamPage.#ctor(Syste
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.StreamPage`1.#ctor(System.Collections.Generic.IReadOnlyList{EventStoreCore.Abstractions.IEvent{`0}},System.Int64,System.Nullable{System.Int64})
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.SubscriptionFailedEventDto.#ctor(System.Guid,System.Guid,System.Int64,System.Int64,System.String,System.String,System.DateTimeOffset,System.String)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.SubscriptionStatusDto.#ctor(System.String,System.Int64,EventStoreCore.Abstractions.SubscriptionState,System.Nullable{System.Int64},System.Nullable{System.Double},System.Nullable{System.DateTimeOffset},System.String,System.Int32,System.Nullable{System.DateTimeOffset},System.Nullable{System.DateTimeOffset},System.Nullable{System.Int64})
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogPage.Events
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogPage.HasMore
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogPage.HeadSequence
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogPage.NextSequence
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogReadOptions.AfterSequence
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogReadOptions.EventTypes
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogReadOptions.MaxCount
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogReadOptions.StreamTypes
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogReadOptions.TenantId
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventLogReadOptions.ThroughSequence
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventMetadata.Actor
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventMetadata.CausationId
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.EventMetadata.CorrelationId
@@ -278,6 +291,8 @@ EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.SubscriptionStatusDto.
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.CheckpointScope
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.EntityChangeKind
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.EventAppendExtensions
+EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.EventLogPage
+EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.EventLogReadOptions
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.EventMetadata
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.EventStoreReadExtensions
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.EventToAppend
@@ -286,6 +301,7 @@ EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.ExpectedVersionMode
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.FailedEventDto
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEvent
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEvent`1
+EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEventLogReader
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEventStore
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEventStoreSerializer
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IHandler`1
@@ -549,6 +565,7 @@ EventStoreCore|M:EventStoreCore.DbContextEventStore.StartStream``1(System.Guid,S
 EventStoreCore|M:EventStoreCore.DbContextEventStore.StartStream``1(System.Guid,System.Guid,System.Collections.Generic.IEnumerable{System.Object})
 EventStoreCore|M:EventStoreCore.DbContextEventStore.StartStream``1(System.String,System.Guid,System.Collections.Generic.IEnumerable{System.Object})
 EventStoreCore|M:EventStoreCore.DbContextEventStore.StartStream``1(System.String,System.Guid,System.Guid,System.Collections.Generic.IEnumerable{System.Object})
+EventStoreCore|M:EventStoreCore.DbContextExtensions.get_EventLog(Microsoft.EntityFrameworkCore.DbContext)
 EventStoreCore|M:EventStoreCore.DbContextExtensions.get_Streams(Microsoft.EntityFrameworkCore.DbContext)
 EventStoreCore|M:EventStoreCore.DbContextStream.#ctor(EventStoreCore.DbStream)
 EventStoreCore|M:EventStoreCore.DbContextStream.#ctor(EventStoreCore.DbStream,Microsoft.EntityFrameworkCore.DbContext)
@@ -727,6 +744,7 @@ EventStoreCore|P:EventStoreCore.DaemonHealthEntry.LastError
 EventStoreCore|P:EventStoreCore.DaemonHealthEntry.LastHeartbeat
 EventStoreCore|P:EventStoreCore.DaemonHealthReport.Entries
 EventStoreCore|P:EventStoreCore.DaemonHealthReport.Status
+EventStoreCore|P:EventStoreCore.DbContextExtensions.<G>$31ACC19CE081C796BC7AE2F44B832DEE.EventLog
 EventStoreCore|P:EventStoreCore.DbContextExtensions.<G>$31ACC19CE081C796BC7AE2F44B832DEE.Streams
 EventStoreCore|P:EventStoreCore.DbContextStream.Events
 EventStoreCore|P:EventStoreCore.DbContextStream.Id

--- a/src/EventStoreCore.Abstractions/EventLogPage.cs
+++ b/src/EventStoreCore.Abstractions/EventLogPage.cs
@@ -1,0 +1,49 @@
+namespace EventStoreCore.Abstractions;
+
+/// <summary>
+/// A bounded page from the global event log.
+/// </summary>
+public sealed class EventLogPage
+{
+    /// <summary>
+    /// Creates a global event-log page.
+    /// </summary>
+    /// <param name="events">Events in ascending global sequence order.</param>
+    /// <param name="headSequence">
+    /// The highest visible sequence captured before the page query and bounded by the requested upper sequence.
+    /// </param>
+    /// <param name="nextSequence">
+    /// The exclusive lower bound to use for the next page, or null when the filtered range is exhausted.
+    /// </param>
+    public EventLogPage(
+        IReadOnlyList<IEvent> events,
+        long headSequence,
+        long? nextSequence)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        Events = events;
+        HeadSequence = headSequence;
+        NextSequence = nextSequence;
+    }
+
+    /// <summary>
+    /// Events in ascending global sequence order.
+    /// </summary>
+    public IReadOnlyList<IEvent> Events { get; }
+
+    /// <summary>
+    /// The highest visible sequence captured before the page query. Events allocated a higher sequence are excluded,
+    /// and an explicit upper sequence can lower this value.
+    /// </summary>
+    public long HeadSequence { get; }
+
+    /// <summary>
+    /// The exclusive lower bound to use for the next page, or null when the filtered range is exhausted.
+    /// </summary>
+    public long? NextSequence { get; }
+
+    /// <summary>
+    /// Indicates whether another page exists in the filtered range.
+    /// </summary>
+    public bool HasMore => NextSequence.HasValue;
+}

--- a/src/EventStoreCore.Abstractions/EventLogReadOptions.cs
+++ b/src/EventStoreCore.Abstractions/EventLogReadOptions.cs
@@ -1,0 +1,38 @@
+namespace EventStoreCore.Abstractions;
+
+/// <summary>
+/// Configures a bounded global event-log read.
+/// </summary>
+public sealed class EventLogReadOptions
+{
+    /// <summary>
+    /// The exclusive lower global-sequence bound. Defaults to zero.
+    /// </summary>
+    public long AfterSequence { get; set; }
+
+    /// <summary>
+    /// The inclusive upper global-sequence bound. When omitted, the reader captures
+    /// the highest currently visible global sequence before querying.
+    /// </summary>
+    public long? ThroughSequence { get; set; }
+
+    /// <summary>
+    /// The maximum number of events returned by one page. Defaults to 100.
+    /// </summary>
+    public int MaxCount { get; set; } = 100;
+
+    /// <summary>
+    /// Limits the read to one tenant. When omitted, events from every tenant are included.
+    /// </summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>
+    /// Limits the read to the specified logical stream types. Null or an empty collection includes every stream type.
+    /// </summary>
+    public IReadOnlyCollection<string>? StreamTypes { get; set; }
+
+    /// <summary>
+    /// Limits the read to the specified logical event types. Null or an empty collection includes every event type.
+    /// </summary>
+    public IReadOnlyCollection<string>? EventTypes { get; set; }
+}

--- a/src/EventStoreCore.Abstractions/IEventLogReader.cs
+++ b/src/EventStoreCore.Abstractions/IEventLogReader.cs
@@ -1,0 +1,27 @@
+namespace EventStoreCore.Abstractions;
+
+/// <summary>
+/// Reads the persisted event log across all streams in global sequence order.
+/// </summary>
+public interface IEventLogReader
+{
+    /// <summary>
+    /// Reads one bounded page from a stable snapshot of the global event log.
+    /// </summary>
+    /// <param name="options">Sequence bounds, filters, and page size.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A page of events and the captured visible global high-water mark.</returns>
+    Task<EventLogPage> ReadPageAsync(
+        EventLogReadOptions options,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously enumerates a sequence-bounded view of the global event log.
+    /// </summary>
+    /// <param name="options">Sequence bounds, filters, and internal page size.</param>
+    /// <param name="cancellationToken">Cancellation token observed between and during page queries.</param>
+    /// <returns>Matching events in ascending global sequence order.</returns>
+    IAsyncEnumerable<IEvent> ReadAsync(
+        EventLogReadOptions options,
+        CancellationToken cancellationToken = default);
+}

--- a/src/EventStoreCore.Abstractions/README.md
+++ b/src/EventStoreCore.Abstractions/README.md
@@ -2,7 +2,7 @@
 
 Provider-neutral contracts for EventStoreCore events, streams, projections,
 subscriptions, entity-outbox management, checkpoints, metadata, serialization,
-and bounded reads.
+bounded stream reads, and global event-log reads.
 
 ```bash
 dotnet add package EventStoreCore.Abstractions
@@ -14,3 +14,7 @@ contracts and should not depend on EF Core or daemon implementations.
 
 The package contains interfaces and DTOs only. It does not register services,
 configure persistence, or start background workers.
+
+`IEventLogReader`, `EventLogReadOptions`, and `EventLogPage` define portable
+global-sequence paging. The `EventStoreCore` package supplies the EF Core
+implementation and registers it through `ExistingDbContext<TDbContext>()`.

--- a/src/EventStoreCore.Postgres/README.md
+++ b/src/EventStoreCore.Postgres/README.md
@@ -44,10 +44,13 @@ calling `UseEventStore()`.
   `(StreamId, StreamType, TenantId, Version)` key.
 - `EventId` is a generated GUID with a global uniqueness constraint; consumers
   must not rely on GUID ordering.
+- Global event-log reads use the unique `Events.Sequence` index plus filtered
+  sequence indexes for tenant, logical stream type, and logical event type.
 - Inline projections share the append transaction. Subscription and eventual
   projection delivery is at-least-once.
 - Daemons require an application-provided `IDistributedLockProvider`.
 
 Provider-specific database migrations remain application owned. Review generated
 migrations when upgrading EventStoreCore, especially changes to keys, indexes,
-or required metadata columns.
+or required metadata columns. Existing databases adding global event-log reads
+need a migration for the new event sequence indexes.

--- a/src/EventStoreCore.SqlServer/README.md
+++ b/src/EventStoreCore.SqlServer/README.md
@@ -44,10 +44,13 @@ calling `UseEventStore()`.
   `(StreamId, StreamType, TenantId, Version)` key.
 - `EventId` is a generated GUID with a global uniqueness constraint; consumers
   must not rely on GUID ordering.
+- Global event-log reads use the unique `Events.Sequence` index plus filtered
+  sequence indexes for tenant, logical stream type, and logical event type.
 - Inline projections share the append transaction. Subscription and eventual
   projection delivery is at-least-once.
 - Daemons require an application-provided `IDistributedLockProvider`.
 
 Provider-specific database migrations remain application owned. Review generated
 migrations when upgrading EventStoreCore, especially changes to keys, indexes,
-or required metadata columns.
+or required metadata columns. Existing databases adding global event-log reads
+need a migration for the new event sequence indexes.

--- a/src/EventStoreCore/DbContextEventLogReader.cs
+++ b/src/EventStoreCore/DbContextEventLogReader.cs
@@ -1,0 +1,182 @@
+using System.Runtime.CompilerServices;
+using EventStoreCore.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStoreCore;
+
+internal sealed class DbContextEventLogReader(DbContext db) : IEventLogReader
+{
+    private readonly EventTypeRegistry? _eventTypes = ResolveService<EventTypeRegistry>(db);
+    private readonly IEventStoreSerializer _serializer =
+        ResolveService<IEventStoreSerializer>(db) ?? new SystemTextJsonEventStoreSerializer();
+
+    public async Task<EventLogPage> ReadPageAsync(
+        EventLogReadOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        Validate(options);
+
+        var headSequence = await db.Set<DbEvent>()
+            .AsNoTracking()
+            .MaxAsync(@event => (long?)@event.Sequence, cancellationToken)
+            ?? 0;
+        var throughSequence = Math.Min(options.ThroughSequence ?? headSequence, headSequence);
+        if (throughSequence <= options.AfterSequence)
+        {
+            return new EventLogPage([], throughSequence, null);
+        }
+
+        var streamTypes = Normalize(options.StreamTypes);
+        var eventTypes = Normalize(options.EventTypes);
+        IQueryable<DbEvent> query = db.Set<DbEvent>()
+            .AsNoTracking()
+            .Where(@event =>
+                @event.Sequence > options.AfterSequence &&
+                @event.Sequence <= throughSequence);
+
+        if (options.TenantId.HasValue)
+        {
+            query = query.Where(@event => @event.TenantId == options.TenantId.Value);
+        }
+
+        if (streamTypes.Length > 0)
+        {
+            query = query.Where(@event => streamTypes.Contains(@event.StreamType));
+        }
+
+        if (eventTypes.Length > 0)
+        {
+            query = query.Where(@event => eventTypes.Contains(@event.TypeName));
+        }
+
+        var records = await query
+            .OrderBy(@event => @event.Sequence)
+            .Take(options.MaxCount + 1)
+            .ToListAsync(cancellationToken);
+        var hasMore = records.Count > options.MaxCount;
+        if (hasMore)
+        {
+            records.RemoveAt(records.Count - 1);
+        }
+
+        var events = records
+            .Select(@event => @event.ToEvent(_eventTypes, _serializer))
+            .ToArray();
+        return new EventLogPage(
+            events,
+            throughSequence,
+            hasMore ? records[^1].Sequence : null);
+    }
+
+    public async IAsyncEnumerable<IEvent> ReadAsync(
+        EventLogReadOptions options,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        Validate(options);
+
+        var pageOptions = Copy(options);
+        long? headSequence = null;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var page = await ReadPageAsync(pageOptions, cancellationToken);
+            headSequence ??= page.HeadSequence;
+            foreach (var @event in page.Events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return @event;
+            }
+
+            if (!page.NextSequence.HasValue)
+            {
+                yield break;
+            }
+
+            pageOptions.AfterSequence = page.NextSequence.Value;
+            pageOptions.ThroughSequence = Math.Min(
+                options.ThroughSequence ?? headSequence.Value,
+                headSequence.Value);
+        }
+    }
+
+    private static void Validate(EventLogReadOptions options)
+    {
+        if (options.AfterSequence < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.AfterSequence,
+                "The exclusive lower sequence bound cannot be negative.");
+        }
+
+        if (options.ThroughSequence < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.ThroughSequence,
+                "The inclusive upper sequence bound cannot be negative.");
+        }
+
+        if (options.MaxCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.MaxCount,
+                "Page size must be greater than zero.");
+        }
+
+        ValidateFilter(options.StreamTypes, nameof(options.StreamTypes));
+        ValidateFilter(options.EventTypes, nameof(options.EventTypes));
+    }
+
+    private static void ValidateFilter(
+        IReadOnlyCollection<string>? values,
+        string parameterName)
+    {
+        if (values?.Any(value => value is null) == true)
+        {
+            throw new ArgumentException(
+                "Filter values cannot contain null.",
+                parameterName);
+        }
+    }
+
+    private static string[] Normalize(IReadOnlyCollection<string>? values) =>
+        values?
+            .Distinct(StringComparer.Ordinal)
+            .ToArray()
+        ?? [];
+
+    private static EventLogReadOptions Copy(EventLogReadOptions options) =>
+        new()
+        {
+            AfterSequence = options.AfterSequence,
+            ThroughSequence = options.ThroughSequence,
+            MaxCount = options.MaxCount,
+            TenantId = options.TenantId,
+            StreamTypes = Normalize(options.StreamTypes),
+            EventTypes = Normalize(options.EventTypes)
+        };
+
+    private static TService? ResolveService<TService>(DbContext dbContext)
+        where TService : class
+    {
+        try
+        {
+            var options = dbContext.GetService<IDbContextOptions>();
+            var appProvider = options.Extensions
+                .OfType<CoreOptionsExtension>()
+                .FirstOrDefault()
+                ?.ApplicationServiceProvider;
+            return appProvider?.GetService<TService>();
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/EventStoreCore/DbContextExtensions.cs
+++ b/src/EventStoreCore/DbContextExtensions.cs
@@ -15,6 +15,11 @@ public static class DbContextExtensions
         /// </summary>
         public IEventStore Streams => dbContext.Streams();
 
+        /// <summary>
+        /// Gets an <see cref="IEventLogReader" /> for reading events across all streams.
+        /// </summary>
+        public IEventLogReader EventLog => dbContext.EventLog();
+
         internal DbSet<DbEvent> Events => dbContext.Events();
 
     }
@@ -22,6 +27,12 @@ public static class DbContextExtensions
     {
         ArgumentNullException.ThrowIfNull(dbContext);
         return new DbContextEventStore(dbContext);
+    }
+
+    private static IEventLogReader EventLog(this DbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        return new DbContextEventLogReader(dbContext);
     }
 
     private static DbSet<DbEvent> Events(this DbContext dbContext)

--- a/src/EventStoreCore/EventStoreBuilderEfCoreExtensions.cs
+++ b/src/EventStoreCore/EventStoreBuilderEfCoreExtensions.cs
@@ -3,6 +3,7 @@ using EventStoreCore.Scheduling;
 using Medallion.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace EventStoreCore;
 
@@ -51,6 +52,8 @@ public static class EventStoreBuilderEfCoreExtensions
         var efBuilder = new EfCoreEventEventStoreBuilder<TDbContext>(builder.Services);
 
         builder.Services.AddSingleton<ISchedulerEventApplicationStore, EfCoreSchedulerEventApplicationStore<TDbContext>>();
+        builder.Services.TryAddScoped<IEventLogReader>(serviceProvider =>
+            new DbContextEventLogReader(serviceProvider.GetRequiredService<TDbContext>()));
 
         efBuilder.Services.AddDbContext<TDbContext>((sp, options) =>
         {

--- a/src/EventStoreCore/ModelBuilderExtensions.cs
+++ b/src/EventStoreCore/ModelBuilderExtensions.cs
@@ -98,6 +98,15 @@ internal static class ModelBuilderExtensions
 
             entity.HasIndex(e => e.TenantId);
 
+            entity.HasIndex(e => e.Sequence)
+                .IsUnique();
+
+            entity.HasIndex(e => new { e.TenantId, e.Sequence });
+
+            entity.HasIndex(e => new { e.StreamType, e.Sequence });
+
+            entity.HasIndex(e => new { e.TypeName, e.Sequence });
+
             entity.HasIndex(e => new { e.TenantId, e.StreamId, e.StreamType });
 
             entity.HasIndex(e => new { e.TenantId, e.StreamType, e.Type });

--- a/src/EventStoreCore/README.md
+++ b/src/EventStoreCore/README.md
@@ -25,6 +25,7 @@ infrastructure remains application-owned.
 
 - Inline and eventual projections
 - Subscription daemons with checkpointing
+- Stable global event-log paging across streams
 - Atomic domain-event capture from ordinary EF entities
 - Standalone outbox reader and independently checkpointed outbox subscriptions
 - Stable outbox subscription identities and recovery/replay management
@@ -56,6 +57,38 @@ Paged reads always read persisted events and do not use aggregate snapshots.
 `FetchForReadingAsync<TState>` remains the state-rehydration API and may use a
 compatible snapshot. Historical typed reads only use a snapshot whose stream
 version is not newer than the requested historical version.
+
+## Global event-log reads
+
+Inject the scoped `IEventLogReader` registered by
+`ExistingDbContext<TDbContext>()`, or use `dbContext.EventLog`, to read across
+all streams in ascending global sequence order.
+
+```csharp
+var page = await eventLogReader.ReadPageAsync(new EventLogReadOptions
+{
+    AfterSequence = checkpoint,
+    TenantId = tenantId,
+    StreamTypes = ["orders"],
+    EventTypes = ["order_created"],
+    MaxCount = 500
+}, ct);
+```
+
+Pages expose the highest currently visible unfiltered `HeadSequence`, bounded
+by an explicit `ThroughSequence`, and an exclusive `NextSequence` cursor. Async
+enumeration freezes that sequence bound automatically. Filters run in the
+database before paging. Event aliases, serializers, and schema upcasters are
+applied during materialization.
+
+Database sequences are allocated before transaction commit. Under concurrent
+appends, a lower sequence can therefore become visible after a higher sequence.
+Live consumers should overlap reads and deduplicate by event ID instead of
+treating `HeadSequence` as a strict commit fence.
+
+Add an application migration for the unique `Events.Sequence` index and the
+tenant, stream-type, and event-type sequence indexes when upgrading an existing
+database.
 
 ## Event metadata
 

--- a/tests/EventStoreCore.Tests/EventLogReaderTests.cs
+++ b/tests/EventStoreCore.Tests/EventLogReaderTests.cs
@@ -1,0 +1,257 @@
+using EventStoreCore.Abstractions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStoreCore.Tests;
+
+public sealed class EventLogReaderTests
+{
+    [Fact]
+    public async Task ReadPageAsync_pages_across_streams_with_a_stable_global_cursor()
+    {
+        await using var fixture = await Fixture.CreateAsync();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        await fixture.AppendAsync("orders", Guid.NewGuid(), tenantA, new OrderCreated(1), 1);
+        await fixture.AppendAsync("customers", Guid.NewGuid(), tenantB, new CustomerCreated(2), 2);
+        await fixture.AppendAsync("orders", Guid.NewGuid(), tenantA, new OrderCreated(3), 3);
+        await fixture.AppendAsync("invoices", Guid.NewGuid(), tenantA, new InvoiceIssued(4), 4);
+        await fixture.AppendAsync("orders", Guid.NewGuid(), tenantB, new OrderCreated(5), 5);
+
+        var first = await fixture.Db.EventLog.ReadPageAsync(
+            new EventLogReadOptions { MaxCount = 2 },
+            TestContext.Current.CancellationToken);
+        Assert.Equal([1L, 2L], first.Events.Select(@event => @event.Sequence));
+        Assert.Equal(5, first.HeadSequence);
+        Assert.Equal(2, first.NextSequence);
+
+        var second = await fixture.Db.EventLog.ReadPageAsync(
+            new EventLogReadOptions
+            {
+                AfterSequence = first.NextSequence!.Value,
+                ThroughSequence = first.HeadSequence,
+                MaxCount = 2
+            },
+            TestContext.Current.CancellationToken);
+        Assert.Equal([3L, 4L], second.Events.Select(@event => @event.Sequence));
+        Assert.Equal(4, second.NextSequence);
+
+        var last = await fixture.Db.EventLog.ReadPageAsync(
+            new EventLogReadOptions
+            {
+                AfterSequence = second.NextSequence!.Value,
+                ThroughSequence = first.HeadSequence,
+                MaxCount = 2
+            },
+            TestContext.Current.CancellationToken);
+        Assert.Equal([5L], last.Events.Select(@event => @event.Sequence));
+        Assert.False(last.HasMore);
+
+        var bounded = await fixture.Db.EventLog.ReadPageAsync(
+            new EventLogReadOptions { ThroughSequence = 3, MaxCount = 10 },
+            TestContext.Current.CancellationToken);
+        Assert.Equal([1L, 2L, 3L], bounded.Events.Select(@event => @event.Sequence));
+        Assert.Equal(3, bounded.HeadSequence);
+    }
+
+    [Fact]
+    public async Task ReadAsync_excludes_events_appended_after_enumeration_starts()
+    {
+        await using var fixture = await Fixture.CreateAsync();
+        await fixture.AppendAsync("orders", Guid.NewGuid(), Guid.Empty, new OrderCreated(1), 1);
+        await fixture.AppendAsync("orders", Guid.NewGuid(), Guid.Empty, new OrderCreated(2), 2);
+
+        await using var enumerator = fixture.Db.EventLog.ReadAsync(
+                new EventLogReadOptions { MaxCount = 1 },
+                TestContext.Current.CancellationToken)
+            .GetAsyncEnumerator(TestContext.Current.CancellationToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(1, enumerator.Current.Sequence);
+
+        await fixture.AppendAsync("orders", Guid.NewGuid(), Guid.Empty, new OrderCreated(3), 3);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(2, enumerator.Current.Sequence);
+        Assert.False(await enumerator.MoveNextAsync());
+    }
+
+    [Fact]
+    public async Task Filters_are_applied_before_paging_and_preserve_the_global_head()
+    {
+        await using var fixture = await Fixture.CreateAsync();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        await fixture.AppendAsync(
+            "orders",
+            Guid.NewGuid(),
+            tenantA,
+            new OrderCreated(1),
+            1);
+        await fixture.AppendAsync(
+            "orders",
+            Guid.NewGuid(),
+            tenantB,
+            new OrderCreated(2),
+            2);
+        await fixture.AppendAsync(
+            "orders",
+            Guid.NewGuid(),
+            tenantA,
+            new OrderCreated(3),
+            3);
+        await fixture.AppendAsync(
+            "invoices",
+            Guid.NewGuid(),
+            tenantA,
+            new InvoiceIssued(4),
+            4);
+
+        var page = await fixture.Db.EventLog.ReadPageAsync(
+            new EventLogReadOptions
+            {
+                TenantId = tenantA,
+                StreamTypes = ["orders"],
+                EventTypes = ["order_created"],
+                AfterSequence = 1,
+                MaxCount = 1
+            },
+            TestContext.Current.CancellationToken);
+
+        var @event = Assert.Single(page.Events);
+        Assert.Equal(3, @event.Sequence);
+        Assert.Equal("orders", @event.StreamType);
+        Assert.Equal("order_created", @event.TypeName);
+        Assert.Equal(4, page.HeadSequence);
+        Assert.False(page.HasMore);
+    }
+
+    [Fact]
+    public async Task Empty_filtered_ranges_return_the_global_head_for_checkpointing()
+    {
+        await using var fixture = await Fixture.CreateAsync();
+        await fixture.AppendAsync("orders", Guid.NewGuid(), Guid.Empty, new OrderCreated(1), 1);
+        await fixture.AppendAsync("orders", Guid.NewGuid(), Guid.Empty, new OrderCreated(2), 2);
+
+        var page = await fixture.Db.EventLog.ReadPageAsync(
+            new EventLogReadOptions { EventTypes = ["not_registered"] },
+            TestContext.Current.CancellationToken);
+
+        Assert.Empty(page.Events);
+        Assert.Equal(2, page.HeadSequence);
+        Assert.Null(page.NextSequence);
+    }
+
+    [Fact]
+    public async Task Invalid_bounds_and_page_sizes_are_rejected()
+    {
+        await using var fixture = await Fixture.CreateAsync();
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            fixture.Db.EventLog.ReadPageAsync(
+                new EventLogReadOptions { AfterSequence = -1 },
+                TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            fixture.Db.EventLog.ReadPageAsync(
+                new EventLogReadOptions { MaxCount = 0 },
+                TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            fixture.Db.EventLog.ReadPageAsync(
+                new EventLogReadOptions { ThroughSequence = -1 },
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Event_model_indexes_support_global_and_filtered_sequence_reads()
+    {
+        await using var fixture = await Fixture.CreateAsync();
+        var indexes = fixture.Db.Model.FindEntityType(typeof(DbEvent))!.GetIndexes().ToArray();
+
+        Assert.Contains(indexes, index =>
+            index.IsUnique &&
+            index.Properties.Select(property => property.Name).SequenceEqual([nameof(DbEvent.Sequence)]));
+        Assert.Contains(indexes, index =>
+            index.Properties.Select(property => property.Name).SequenceEqual(
+                [nameof(DbEvent.TenantId), nameof(DbEvent.Sequence)]));
+        Assert.Contains(indexes, index =>
+            index.Properties.Select(property => property.Name).SequenceEqual(
+                [nameof(DbEvent.StreamType), nameof(DbEvent.Sequence)]));
+        Assert.Contains(indexes, index =>
+            index.Properties.Select(property => property.Name).SequenceEqual(
+                [nameof(DbEvent.TypeName), nameof(DbEvent.Sequence)]));
+    }
+
+    [Fact]
+    public void ExistingDbContext_registers_the_global_reader_for_dependency_injection()
+    {
+        var services = new ServiceCollection();
+        services.AddEventStore(builder => builder.ExistingDbContext<EventLogDbContext>());
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        Assert.IsAssignableFrom<IEventLogReader>(
+            scope.ServiceProvider.GetRequiredService<IEventLogReader>());
+    }
+
+    private sealed record OrderCreated(int Number);
+
+    private sealed record CustomerCreated(int Number);
+
+    private sealed record InvoiceIssued(int Number);
+
+    private sealed class Fixture : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        private Fixture(SqliteConnection connection, EventLogDbContext db)
+        {
+            _connection = connection;
+            Db = db;
+        }
+
+        internal EventLogDbContext Db { get; }
+
+        internal static async Task<Fixture> CreateAsync()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync(TestContext.Current.CancellationToken);
+            var db = new EventLogDbContext(
+                new DbContextOptionsBuilder<EventLogDbContext>()
+                    .UseSqlite(connection)
+                    .Options);
+            await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            return new Fixture(connection, db);
+        }
+
+        internal async Task AppendAsync(
+            string streamType,
+            Guid streamId,
+            Guid tenantId,
+            object @event,
+            long sequence)
+        {
+            Db.Streams.StartStream(streamType, streamId, tenantId, @event);
+            var stored = Db.ChangeTracker.Entries<DbEvent>()
+                .Single(entry =>
+                    entry.State == EntityState.Added &&
+                    entry.Entity.StreamId == streamId)
+                .Entity;
+            stored.Sequence = sequence;
+
+            await Db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+
+    private sealed class EventLogDbContext(DbContextOptions<EventLogDbContext> options)
+        : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            ModelBuilderExtensions.ConfigureEventStoreModel(modelBuilder);
+    }
+}

--- a/tests/EventStoreCore.Tests/ProviderBehaviorTests.cs
+++ b/tests/EventStoreCore.Tests/ProviderBehaviorTests.cs
@@ -80,6 +80,36 @@ public class ProviderBehaviorTests : IClassFixture<PostgresFixture>, IClassFixtu
         await context.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
     }
 
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task EventStore_ReadsTheGlobalLogAcrossStreams(ProviderKind provider)
+    {
+        await using var context = CreateContext(provider);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        context.Streams.StartStream(
+            "orders",
+            Guid.NewGuid(),
+            events: new SampleEvent { Name = "first" });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        context.Streams.StartStream(
+            "customers",
+            Guid.NewGuid(),
+            events: new SampleEvent { Name = "second" });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await context.EventLog.ReadPageAsync(
+            new EventLogReadOptions { MaxCount = 10 },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, page.Events.Count);
+        Assert.True(page.Events[0].Sequence < page.Events[1].Sequence);
+        Assert.Equal(["orders", "customers"], page.Events.Select(@event => @event.StreamType));
+        Assert.Equal(page.Events[1].Sequence, page.HeadSequence);
+
+        await context.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+    }
+
     private DbContext CreateContext(ProviderKind provider)
     {
         return provider switch
@@ -94,7 +124,7 @@ public class ProviderBehaviorTests : IClassFixture<PostgresFixture>, IClassFixtu
         };
     }
 
-   
+
     private sealed class PostgresContext : DbContext
     {
         public PostgresContext(DbContextOptions<PostgresContext> options) : base(options)
@@ -119,7 +149,7 @@ public class ProviderBehaviorTests : IClassFixture<PostgresFixture>, IClassFixtu
         }
     }
 
-    
+
     private sealed class SampleEvent
     {
         public string Name { get; set; } = string.Empty;

--- a/tests/EventStoreCore.Tests/PublicApiVisibilityContractTests.cs
+++ b/tests/EventStoreCore.Tests/PublicApiVisibilityContractTests.cs
@@ -27,6 +27,7 @@ public sealed class PublicApiVisibilityContractTests
     [InlineData(typeof(DbProjectionStatus))]
     [InlineData(typeof(DbSubscription))]
     [InlineData(typeof(DbContextEventStore))]
+    [InlineData(typeof(DbContextEventLogReader))]
     [InlineData(typeof(DbContextStream))]
     public void Persistence_and_ef_implementation_types_are_not_public(Type type)
     {


### PR DESCRIPTION
Global event-log reader is implemented on `codex/global-event-log-reader`.

Highlights:

- Scoped [IEventLogReader](D:/Github/eventstore/src/EventStoreCore.Abstractions/IEventLogReader.cs:6) plus `dbContext.EventLog`.
- Stable paged and async global-sequence reads.
- Tenant, stream-type, and logical event-type filters.
- Captured visible high-water mark with explicit continuation cursors.
- Supporting unique/global filtered database indexes.
- Provider tests, consumer documentation, migration guidance, and public API baseline updates.
- Concurrent commit-order limitations are explicitly documented, including overlap-and-deduplicate guidance.

Validation:

- Release build passed.
- 26 focused tests passed.
- All 14 packages and public API baseline validated.
- PostgreSQL/SQL Server integration tests compile but weren’t executed locally because they require Docker.
- Existing SQLite NU1903 test warning remains.
