### PR TITLE
Bound snapshot-aware write rehydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,14 @@ When an expected-version check fails, or when two writers race and the database 
 
 The final optimistic concurrency guard is enforced by the event table key over stream identity plus event version. This means concurrent writers to the same stream cannot both commit the same next version.
 
+`AppendAsync` loads only stream identity and current version. The returned stream's
+`Events` collection contains the appended batch, not the complete history. Likewise,
+untyped `FetchForWritingAsync` does not load existing events. Typed
+`FetchForWritingAsync<TState>` uses a compatible configured aggregate snapshot and
+loads only events after that snapshot; without a compatible snapshot it falls back
+to replaying the complete stream. Snapshot updates and inline projections remain
+part of the same `SaveChanges` transaction as the appended events.
+
 ## Project guidelines
 
 - Keep public APIs small, composable, and backwards compatible.

--- a/src/EventStoreCore.Abstractions/IEventStore.cs
+++ b/src/EventStoreCore.Abstractions/IEventStore.cs
@@ -44,7 +44,10 @@ public interface IEventStore
     /// <param name="expectedVersion">The expected-version mode to enforce.</param>
     /// <param name="events">The events to append.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The updated read-only stream.</returns>
+    /// <returns>
+    /// The updated read-only stream. Its loaded <see cref="IReadOnlyStream.Events"/> contain
+    /// the appended batch rather than the stream's complete history.
+    /// </returns>
     Task<IReadOnlyStream> AppendAsync(
         Guid streamId,
         ExpectedVersion expectedVersion,
@@ -59,7 +62,10 @@ public interface IEventStore
     /// <param name="expectedVersion">The expected-version mode to enforce.</param>
     /// <param name="events">The events to append.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The updated read-only stream.</returns>
+    /// <returns>
+    /// The updated read-only stream. Its loaded <see cref="IReadOnlyStream.Events"/> contain
+    /// the appended batch rather than the stream's complete history.
+    /// </returns>
     Task<IReadOnlyStream> AppendAsync(
         Guid streamId,
         Guid tenantId,
@@ -75,7 +81,10 @@ public interface IEventStore
     /// <param name="expectedVersion">The expected-version mode to enforce.</param>
     /// <param name="events">The events to append.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The updated read-only stream.</returns>
+    /// <returns>
+    /// The updated read-only stream. Its loaded <see cref="IReadOnlyStream.Events"/> contain
+    /// the appended batch rather than the stream's complete history.
+    /// </returns>
     Task<IReadOnlyStream> AppendAsync(
         string streamType,
         Guid streamId,
@@ -92,7 +101,10 @@ public interface IEventStore
     /// <param name="expectedVersion">The expected-version mode to enforce.</param>
     /// <param name="events">The events to append.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The updated read-only stream.</returns>
+    /// <returns>
+    /// The updated read-only stream. Its loaded <see cref="IReadOnlyStream.Events"/> contain
+    /// the appended batch rather than the stream's complete history.
+    /// </returns>
     Task<IReadOnlyStream> AppendAsync(
         string streamType,
         Guid streamId,
@@ -106,7 +118,10 @@ public interface IEventStore
     /// </summary>
     /// <param name="streamId">The stream identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The writable stream, or null when it does not exist.</returns>
+    /// <returns>
+    /// The writable stream, or null when it does not exist. Existing events are not loaded;
+    /// <see cref="IReadOnlyStream.Events"/> contains only events appended through the returned stream.
+    /// </returns>
     Task<IStream?> FetchForWritingAsync(Guid streamId, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -115,7 +130,10 @@ public interface IEventStore
     /// <param name="streamId">The stream identifier.</param>
     /// <param name="tenantId">The tenant identifier for multi-tenant scenarios.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The writable stream, or null when it does not exist.</returns>
+    /// <returns>
+    /// The writable stream, or null when it does not exist. Existing events are not loaded;
+    /// <see cref="IReadOnlyStream.Events"/> contains only events appended through the returned stream.
+    /// </returns>
     Task<IStream?> FetchForWritingAsync(Guid streamId, Guid tenantId, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -124,7 +142,10 @@ public interface IEventStore
     /// <param name="streamType">The stream type for distinguishing multiple streams with the same ID.</param>
     /// <param name="streamId">The stream identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The writable stream, or null when it does not exist.</returns>
+    /// <returns>
+    /// The writable stream, or null when it does not exist. Existing events are not loaded;
+    /// <see cref="IReadOnlyStream.Events"/> contains only events appended through the returned stream.
+    /// </returns>
     Task<IStream?> FetchForWritingAsync(string streamType, Guid streamId, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -134,7 +155,10 @@ public interface IEventStore
     /// <param name="streamId">The stream identifier.</param>
     /// <param name="tenantId">The tenant identifier for multi-tenant scenarios.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The writable stream, or null when it does not exist.</returns>
+    /// <returns>
+    /// The writable stream, or null when it does not exist. Existing events are not loaded;
+    /// <see cref="IReadOnlyStream.Events"/> contains only events appended through the returned stream.
+    /// </returns>
     Task<IStream?> FetchForWritingAsync(string streamType, Guid streamId, Guid tenantId, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -143,7 +167,10 @@ public interface IEventStore
     /// <param name="streamId">The stream identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <typeparam name="T">The state type reconstructed from the stream.</typeparam>
-    /// <returns>The writable stream, or null when it does not exist.</returns>
+    /// <returns>
+    /// The writable stream, or null when it does not exist. When a compatible configured snapshot
+    /// exists, state is rebuilt from that snapshot and only its event tail is loaded.
+    /// </returns>
     Task<IStream<T>?> FetchForWritingAsync<T>(Guid streamId, CancellationToken cancellationToken = default)
         where T : IState, new();
 
@@ -154,7 +181,10 @@ public interface IEventStore
     /// <param name="tenantId">The tenant identifier for multi-tenant scenarios.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <typeparam name="T">The state type reconstructed from the stream.</typeparam>
-    /// <returns>The writable stream, or null when it does not exist.</returns>
+    /// <returns>
+    /// The writable stream, or null when it does not exist. When a compatible configured snapshot
+    /// exists, state is rebuilt from that snapshot and only its event tail is loaded.
+    /// </returns>
     Task<IStream<T>?> FetchForWritingAsync<T>(Guid streamId, Guid tenantId, CancellationToken cancellationToken = default)
         where T : IState, new();
 
@@ -165,7 +195,10 @@ public interface IEventStore
     /// <param name="streamId">The stream identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <typeparam name="T">The state type reconstructed from the stream.</typeparam>
-    /// <returns>The writable stream, or null when it does not exist.</returns>
+    /// <returns>
+    /// The writable stream, or null when it does not exist. When a compatible configured snapshot
+    /// exists, state is rebuilt from that snapshot and only its event tail is loaded.
+    /// </returns>
     Task<IStream<T>?> FetchForWritingAsync<T>(string streamType, Guid streamId, CancellationToken cancellationToken = default)
         where T : IState, new();
 
@@ -177,7 +210,10 @@ public interface IEventStore
     /// <param name="tenantId">The tenant identifier for multi-tenant scenarios.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <typeparam name="T">The state type reconstructed from the stream.</typeparam>
-    /// <returns>The writable stream, or null when it does not exist.</returns>
+    /// <returns>
+    /// The writable stream, or null when it does not exist. When a compatible configured snapshot
+    /// exists, state is rebuilt from that snapshot and only its event tail is loaded.
+    /// </returns>
     Task<IStream<T>?> FetchForWritingAsync<T>(string streamType, Guid streamId, Guid tenantId, CancellationToken cancellationToken = default)
         where T : IState, new();
 
@@ -429,5 +465,4 @@ public interface IEventStore
     Task<IReadOnlyStream<T>?> FetchForReadingAsync<T>(string streamType, Guid streamId, Guid tenantId, long version, CancellationToken cancellationToken = default)
         where T : IState, new();
 }
-
 

--- a/src/EventStoreCore/DbContextEventStore.cs
+++ b/src/EventStoreCore/DbContextEventStore.cs
@@ -198,7 +198,6 @@ internal sealed class DbContextEventStore(DbContext db) : IEventStore
         var unrelatedChanges = CaptureUnrelatedChanges();
         var stream = await db.Set<DbStream>()
             .Where(x => x.TenantId == tenantId && x.StreamType == streamType)
-            .Include(x => x.Events)
             .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
 
         stream = expectedVersion.Mode switch
@@ -388,7 +387,6 @@ internal sealed class DbContextEventStore(DbContext db) : IEventStore
     {
         var stream = await db.Set<DbStream>()
             .Where(x => x.TenantId == tenantId && x.StreamType == streamType)
-            .Include(x => x.Events)
             .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
         if (stream is null) return null;
         return new DbContextStream(stream, db);
@@ -409,12 +407,15 @@ internal sealed class DbContextEventStore(DbContext db) : IEventStore
     /// <inheritdoc />
     public async Task<IStream<T>?> FetchForWritingAsync<T>(string streamType, Guid streamId, Guid tenantId, CancellationToken cancellationToken = default) where T : IState, new()
     {
+        var snapshot = _snapshots?.LoadSnapshot<T>(db, streamType, streamId, tenantId);
+        var snapshotVersion = snapshot?.Version ?? 0;
+
         var stream = await db.Set<DbStream>()
-          .Where(x => x.TenantId == tenantId && x.StreamType == streamType)
-          .Include(x => x.Events)
-          .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
+            .Where(x => x.TenantId == tenantId && x.StreamType == streamType)
+            .Include(x => x.Events.Where(e => e.Version > snapshotVersion))
+            .FirstOrDefaultAsync(x => x.Id == streamId, cancellationToken);
         if (stream is null) return null;
-        return new DbContextStream<T>(stream, db);
+        return new DbContextStream<T>(stream, db, DeserializeSnapshot<T>(snapshot));
     }
 
     /// <inheritdoc />

--- a/src/EventStoreCore/DbContextStream.cs
+++ b/src/EventStoreCore/DbContextStream.cs
@@ -131,7 +131,6 @@ internal class DbContextStream : IStream
 internal class DbContextStream<T> : DbContextStream, IStream<T> where T : IState, new()
 {
     private readonly T? _snapshotState;
-    private readonly IReadOnlyList<IEvent>? _stateEvents;
 
     /// <summary>
     /// Creates a typed stream wrapper for the provided stream record.
@@ -153,7 +152,6 @@ internal class DbContextStream<T> : DbContextStream, IStream<T> where T : IState
     internal DbContextStream(DbStream dbStream, DbContext db, T? snapshotState) : base(dbStream, db)
     {
         _snapshotState = snapshotState;
-        _stateEvents = MaterializeEvents(dbStream.Events);
     }
 
     /// <inheritdoc />
@@ -166,7 +164,7 @@ internal class DbContextStream<T> : DbContextStream, IStream<T> where T : IState
                 : (T?)Serializer.Deserialize(
                     Serializer.Serialize(_snapshotState, typeof(T)),
                     typeof(T)) ?? new T();
-            foreach (var @event in _stateEvents ?? Events)
+            foreach (var @event in Events)
             {
                 state.Apply(@event);
             }

--- a/src/EventStoreCore/README.md
+++ b/src/EventStoreCore/README.md
@@ -58,6 +58,16 @@ Paged reads always read persisted events and do not use aggregate snapshots.
 compatible snapshot. Historical typed reads only use a snapshot whose stream
 version is not newer than the requested historical version.
 
+## Bounded stream writes
+
+`AppendAsync` and untyped `FetchForWritingAsync` load only stream identity and
+current version, not existing events. Their returned `Events` collections
+therefore contain only events appended through that write operation. Typed
+`FetchForWritingAsync<TState>` rebuilds state from a compatible configured
+aggregate snapshot plus later events, falling back to a complete replay when no
+compatible snapshot exists. Snapshot updates and inline projections remain in
+the append transaction.
+
 ## Global event-log reads
 
 Inject the scoped `IEventLogReader` registered by

--- a/src/EventStoreCore/SnapshotRegistration.cs
+++ b/src/EventStoreCore/SnapshotRegistration.cs
@@ -76,6 +76,23 @@ internal sealed class SnapshotRegistration<TState> : SnapshotRegistration
         var snapshotState = snapshot is not null && schemaMatches
             ? Deserialize(snapshot, serializer)
             : default;
+        var persistedTail = db.Set<DbEvent>()
+            .AsNoTracking()
+            .Where(e => e.StreamId == stream.Id
+                && e.StreamType == stream.StreamType
+                && e.TenantId == stream.TenantId
+                && e.Version > snapshotVersion
+                && e.Version <= stream.CurrentVersion)
+            .ToList();
+        var pendingTail = db.ChangeTracker
+            .Entries<DbEvent>()
+            .Where(e => e.State == EntityState.Added
+                && e.Entity.StreamId == stream.Id
+                && e.Entity.StreamType == stream.StreamType
+                && e.Entity.TenantId == stream.TenantId
+                && e.Entity.Version > snapshotVersion
+                && e.Entity.Version <= stream.CurrentVersion)
+            .Select(e => e.Entity);
         var tailStream = new DbStream
         {
             Id = stream.Id,
@@ -84,8 +101,8 @@ internal sealed class SnapshotRegistration<TState> : SnapshotRegistration
             CurrentVersion = stream.CurrentVersion,
             CreatedTimestamp = stream.CreatedTimestamp,
             UpdatedTimestamp = stream.UpdatedTimestamp,
-            Events = stream.Events
-                .Where(e => e.Version > snapshotVersion)
+            Events = persistedTail
+                .Concat(pendingTail)
                 .OrderBy(e => e.Version)
                 .ToList()
         };

--- a/tests/EventStoreCore.Tests/EventStoreTests.cs
+++ b/tests/EventStoreCore.Tests/EventStoreTests.cs
@@ -363,6 +363,136 @@ public class EventStoreTests(EventStoreFixture eventStoreFixture) : IClassFixtur
     }
 
     [Fact]
+    public async Task AppendAsyncLoadsOnlyStreamMetadataAndReturnsAppendedBatch()
+    {
+        var streamId = Guid.NewGuid();
+
+        using (var createContext = eventStoreFixture.CreateNewContext())
+        {
+            createContext.Streams.StartStream(
+                streamId,
+                events: Enumerable.Range(1, 20)
+                    .Select(number => new TestEvent { Name = $"event-{number}" }));
+            await createContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var appendContext = eventStoreFixture.CreateNewContext();
+        var result = await appendContext.Streams.AppendAsync(
+            streamId,
+            ExpectedVersion.Exact(20),
+            [new TestEvent { Name = "event-21" }, new TestEvent { Name = "event-22" }],
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(22, result.Version);
+        Assert.Equal(2, result.Events.Count);
+        Assert.Equal(
+            [21L, 22L],
+            appendContext.ChangeTracker.Entries<DbEvent>()
+                .Select(entry => entry.Entity.Version)
+                .Order()
+                .ToArray());
+    }
+
+    [Fact]
+    public async Task UntypedWriteFetchDoesNotLoadExistingEvents()
+    {
+        var streamId = Guid.NewGuid();
+
+        using (var createContext = eventStoreFixture.CreateNewContext())
+        {
+            createContext.Streams.StartStream(
+                streamId,
+                events: Enumerable.Range(1, 20)
+                    .Select(number => new TestEvent { Name = $"event-{number}" }));
+            await createContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var writeContext = eventStoreFixture.CreateNewContext();
+        var stream = await writeContext.Streams.FetchForWritingAsync(
+            streamId,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(stream);
+        Assert.Equal(20, stream!.Version);
+        Assert.Empty(stream.Events);
+        Assert.Empty(writeContext.ChangeTracker.Entries<DbEvent>());
+
+        stream.Append(new TestEvent { Name = "event-21" });
+
+        Assert.Single(stream.Events);
+        Assert.Single(writeContext.ChangeTracker.Entries<DbEvent>());
+    }
+
+    [Fact]
+    public async Task TypedWriteUsesSnapshotTailAndPersistsCorrectNextSnapshot()
+    {
+        using var provider = CreateSnapshotProvider();
+        var streamId = Guid.NewGuid();
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            await RecreateAsync(dbContext);
+
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.NoStream,
+                [new TestEvent { Name = "one" }, new TestEvent { Name = "two" }],
+                TestContext.Current.CancellationToken);
+            await dbContext.Streams.AppendAsync(
+                "orders",
+                streamId,
+                ExpectedVersion.Exact(2),
+                [new TestEvent { Name = "three" }],
+                TestContext.Current.CancellationToken);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            var stream = await dbContext.Streams.FetchForWritingAsync<SnapshotState>(
+                "orders",
+                streamId,
+                TestContext.Current.CancellationToken);
+
+            Assert.NotNull(stream);
+            Assert.Single(stream!.Events);
+            Assert.Single(dbContext.ChangeTracker.Entries<DbEvent>());
+            Assert.Equal("three", stream.State.Name);
+            Assert.Equal(3, stream.State.ApplyCount);
+
+            stream.Append(new TestEvent { Name = "four" });
+
+            Assert.Equal("four", stream.State.Name);
+            Assert.Equal(4, stream.State.ApplyCount);
+            await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EventStoreFixture.EventStoreDbContext>();
+            var snapshot = await dbContext.Set<DbSnapshot>()
+                .AsNoTracking()
+                .SingleAsync(
+                    x => x.StreamId == streamId
+                        && x.StreamType == "orders"
+                        && x.StateType == typeof(SnapshotState).FullName,
+                    TestContext.Current.CancellationToken);
+            var stream = await dbContext.Streams.FetchForReadingAsync<SnapshotState>(
+                "orders",
+                streamId,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(4, snapshot.Version);
+            Assert.NotNull(stream);
+            Assert.Empty(stream!.Events);
+            Assert.Equal("four", stream.State.Name);
+            Assert.Equal(4, stream.State.ApplyCount);
+        }
+    }
+
+    [Fact]
     public async Task SnapshotBackedVersionedReadExposesOnlyReplayTail()
     {
         using var provider = CreateSnapshotProvider();


### PR DESCRIPTION
## Summary
- stop append-only writes from loading complete stream histories
- rehydrate typed writes from compatible aggregate snapshots plus tail events
- preserve snapshot updates, optimistic concurrency, and inline projection transaction behavior
- document the compact loaded-events contract and add bounded-load/snapshot correctness tests

## Validation
- 27 focused EventStoreTests passed
- 8 inline ProjectionTests passed
- production projects compiled successfully
- git diff --check passed

## Environment note
The full solution build still encounters the repository’s existing CS0570 failures for the internal DbContext.Events extension property with the installed .NET 10 compiler. A temporary visibility-only test-build workaround was reverted before commit.