### PR TITLE
Isolate daemon scheduling and add bounded backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,33 @@ redeliver the event and handlers must remain idempotent.
 
 Add migrations for the `OutboxMessages` and `OutboxSubscriptions` tables after enabling the feature.
 
+## Daemon scheduling, isolation, and backpressure
+
+Stream subscriptions, entity-outbox subscriptions, and eventual projections run
+one logical worker per registration and checkpoint scope. A caught-up, paused,
+retrying, failing, or slow worker therefore does not impose its polling or retry
+delay on another worker. Tenant-scoped daemons add workers as new event or
+checkpoint tenants are discovered.
+
+Each daemon has a positive `MaxConcurrentWorkers` option, defaulting to `8`.
+The limit bounds concurrent batch executions within that daemon instance;
+additional logical workers wait for capacity. Distributed-lock waits, polling,
+retrying, and projection `BatchDelay` happen outside the capacity slot, providing
+backpressure without recreating head-of-line blocking.
+
+Ordering remains serial within one registration/checkpoint scope. Its existing
+distributed lock is held across reading, handler or projection execution, and
+checkpoint persistence. This preserves the at-least-once contract: a crash after
+delivery but before checkpoint persistence may redeliver, and handlers must
+remain idempotent.
+
+Daemon shutdown cancels discovery, lock waits, batch work, and delays, then
+awaits every logical worker so scopes and acquired locks are disposed. Handlers
+should honor their cancellation token. Tenant-scoped stream subscriptions use
+the registered handler instance from multiple scope workers, so those handlers
+must also be safe for concurrent calls; set `MaxConcurrentWorkers = 1` when
+serial handler invocation is required.
+
 ## Inline projection contract
 
 Inline projections run inside the same `DbContext` scope and `SaveChanges` transaction that appends events. If an inline projection throws, the append is rolled back with it.
@@ -469,13 +496,18 @@ services.AddEventStore(builder =>
 
     builder.AddSubscriptionDaemon<MyEventStoreDbContext>(
         _ => distributedLockProvider,
-        options => options.CheckpointScope = CheckpointScope.Tenant);
+        options =>
+        {
+            options.CheckpointScope = CheckpointScope.Tenant;
+            options.MaxConcurrentWorkers = 8;
+        });
 
     builder.AddProjectionDaemon<MyEventStoreDbContext>(
         _ => distributedLockProvider,
         options =>
         {
             options.CheckpointScope = CheckpointScope.Tenant;
+            options.MaxConcurrentWorkers = 8;
             options.AutoRebuildOnVersionChange = false;
         });
 });

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -34,3 +34,7 @@ The following changes are intentional for the next beta:
 - Projection versions are configured exclusively with `ProjectionVersionAttribute`; the default is version 1. The concrete projection-options implementation and its former `Version(int)` method are no longer public.
 - The misspelled projection matching helper `IsHandeled` was renamed to `IsHandled` and made internal.
 - EF persistence rows and EF-backed store/stream implementations are internal. Public event and stream interfaces remain the supported consumption boundary.
+- `SubscriptionOptions`, `ProjectionDaemonOptions`, and `EntityOutboxOptions`
+  expose `MaxConcurrentWorkers` to bound independent registration/checkpoint
+  workers. The positive value defaults to `8`; polling and retry delays happen
+  outside the active-work limit.

--- a/docs/daemon-identities-and-filtering.md
+++ b/docs/daemon-identities-and-filtering.md
@@ -79,3 +79,25 @@ receive structured projection fault and subscription fault/dead-letter transitio
 
 Entity-outbox dispatch uses the same diagnostic sources with daemon kind
 `outbox-subscription`.
+
+Each registration/checkpoint scope has an independent logical worker.
+`MaxConcurrentWorkers` on `SubscriptionOptions`, `ProjectionDaemonOptions`, and
+`EntityOutboxOptions` bounds concurrent batch executions per daemon instance.
+Distributed-lock waits, polling, retry, and projection batch delays happen
+outside the concurrency slot. The scheduler additionally emits:
+
+- `eventstore.daemon.workers.active` for logical workers currently running.
+- `eventstore.daemon.workers.executing` for workers currently processing a
+  batch.
+- `eventstore.daemon.workers.throttled` when an attempt waits for configured
+  capacity.
+- `eventstore.daemon.worker.queue.duration` for that capacity wait.
+
+These instruments use the existing logical identity and daemon-kind tags. They
+intentionally do not attach tenant IDs, avoiding an unbounded metric-cardinality
+dimension. Batch activities include checkpoint-scope and, for tenant-scoped
+work, tenant-ID tags. `DaemonFaultNotification` remains the scope- and
+tenant-specific fault signal.
+
+Health entries are tracked per registration/checkpoint scope internally, so a
+healthy tenant heartbeat cannot clear a durable fault in another tenant scope.

--- a/eng/PublicApiBaseline.txt
+++ b/eng/PublicApiBaseline.txt
@@ -828,6 +828,7 @@ EventStoreCore|P:EventStoreCore.EntityChange`1.Entity
 EventStoreCore|P:EventStoreCore.EntityOutboxOptions.BatchSize
 EventStoreCore|P:EventStoreCore.EntityOutboxOptions.CheckpointScope
 EventStoreCore|P:EventStoreCore.EntityOutboxOptions.LockTimeout
+EventStoreCore|P:EventStoreCore.EntityOutboxOptions.MaxConcurrentWorkers
 EventStoreCore|P:EventStoreCore.EntityOutboxOptions.MaxRetryAttempts
 EventStoreCore|P:EventStoreCore.EntityOutboxOptions.PollingInterval
 EventStoreCore|P:EventStoreCore.EntityOutboxOptions.RetryDelay
@@ -863,6 +864,7 @@ EventStoreCore|P:EventStoreCore.ProjectionDaemonOptions.BatchDelay
 EventStoreCore|P:EventStoreCore.ProjectionDaemonOptions.BatchSize
 EventStoreCore|P:EventStoreCore.ProjectionDaemonOptions.CheckpointScope
 EventStoreCore|P:EventStoreCore.ProjectionDaemonOptions.LockTimeout
+EventStoreCore|P:EventStoreCore.ProjectionDaemonOptions.MaxConcurrentWorkers
 EventStoreCore|P:EventStoreCore.ProjectionDaemonOptions.PollingInterval
 EventStoreCore|P:EventStoreCore.ProjectionDaemonOptions.RetryDelay
 EventStoreCore|P:EventStoreCore.ProjectionOptions.ShouldIgnoreUnknown
@@ -883,6 +885,7 @@ EventStoreCore|P:EventStoreCore.SubscriptionOptions.BatchSize
 EventStoreCore|P:EventStoreCore.SubscriptionOptions.CheckpointFrequency
 EventStoreCore|P:EventStoreCore.SubscriptionOptions.CheckpointScope
 EventStoreCore|P:EventStoreCore.SubscriptionOptions.LockTimeout
+EventStoreCore|P:EventStoreCore.SubscriptionOptions.MaxConcurrentWorkers
 EventStoreCore|P:EventStoreCore.SubscriptionOptions.MaxRetryAttempts
 EventStoreCore|P:EventStoreCore.SubscriptionOptions.PollingInterval
 EventStoreCore|P:EventStoreCore.SubscriptionOptions.RetryDelay

--- a/src/EventStoreCore/DaemonExecutionLimiter.cs
+++ b/src/EventStoreCore/DaemonExecutionLimiter.cs
@@ -1,0 +1,42 @@
+namespace EventStoreCore;
+
+internal sealed class DaemonExecutionLimiter
+{
+    private readonly SemaphoreSlim _semaphore;
+    private readonly TimeProvider _timeProvider;
+
+    internal DaemonExecutionLimiter(int maxConcurrency, TimeProvider timeProvider)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxConcurrency, 1);
+        _semaphore = new SemaphoreSlim(maxConcurrency, maxConcurrency);
+        _timeProvider = timeProvider;
+    }
+
+    internal async Task<TResult> RunAsync<TResult>(
+        string identity,
+        string kind,
+        Func<CancellationToken, Task<TResult>> action,
+        CancellationToken ct)
+    {
+        var queuedAt = _timeProvider.GetTimestamp();
+        if (!await _semaphore.WaitAsync(0, ct))
+        {
+            EventStoreDaemonDiagnostics.WorkerThrottled(identity, kind);
+            await _semaphore.WaitAsync(ct);
+        }
+
+        EventStoreDaemonDiagnostics.ExecutionStarted(
+            identity,
+            kind,
+            _timeProvider.GetElapsedTime(queuedAt));
+        try
+        {
+            return await action(ct);
+        }
+        finally
+        {
+            EventStoreDaemonDiagnostics.ExecutionStopped(identity, kind);
+            _semaphore.Release();
+        }
+    }
+}

--- a/src/EventStoreCore/DaemonFaultNotification.cs
+++ b/src/EventStoreCore/DaemonFaultNotification.cs
@@ -6,7 +6,9 @@ namespace EventStoreCore;
 /// Describes a durable daemon fault or dead-letter transition.
 /// </summary>
 /// <param name="Identity">The stable logical projection or subscription identity.</param>
-/// <param name="DaemonKind">The daemon kind: <c>projection</c> or <c>subscription</c>.</param>
+/// <param name="DaemonKind">
+/// The daemon kind: <c>projection</c>, <c>subscription</c>, or <c>outbox-subscription</c>.
+/// </param>
 /// <param name="State">The new persisted fault state.</param>
 /// <param name="CheckpointScope">The checkpoint scope.</param>
 /// <param name="TenantId">The tenant identifier for a tenant-scoped checkpoint.</param>

--- a/src/EventStoreCore/DaemonHealthMonitor.cs
+++ b/src/EventStoreCore/DaemonHealthMonitor.cs
@@ -35,9 +35,12 @@ public sealed class DaemonHealthMonitor
         return new DaemonHealthReport(status, entries);
     }
 
-    internal void Heartbeat(string identity, string daemonKind) =>
+    internal void Heartbeat(
+        string identity,
+        string daemonKind,
+        CheckpointScopeKey checkpointScope = default) =>
         _entries.AddOrUpdate(
-            $"{daemonKind}:{identity}",
+            GetKey(identity, daemonKind, checkpointScope),
             _ => new DaemonHealthEntry(identity, daemonKind, _timeProvider.GetUtcNow(), false, null),
             (_, current) => current with
             {
@@ -46,9 +49,13 @@ public sealed class DaemonHealthMonitor
                 LastError = null
             });
 
-    internal void Fault(string identity, string daemonKind, Exception exception) =>
+    internal void Fault(
+        string identity,
+        string daemonKind,
+        Exception exception,
+        CheckpointScopeKey checkpointScope = default) =>
         _entries.AddOrUpdate(
-            $"{daemonKind}:{identity}",
+            GetKey(identity, daemonKind, checkpointScope),
             _ => new DaemonHealthEntry(identity, daemonKind, _timeProvider.GetUtcNow(), true, exception.Message),
             (_, current) => current with
             {
@@ -56,6 +63,12 @@ public sealed class DaemonHealthMonitor
                 IsFaulted = true,
                 LastError = exception.Message
             });
+
+    private static string GetKey(
+        string identity,
+        string daemonKind,
+        CheckpointScopeKey checkpointScope) =>
+        $"{daemonKind}:{identity}{checkpointScope.LockSuffix}";
 }
 
 /// <summary>Overall daemon health state.</summary>
@@ -79,7 +92,7 @@ public sealed record DaemonHealthReport(
     IReadOnlyList<DaemonHealthEntry> Entries);
 
 /// <summary>
-/// Represents liveness and fault information for one logical daemon identity.
+/// Represents liveness and fault information for one logical daemon checkpoint.
 /// </summary>
 /// <param name="Identity">The stable logical identity.</param>
 /// <param name="DaemonKind">The daemon kind.</param>

--- a/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
+++ b/src/EventStoreCore/EfCoreEventEventStoreBuilder.cs
@@ -69,6 +69,24 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
             .Validate(
                 opts => opts.LockTimeout >= TimeSpan.Zero || opts.LockTimeout == Timeout.InfiniteTimeSpan,
                 $"{nameof(SubscriptionOptions.LockTimeout)} must be non-negative or Timeout.InfiniteTimeSpan.")
+            .Validate(
+                opts => opts.MaxConcurrentWorkers > 0,
+                $"{nameof(SubscriptionOptions.MaxConcurrentWorkers)} must be positive.")
+            .Validate(
+                opts => opts.BatchSize > 0,
+                $"{nameof(SubscriptionOptions.BatchSize)} must be positive.")
+            .Validate(
+                opts => opts.CheckpointFrequency > 0,
+                $"{nameof(SubscriptionOptions.CheckpointFrequency)} must be positive.")
+            .Validate(
+                opts => opts.MaxRetryAttempts > 0,
+                $"{nameof(SubscriptionOptions.MaxRetryAttempts)} must be positive.")
+            .Validate(
+                opts => opts.PollingInterval >= TimeSpan.Zero,
+                $"{nameof(SubscriptionOptions.PollingInterval)} must be non-negative.")
+            .Validate(
+                opts => opts.RetryDelay >= TimeSpan.Zero,
+                $"{nameof(SubscriptionOptions.RetryDelay)} must be non-negative.")
             .ValidateOnStart();
         services.TryAddSingleton<SubscriptionDaemon<TDbContext>>();
         services.TryAddScoped<ISubscriptionManager>(sp =>
@@ -96,6 +114,21 @@ internal sealed class EfCoreEventEventStoreBuilder<TDbContext>(
             .Validate(
                 opts => opts.LockTimeout >= TimeSpan.Zero || opts.LockTimeout == Timeout.InfiniteTimeSpan,
                 $"{nameof(ProjectionDaemonOptions.LockTimeout)} must be non-negative or Timeout.InfiniteTimeSpan.")
+            .Validate(
+                opts => opts.MaxConcurrentWorkers > 0,
+                $"{nameof(ProjectionDaemonOptions.MaxConcurrentWorkers)} must be positive.")
+            .Validate(
+                opts => opts.BatchSize > 0,
+                $"{nameof(ProjectionDaemonOptions.BatchSize)} must be positive.")
+            .Validate(
+                opts => opts.PollingInterval >= TimeSpan.Zero,
+                $"{nameof(ProjectionDaemonOptions.PollingInterval)} must be non-negative.")
+            .Validate(
+                opts => opts.RetryDelay >= TimeSpan.Zero,
+                $"{nameof(ProjectionDaemonOptions.RetryDelay)} must be non-negative.")
+            .Validate(
+                opts => opts.BatchDelay >= TimeSpan.Zero,
+                $"{nameof(ProjectionDaemonOptions.BatchDelay)} must be non-negative.")
             .ValidateOnStart();
 
         services.TryAddSingleton<ProjectionDaemon<TDbContext>>();

--- a/src/EventStoreCore/EntityOutboxDaemon.cs
+++ b/src/EventStoreCore/EntityOutboxDaemon.cs
@@ -33,54 +33,217 @@ public sealed class EntityOutboxDaemon<TDbContext>(
         var registrations = serviceProvider
             .GetServices<OutboxSubscriptionRegistration>()
             .ToArray();
+        var limiter = new DaemonExecutionLimiter(
+            _options.MaxConcurrentWorkers,
+            timeProvider);
+        var workers = registrations
+            .Select(registration => RunRegistrationAsync(
+                registration,
+                limiter,
+                stoppingToken))
+            .ToArray();
 
-        while (!stoppingToken.IsCancellationRequested)
+        try
         {
-            var processedAny = false;
+            await Task.WhenAll(workers);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            logger.LogInformation("Entity outbox daemon stopping gracefully.");
+        }
+    }
 
-            foreach (var registration in registrations)
+    private async Task RunRegistrationAsync(
+        OutboxSubscriptionRegistration registration,
+        DaemonExecutionLimiter limiter,
+        CancellationToken ct)
+    {
+        if (_options.CheckpointScope == CheckpointScope.Global)
+        {
+            await RunCheckpointWorkerAsync(
+                registration,
+                CheckpointScopeKey.Global,
+                limiter,
+                ct);
+            return;
+        }
+
+        var scopeWorkers = new Dictionary<CheckpointScopeKey, Task>();
+        try
+        {
+            while (!ct.IsCancellationRequested)
             {
                 try
                 {
-                    foreach (var checkpointScope in await GetCheckpointScopesAsync(registration, stoppingToken))
+                    foreach (var checkpointScope in await GetCheckpointScopesAsync(
+                        registration,
+                        ct))
                     {
-                        await using var acquired = await AcquireLockAsync(
-                            registration.Name,
-                            checkpointScope,
-                            stoppingToken);
-                        if (acquired is null)
+                        if (!scopeWorkers.ContainsKey(checkpointScope))
                         {
-                            continue;
+                            scopeWorkers.Add(
+                                checkpointScope,
+                                RunCheckpointWorkerAsync(
+                                    registration,
+                                    checkpointScope,
+                                    limiter,
+                                    ct));
                         }
-
-                        using var handlerScope = serviceProvider.CreateScope();
-                        using var checkpointScopeServices = serviceProvider.CreateScope();
-                        var subscription = registration.Resolve(handlerScope.ServiceProvider);
-                        processedAny |= await ProcessNextBatchAsync(
-                            checkpointScopeServices,
-                            subscription,
-                            registration,
-                            checkpointScope,
-                            stoppingToken) > 0;
                     }
+
+                    await Task.Delay(
+                        _options.PollingInterval,
+                        timeProvider,
+                        ct);
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
-                    return;
+                    break;
                 }
                 catch (Exception ex)
                 {
                     logger.LogError(
                         ex,
-                        "Entity outbox subscription {Subscription} failed.",
-                        registration.Name);
+                        "Error discovering checkpoint scopes for entity outbox subscription {Subscription}. Retrying in {RetryDelay}.",
+                        registration.Name,
+                        _options.RetryDelay);
+                    EventStoreDaemonDiagnostics.Retry(
+                        registration.Name,
+                        "outbox-subscription");
+                    await DelayAfterFailureAsync(_options.RetryDelay, ct);
                 }
             }
+        }
+        finally
+        {
+            await AwaitWorkersAsync(scopeWorkers.Values);
+        }
+    }
 
-            if (!processedAny)
+    private async Task RunCheckpointWorkerAsync(
+        OutboxSubscriptionRegistration registration,
+        CheckpointScopeKey checkpointScope,
+        DaemonExecutionLimiter limiter,
+        CancellationToken ct)
+    {
+        var name = registration.Name;
+        EventStoreDaemonDiagnostics.WorkerStarted(name, "outbox-subscription");
+        try
+        {
+            while (!ct.IsCancellationRequested)
             {
-                await Task.Delay(_options.PollingInterval, timeProvider, stoppingToken);
+                try
+                {
+                    var acquired = await AcquireLockAsync(
+                        name,
+                        checkpointScope,
+                        ct);
+                    var iteration = (ProcessedCount: 0, Delay: _options.PollingInterval);
+                    if (acquired is not null)
+                    {
+                        await using (acquired)
+                        {
+                            iteration = await limiter.RunAsync(
+                                name,
+                                "outbox-subscription",
+                                async token =>
+                                {
+                                    using var handlerScope = serviceProvider.CreateScope();
+                                    using var checkpointScopeServices = serviceProvider.CreateScope();
+                                    var subscription = registration.Resolve(
+                                        handlerScope.ServiceProvider);
+                                    var processed = await ProcessNextBatchAsync(
+                                        checkpointScopeServices,
+                                        subscription,
+                                        registration,
+                                        checkpointScope,
+                                        token);
+                                    var checkpoint = checkpointScopeServices.ServiceProvider
+                                        .GetRequiredService<TDbContext>()
+                                        .Set<DbOutboxSubscription>()
+                                        .Local
+                                        .FirstOrDefault(row =>
+                                            row.SubscriptionAssemblyQualifiedName == name &&
+                                            row.CheckpointScope == checkpointScope.Scope &&
+                                            row.TenantId == checkpointScope.TenantId);
+                                    return (
+                                        processed,
+                                        GetNextDelay(checkpoint));
+                                },
+                                ct);
+                        }
+                    }
+
+                    if (iteration.ProcessedCount == 0)
+                    {
+                        await Task.Delay(
+                            iteration.Delay,
+                            timeProvider,
+                            ct);
+                    }
+                    else
+                    {
+                        await Task.Yield();
+                    }
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(
+                        ex,
+                        "Entity outbox subscription {Subscription} failed in checkpoint scope {Scope}. Retrying in {RetryDelay}.",
+                        name,
+                        checkpointScope,
+                        _options.RetryDelay);
+                    EventStoreDaemonDiagnostics.Retry(
+                        name,
+                        "outbox-subscription");
+                    await DelayAfterFailureAsync(_options.RetryDelay, ct);
+                }
             }
+        }
+        finally
+        {
+            EventStoreDaemonDiagnostics.WorkerStopped(
+                name,
+                "outbox-subscription");
+        }
+    }
+
+    private async Task DelayAfterFailureAsync(TimeSpan delay, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(delay, timeProvider, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+    }
+
+    private TimeSpan GetNextDelay(DbOutboxSubscription? checkpoint)
+    {
+        if (checkpoint?.State == SubscriptionState.Faulted &&
+            checkpoint.NextAttemptAt is { } nextAttemptAt)
+        {
+            var remaining = nextAttemptAt - timeProvider.GetUtcNow();
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+        }
+
+        return _options.PollingInterval;
+    }
+
+    private static async Task AwaitWorkersAsync(IEnumerable<Task> workers)
+    {
+        try
+        {
+            await Task.WhenAll(workers);
+        }
+        catch (OperationCanceledException)
+        {
         }
     }
 
@@ -120,7 +283,10 @@ public sealed class EntityOutboxDaemon<TDbContext>(
         var reader = (EntityOutboxReader<TDbContext>)scope.ServiceProvider.GetRequiredService<IOutboxReader>();
         var name = registration.Name;
         var startedAt = timeProvider.GetTimestamp();
-        using var activity = EventStoreDaemonDiagnostics.StartBatch(name, "outbox-subscription");
+        using var activity = EventStoreDaemonDiagnostics.StartBatch(
+            name,
+            "outbox-subscription",
+            checkpointScope);
 
         var checkpoint = await dbContext.Set<DbOutboxSubscription>().FirstOrDefaultAsync(
             row =>
@@ -146,7 +312,7 @@ public sealed class EntityOutboxDaemon<TDbContext>(
             if (checkpoint.State == SubscriptionState.Paused)
             {
                 serviceProvider.GetService<DaemonHealthMonitor>()?
-                    .Heartbeat(name, "outbox-subscription");
+                    .Heartbeat(name, "outbox-subscription", checkpointScope);
             }
             return 0;
         }
@@ -281,7 +447,7 @@ public sealed class EntityOutboxDaemon<TDbContext>(
             timeProvider.GetElapsedTime(startedAt),
             Math.Max(0, lag));
         serviceProvider.GetService<DaemonHealthMonitor>()?
-            .Heartbeat(name, "outbox-subscription");
+            .Heartbeat(name, "outbox-subscription", checkpointScope);
         return processed;
     }
 
@@ -328,7 +494,10 @@ public sealed class EntityOutboxDaemon<TDbContext>(
         var lockName = $"entity-outbox:{subscriptionName}{checkpointScope.LockSuffix}";
         try
         {
-            var acquired = await distributedLockProvider.AcquireLockAsync(lockName, _options.LockTimeout, ct);
+            var acquired = await distributedLockProvider.AcquireLockAsync(
+                lockName,
+                _options.LockTimeout,
+                ct);
             return acquired as IAsyncDisposable ?? acquired;
         }
         catch (TimeoutException)
@@ -424,6 +593,6 @@ public sealed class EntityOutboxDaemon<TDbContext>(
         }
 
         serviceProvider.GetService<DaemonHealthMonitor>()?
-            .Fault(identity, "outbox-subscription", exception);
+            .Fault(identity, "outbox-subscription", exception, checkpointScope);
     }
 }

--- a/src/EventStoreCore/EntityOutboxOptions.cs
+++ b/src/EventStoreCore/EntityOutboxOptions.cs
@@ -8,27 +8,34 @@ namespace EventStoreCore;
 public sealed class EntityOutboxOptions
 {
     /// <summary>
-    /// The maximum number of messages processed per batch.
+    /// The maximum number of outbox checkpoint workers that may process batches concurrently.
+    /// Polling and retry delays do not consume concurrency slots. The value must be positive.
+    /// </summary>
+    public int MaxConcurrentWorkers { get; set; } = 8;
+
+    /// <summary>
+    /// The positive maximum number of messages processed per batch.
     /// </summary>
     public int BatchSize { get; set; } = 500;
 
     /// <summary>
-    /// How often a caught-up daemon polls for new messages.
+    /// How often a caught-up daemon polls for new messages. The value must be non-negative.
     /// </summary>
     public TimeSpan PollingInterval { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// The delay before retrying a failed message.
+    /// The delay before retrying a failed message. The value must be non-negative.
     /// </summary>
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// The maximum time spent waiting to acquire a subscription's distributed lock.
+    /// Lock acquisition does not consume worker capacity.
     /// </summary>
     public TimeSpan LockTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
-    /// The number of failed attempts before a checkpoint is dead-lettered.
+    /// The positive number of failed attempts before a checkpoint is dead-lettered.
     /// </summary>
     public int MaxRetryAttempts { get; set; } = 3;
 

--- a/src/EventStoreCore/EntityOutboxServiceCollectionExtensions.cs
+++ b/src/EventStoreCore/EntityOutboxServiceCollectionExtensions.cs
@@ -167,7 +167,29 @@ public static class EntityOutboxServiceCollectionExtensions
 
         services.TryAddSingleton(lockProviderFactory);
         services.TryAddSingleton<DaemonHealthMonitor>();
-        services.Configure<EntityOutboxOptions>(options => configure?.Invoke(options));
+        services.AddOptions<EntityOutboxOptions>()
+            .Configure(options => configure?.Invoke(options))
+            .Validate(
+                options => options.MaxConcurrentWorkers > 0,
+                $"{nameof(EntityOutboxOptions.MaxConcurrentWorkers)} must be positive.")
+            .Validate(
+                options =>
+                    options.LockTimeout >= TimeSpan.Zero ||
+                    options.LockTimeout == Timeout.InfiniteTimeSpan,
+                $"{nameof(EntityOutboxOptions.LockTimeout)} must be non-negative or Timeout.InfiniteTimeSpan.")
+            .Validate(
+                options => options.BatchSize > 0,
+                $"{nameof(EntityOutboxOptions.BatchSize)} must be positive.")
+            .Validate(
+                options => options.MaxRetryAttempts > 0,
+                $"{nameof(EntityOutboxOptions.MaxRetryAttempts)} must be positive.")
+            .Validate(
+                options => options.PollingInterval >= TimeSpan.Zero,
+                $"{nameof(EntityOutboxOptions.PollingInterval)} must be non-negative.")
+            .Validate(
+                options => options.RetryDelay >= TimeSpan.Zero,
+                $"{nameof(EntityOutboxOptions.RetryDelay)} must be non-negative.")
+            .ValidateOnStart();
         services.TryAddSingleton<EntityOutboxDaemon<TDbContext>>();
         services.TryAddScoped<IOutboxSubscriptionManager>(sp =>
             new EntityOutboxManager<TDbContext>(

--- a/src/EventStoreCore/EventStoreDaemonDiagnostics.cs
+++ b/src/EventStoreCore/EventStoreDaemonDiagnostics.cs
@@ -34,18 +34,48 @@ internal static class EventStoreDaemonDiagnostics
     private static readonly Histogram<long> CheckpointLag = Meter.CreateHistogram<long>(
         "eventstore.daemon.checkpoint.lag",
         "{event}");
+    private static readonly UpDownCounter<long> ActiveWorkers = Meter.CreateUpDownCounter<long>(
+        "eventstore.daemon.workers.active",
+        "{worker}",
+        "Logical checkpoint workers currently running.");
+    private static readonly UpDownCounter<long> ExecutingWorkers = Meter.CreateUpDownCounter<long>(
+        "eventstore.daemon.workers.executing",
+        "{worker}",
+        "Checkpoint workers currently processing a batch.");
+    private static readonly Counter<long> ThrottledWorkers = Meter.CreateCounter<long>(
+        "eventstore.daemon.workers.throttled",
+        "{worker}",
+        "Checkpoint worker batch attempts delayed by the daemon concurrency limit.");
+    private static readonly Histogram<double> WorkerQueueDuration = Meter.CreateHistogram<double>(
+        "eventstore.daemon.worker.queue.duration",
+        "s",
+        "Time checkpoint workers spend waiting for a daemon concurrency slot.");
 
-    internal static Activity? StartBatch(string identity, string kind) =>
-        ActivitySource.StartActivity(
+    internal static Activity? StartBatch(
+        string identity,
+        string kind,
+        CheckpointScopeKey? checkpointScope = null)
+    {
+        var tags = new List<KeyValuePair<string, object?>>
+        {
+            new("eventstore.daemon.identity", identity),
+            new("eventstore.daemon.kind", kind)
+        };
+        if (checkpointScope is { } scope)
+        {
+            tags.Add(new("eventstore.daemon.checkpoint.scope", scope.Scope.ToString()));
+            if (scope.IsTenant)
+            {
+                tags.Add(new("eventstore.daemon.checkpoint.tenant_id", scope.TenantId));
+            }
+        }
+
+        return ActivitySource.StartActivity(
             "eventstore.daemon.process_batch",
             ActivityKind.Internal,
             default(ActivityContext),
-            tags:
-            new KeyValuePair<string, object?>[]
-            {
-                new("eventstore.daemon.identity", identity),
-                new("eventstore.daemon.kind", kind)
-            });
+            tags);
+    }
 
     internal static void BatchCompleted(string identity, string kind, long count, TimeSpan duration, long lag = 0)
     {
@@ -67,6 +97,28 @@ internal static class EventStoreDaemonDiagnostics
 
     internal static void LockContended(string identity, string kind) =>
         LockContention.Add(1, CreateTags(identity, kind));
+
+    internal static void WorkerStarted(string identity, string kind) =>
+        ActiveWorkers.Add(1, CreateTags(identity, kind));
+
+    internal static void WorkerStopped(string identity, string kind) =>
+        ActiveWorkers.Add(-1, CreateTags(identity, kind));
+
+    internal static void WorkerThrottled(string identity, string kind) =>
+        ThrottledWorkers.Add(1, CreateTags(identity, kind));
+
+    internal static void ExecutionStarted(
+        string identity,
+        string kind,
+        TimeSpan queueDuration)
+    {
+        var tags = CreateTags(identity, kind);
+        ExecutingWorkers.Add(1, tags);
+        WorkerQueueDuration.Record(queueDuration.TotalSeconds, tags);
+    }
+
+    internal static void ExecutionStopped(string identity, string kind) =>
+        ExecutingWorkers.Add(-1, CreateTags(identity, kind));
 
     private static TagList CreateTags(string identity, string kind) =>
         new()

--- a/src/EventStoreCore/ProjectionDaemon.cs
+++ b/src/EventStoreCore/ProjectionDaemon.cs
@@ -63,35 +63,205 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Projection daemon starting with {Count} registered projections", _projections.Count);
+        var limiter = new DaemonExecutionLimiter(
+            _options.MaxConcurrentWorkers,
+            _timeProvider);
+        var workers = _projections
+            .Select(projection => RunProjectionAsync(
+                projection,
+                limiter,
+                stoppingToken))
+            .ToArray();
 
-        while (!stoppingToken.IsCancellationRequested)
+        try
         {
-            foreach (var projection in _projections)
-            {
-                if (stoppingToken.IsCancellationRequested)
-                    break;
+            await Task.WhenAll(workers);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Projection daemon stopping gracefully");
+        }
+    }
 
+    private async Task RunProjectionAsync(
+        ProjectionRegistration projection,
+        DaemonExecutionLimiter limiter,
+        CancellationToken ct)
+    {
+        if (_options.CheckpointScope == CheckpointScope.Global)
+        {
+            await RunCheckpointWorkerAsync(
+                projection,
+                CheckpointScopeKey.Global,
+                limiter,
+                ct);
+            return;
+        }
+
+        var scopeWorkers = new Dictionary<CheckpointScopeKey, Task>();
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
                 try
                 {
-                    await ProcessProjectionAsync(projection, stoppingToken);
+                    foreach (var checkpointScope in await GetCheckpointScopesAsync(
+                        projection.Name,
+                        ct))
+                    {
+                        if (!scopeWorkers.ContainsKey(checkpointScope))
+                        {
+                            scopeWorkers.Add(
+                                checkpointScope,
+                                RunCheckpointWorkerAsync(
+                                    projection,
+                                    checkpointScope,
+                                    limiter,
+                                    ct));
+                        }
+                    }
+
+                    await Task.Delay(
+                        _options.PollingInterval,
+                        _timeProvider,
+                        ct);
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
-                    _logger.LogInformation("Projection daemon stopping gracefully");
                     break;
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error processing projection {Projection}", projection.Name);
-                    EventStoreDaemonDiagnostics.Retry(projection.Name, "projection");
-                    await Task.Delay(_options.RetryDelay, _timeProvider, stoppingToken);
+                    _logger.LogError(
+                        ex,
+                        "Error discovering checkpoint scopes for projection {Projection}. Retrying in {RetryDelay}",
+                        projection.Name,
+                        _options.RetryDelay);
+                    EventStoreDaemonDiagnostics.Retry(
+                        projection.Name,
+                        "projection");
+                    await DelayAfterFailureAsync(_options.RetryDelay, ct);
                 }
             }
+        }
+        finally
+        {
+            await AwaitWorkersAsync(scopeWorkers.Values);
+        }
+    }
 
-            if (!stoppingToken.IsCancellationRequested)
+    private async Task RunCheckpointWorkerAsync(
+        ProjectionRegistration projection,
+        CheckpointScopeKey checkpointScope,
+        DaemonExecutionLimiter limiter,
+        CancellationToken ct)
+    {
+        EventStoreDaemonDiagnostics.WorkerStarted(
+            projection.Name,
+            "projection");
+        try
+        {
+            while (!ct.IsCancellationRequested)
             {
-                await Task.Delay(_options.PollingInterval, _timeProvider, stoppingToken);
+                try
+                {
+                    IDistributedSynchronizationHandle? lockHandle = null;
+                    bool processed;
+                    try
+                    {
+                        lockHandle = await AcquireProjectionLockAsync(
+                            projection,
+                            checkpointScope,
+                            ValidateLockTimeout(_options.LockTimeout),
+                            ct);
+                        processed = lockHandle is not null &&
+                            await limiter.RunAsync(
+                                projection.Name,
+                                "projection",
+                                token => ProcessProjectionScopeUnderLockAsync(
+                                    projection,
+                                    checkpointScope,
+                                    token),
+                                ct);
+
+                        if (processed && _options.BatchDelay > TimeSpan.Zero)
+                        {
+                            await Task.Delay(
+                                _options.BatchDelay,
+                                _timeProvider,
+                                ct);
+                        }
+                    }
+                    finally
+                    {
+                        if (lockHandle is not null)
+                        {
+                            await lockHandle.DisposeAsync();
+                            _logger.LogDebug(
+                                "Released lock for projection {Projection} in checkpoint scope {Scope}",
+                                projection.Name,
+                                checkpointScope);
+                        }
+                    }
+
+                    if (!processed)
+                    {
+                        await Task.Delay(
+                            _options.PollingInterval,
+                            _timeProvider,
+                            ct);
+                    }
+                    else if (_options.BatchDelay <= TimeSpan.Zero)
+                    {
+                        await Task.Yield();
+                    }
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Error processing projection {Projection} in checkpoint scope {Scope}. Retrying in {RetryDelay}",
+                        projection.Name,
+                        checkpointScope,
+                        _options.RetryDelay);
+                    EventStoreDaemonDiagnostics.Retry(
+                        projection.Name,
+                        "projection");
+                    await DelayAfterFailureAsync(_options.RetryDelay, ct);
+                }
             }
+        }
+        finally
+        {
+            EventStoreDaemonDiagnostics.WorkerStopped(
+                projection.Name,
+                "projection");
+        }
+    }
+
+    private async Task DelayAfterFailureAsync(TimeSpan delay, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(delay, _timeProvider, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+    }
+
+    private static async Task AwaitWorkersAsync(IEnumerable<Task> workers)
+    {
+        try
+        {
+            await Task.WhenAll(workers);
+        }
+        catch (OperationCanceledException)
+        {
         }
     }
 
@@ -131,74 +301,122 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
         CheckpointScopeKey checkpointScope,
         CancellationToken ct)
     {
-        var lockName = $"projection:{projection.Name}{checkpointScope.LockSuffix}";
-
-        IDistributedSynchronizationHandle? lockHandle = null;
-        try
+        var lockHandle = await AcquireProjectionLockAsync(
+            projection,
+            checkpointScope,
+            ValidateLockTimeout(_options.LockTimeout),
+            ct);
+        if (lockHandle is null)
         {
-            lockHandle = await _distributedLockProvider.TryAcquireLockAsync(
-                lockName,
-                ValidateLockTimeout(_options.LockTimeout),
-                ct);
-
-            if (lockHandle == null)
-            {
-                EventStoreDaemonDiagnostics.LockContended(projection.Name, "projection");
-                _logger.LogDebug("Could not acquire lock for projection {Projection}, another instance may be processing", projection.Name);
-                return;
-            }
-
-            _logger.LogDebug("Acquired lock for projection {Projection}", projection.Name);
-
-            using var scope = _serviceProvider.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
-
-            var status = await GetOrCreateStatusAsync(dbContext, projection, checkpointScope, ct);
-
-            // Check for version mismatch and trigger rebuild if configured
-            if (_options.AutoRebuildOnVersionChange && status.Version != projection.Version)
-            {
-                if (checkpointScope.IsTenant)
-                {
-                    throw new InvalidOperationException(
-                        "Tenant-scoped projection checkpoints do not support automatic rebuild because projection ClearAsync is not tenant-aware. " +
-                        "Disable AutoRebuildOnVersionChange or run a global projection rebuild.");
-                }
-
-                _logger.LogInformation(
-                    "Projection {Projection} version changed from {OldVersion} to {NewVersion}, triggering rebuild",
-                    projection.Name, status.Version, projection.Version);
-
-                await InitiateRebuildAsync(dbContext, scope.ServiceProvider, projection, status, ct);
-            }
-
-            // Process based on current state
-            switch (status.State)
-            {
-                case ProjectionState.Active:
-                    await ProcessEventsAsync(dbContext, scope.ServiceProvider, projection, status, ct);
-                    break;
-
-                case ProjectionState.Rebuilding:
-                    await ContinueRebuildAsync(dbContext, scope.ServiceProvider, projection, status, ct);
-                    break;
-
-                case ProjectionState.Paused:
-                    _logger.LogDebug("Projection {Projection} is paused, skipping", projection.Name);
-                    break;
-
-                case ProjectionState.Faulted:
-                    _logger.LogDebug("Projection {Projection} is faulted, requires manual intervention", projection.Name);
-                    break;
-            }
+            return;
         }
-        finally
+
+        await using (lockHandle)
         {
-            if (lockHandle != null)
+            await ProcessProjectionScopeUnderLockAsync(
+                projection,
+                checkpointScope,
+                ct);
+        }
+        _logger.LogDebug(
+            "Released lock for projection {Projection} in checkpoint scope {Scope}",
+            projection.Name,
+            checkpointScope);
+    }
+
+    private async Task<IDistributedSynchronizationHandle?> AcquireProjectionLockAsync(
+        ProjectionRegistration projection,
+        CheckpointScopeKey checkpointScope,
+        TimeSpan timeout,
+        CancellationToken ct)
+    {
+        var lockName = $"projection:{projection.Name}{checkpointScope.LockSuffix}";
+        var lockHandle = await _distributedLockProvider.TryAcquireLockAsync(
+            lockName,
+            timeout,
+            ct);
+        if (lockHandle is null)
+        {
+            EventStoreDaemonDiagnostics.LockContended(projection.Name, "projection");
+            _logger.LogDebug(
+                "Could not acquire lock for projection {Projection} in checkpoint scope {Scope}, another instance may be processing",
+                projection.Name,
+                checkpointScope);
+            return null;
+        }
+
+        _logger.LogDebug(
+            "Acquired lock for projection {Projection} in checkpoint scope {Scope}",
+            projection.Name,
+            checkpointScope);
+        return lockHandle;
+    }
+
+    private async Task<bool> ProcessProjectionScopeUnderLockAsync(
+        ProjectionRegistration projection,
+        CheckpointScopeKey checkpointScope,
+        CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
+
+        var status = await GetOrCreateStatusAsync(
+            dbContext,
+            projection,
+            checkpointScope,
+            ct);
+
+        // Check for version mismatch and trigger rebuild if configured
+        if (_options.AutoRebuildOnVersionChange && status.Version != projection.Version)
+        {
+            if (checkpointScope.IsTenant)
             {
-                await lockHandle.DisposeAsync();
-                _logger.LogDebug("Released lock for projection {Projection}", projection.Name);
+                throw new InvalidOperationException(
+                    "Tenant-scoped projection checkpoints do not support automatic rebuild because projection ClearAsync is not tenant-aware. " +
+                    "Disable AutoRebuildOnVersionChange or run a global projection rebuild.");
             }
+
+            _logger.LogInformation(
+                "Projection {Projection} version changed from {OldVersion} to {NewVersion}, triggering rebuild",
+                projection.Name, status.Version, projection.Version);
+
+            await InitiateRebuildAsync(
+                dbContext,
+                scope.ServiceProvider,
+                projection,
+                status,
+                ct);
+        }
+
+        // Process based on current state
+        switch (status.State)
+        {
+            case ProjectionState.Active:
+                return await ProcessEventsAsync(
+                    dbContext,
+                    scope.ServiceProvider,
+                    projection,
+                    status,
+                    ct);
+
+            case ProjectionState.Rebuilding:
+                return await ContinueRebuildAsync(
+                    dbContext,
+                    scope.ServiceProvider,
+                    projection,
+                    status,
+                    ct);
+
+            case ProjectionState.Paused:
+                _logger.LogDebug("Projection {Projection} is paused, skipping", projection.Name);
+                return false;
+
+            case ProjectionState.Faulted:
+                _logger.LogDebug("Projection {Projection} is faulted, requires manual intervention", projection.Name);
+                return false;
+
+            default:
+                return false;
         }
     }
 
@@ -305,7 +523,7 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     /// <param name="projection">The projection registration.</param>
     /// <param name="status">The current projection status.</param>
     /// <param name="ct">Cancellation token.</param>
-    private async Task ContinueRebuildAsync(
+    private async Task<bool> ContinueRebuildAsync(
         TDbContext dbContext,
         IServiceProvider services,
         ProjectionRegistration projection,
@@ -327,6 +545,8 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
                 projection.Name,
                 status.RebuildCompletedAt - status.RebuildStartedAt);
         }
+
+        return processed;
     }
 
     /// <summary>
@@ -337,7 +557,7 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     /// <param name="projection">The projection registration.</param>
     /// <param name="status">The current projection status.</param>
     /// <param name="ct">Cancellation token.</param>
-    private async Task ProcessEventsAsync(
+    private async Task<bool> ProcessEventsAsync(
         TDbContext dbContext,
         IServiceProvider services,
         ProjectionRegistration projection,
@@ -352,6 +572,8 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
             _logger.LogDebug("Projection {Projection} is caught up at position {Position}", 
                 projection.Name, status.Position);
         }
+
+        return processed;
     }
 
     /// <summary>
@@ -372,7 +594,10 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
     {
         var checkpointScope = new CheckpointScopeKey(status.CheckpointScope, status.TenantId);
         var startedAt = _timeProvider.GetTimestamp();
-        using var activity = EventStoreDaemonDiagnostics.StartBatch(projection.Name, "projection");
+        using var activity = EventStoreDaemonDiagnostics.StartBatch(
+            projection.Name,
+            "projection",
+            checkpointScope);
         var events = await ApplyCheckpointScope(dbContext.Events, checkpointScope)
             .Where(e => e.Sequence > status.Position)
             .OrderBy(e => e.Sequence)
@@ -382,7 +607,10 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
 
         if (events.Count == 0)
         {
-            _serviceProvider.GetService<DaemonHealthMonitor>()?.Heartbeat(projection.Name, "projection");
+            _serviceProvider.GetService<DaemonHealthMonitor>()?.Heartbeat(
+                projection.Name,
+                "projection",
+                checkpointScope);
             return false;
         }
 
@@ -450,12 +678,6 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
                 "Processed batch for projection {Projection}, new position: {Position}",
                 projection.Name, status.Position);
 
-            // Optional batch delay for throttling
-            if (_options.BatchDelay > TimeSpan.Zero)
-            {
-                await Task.Delay(_options.BatchDelay, _timeProvider, ct);
-            }
-
             var checkpointLag = await ApplyCheckpointScope(dbContext.Events, checkpointScope)
                 .LongCountAsync(e => e.Sequence > status.Position, ct);
             EventStoreDaemonDiagnostics.BatchCompleted(
@@ -464,14 +686,25 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
                 events.Count,
                 _timeProvider.GetElapsedTime(startedAt),
                 checkpointLag);
-            _serviceProvider.GetService<DaemonHealthMonitor>()?.Heartbeat(projection.Name, "projection");
+            _serviceProvider.GetService<DaemonHealthMonitor>()?.Heartbeat(
+                projection.Name,
+                "projection",
+                checkpointScope);
             return true;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex,
                 "Error processing event at sequence {Sequence} for projection {Projection}",
                 status.Position + 1, projection.Name);
+
+            // Release any provider locks held by the failed transaction before a
+            // separate context persists the durable fault checkpoint.
+            await transaction.RollbackAsync(ct);
 
             // Mark projection as faulted
             status.State = ProjectionState.Faulted;
@@ -578,6 +811,10 @@ public sealed class ProjectionDaemon<TDbContext> : BackgroundService
                     identity);
             }
         }
-        _serviceProvider.GetService<DaemonHealthMonitor>()?.Fault(identity, "projection", exception);
+        _serviceProvider.GetService<DaemonHealthMonitor>()?.Fault(
+            identity,
+            "projection",
+            exception,
+            new CheckpointScopeKey(status.CheckpointScope, status.TenantId));
     }
 }

--- a/src/EventStoreCore/ProjectionDaemonOptions.cs
+++ b/src/EventStoreCore/ProjectionDaemonOptions.cs
@@ -9,20 +9,27 @@ namespace EventStoreCore;
 public sealed class ProjectionDaemonOptions
 {
     /// <summary>
-    /// The number of events to process in each batch during rebuilds and catch-up.
+    /// The maximum number of projection checkpoint workers that may process batches concurrently.
+    /// Polling and retry delays do not consume concurrency slots. The value must be positive.
+    /// </summary>
+    public int MaxConcurrentWorkers { get; set; } = 8;
+
+    /// <summary>
+    /// The positive number of events to process in each batch during rebuilds and catch-up.
     /// Default is 500.
     /// </summary>
     public int BatchSize { get; set; } = 500;
 
     /// <summary>
-    /// How often the daemon polls for new events when caught up.
+    /// How often the daemon polls for new events when caught up. The value must be non-negative.
     /// Default is 5 seconds.
     /// </summary>
     public TimeSpan PollingInterval { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Maximum time to wait to acquire a distributed lock for a projection.
-    /// The acquired lock is held until its handle is disposed.
+    /// Lock acquisition does not consume worker capacity. The acquired lock is held
+    /// until its handle is disposed.
     /// Default is 5 minutes.
     /// </summary>
     public TimeSpan LockTimeout { get; set; } = TimeSpan.FromMinutes(5);
@@ -34,7 +41,7 @@ public sealed class ProjectionDaemonOptions
     public bool AutoRebuildOnVersionChange { get; set; } = true;
 
     /// <summary>
-    /// How long to wait before retrying after an error.
+    /// How long to wait before retrying after an error. The value must be non-negative.
     /// Default is 30 seconds.
     /// </summary>
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(30);
@@ -46,7 +53,7 @@ public sealed class ProjectionDaemonOptions
     public CheckpointScope CheckpointScope { get; set; } = CheckpointScope.Global;
 
     /// <summary>
-    /// Optional delay between batches during rebuild (for throttling).
+    /// Optional non-negative delay between batches during rebuild (for throttling).
     /// Default is no delay.
     /// </summary>
     public TimeSpan BatchDelay { get; set; } = TimeSpan.Zero;

--- a/src/EventStoreCore/README.md
+++ b/src/EventStoreCore/README.md
@@ -41,6 +41,12 @@ infrastructure remains application-owned.
 - Inline projections participate in the append transaction.
 - Subscriptions and eventual projections are at-least-once and consumers must be
   idempotent.
+- Daemons isolate each registration/checkpoint scope in its own logical worker
+  and apply a configurable `MaxConcurrentWorkers` bound to active
+  batch executions. Distributed-lock, polling, and retry waits do not occupy
+  worker capacity.
+- Distributed locks continue to cover handler or projection execution and
+  checkpoint persistence. Shutdown cancels and awaits all logical workers.
 - Provider-specific storage types and migration considerations are documented by
   the PostgreSQL and SQL Server packages.
 

--- a/src/EventStoreCore/SubscriptionDaemon.cs
+++ b/src/EventStoreCore/SubscriptionDaemon.cs
@@ -37,44 +37,142 @@ public sealed class SubscriptionDaemon<TDbContext>(
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var registrations = GetRegistrations();
+        var limiter = new DaemonExecutionLimiter(
+            _options.MaxConcurrentWorkers,
+            _timeProvider);
+        var workers = registrations
+            .Select(registration => RunRegistrationAsync(
+                registration,
+                limiter,
+                stoppingToken))
+            .ToArray();
 
-        while (!stoppingToken.IsCancellationRequested)
+        try
         {
-            foreach (var registration in registrations)
-            {
-                var subscription = registration.Subscription;
-                var subscriptionType = subscription.GetType();
-                var name = registration.Name;
+            await Task.WhenAll(workers);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            logger.LogInformation("Subscription daemon stopping gracefully");
+        }
+    }
 
+    private async Task RunRegistrationAsync(
+        SubscriptionRegistration registration,
+        DaemonExecutionLimiter limiter,
+        CancellationToken ct)
+    {
+        if (_options.CheckpointScope == CheckpointScope.Global)
+        {
+            await RunCheckpointWorkerAsync(
+                registration,
+                CheckpointScopeKey.Global,
+                limiter,
+                ct);
+            return;
+        }
+
+        var scopeWorkers = new Dictionary<CheckpointScopeKey, Task>();
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
                 try
                 {
-                    var checkpointScopes = await GetCheckpointScopesAsync(name, stoppingToken);
-
-                    if (checkpointScopes.Count == 0)
-                    {
-                        await Task.Delay(_options.PollingInterval, _timeProvider, stoppingToken);
-                        continue;
-                    }
-
-                    var processedAny = false;
+                    var checkpointScopes = await GetCheckpointScopesAsync(
+                        registration.Name,
+                        ct);
                     foreach (var checkpointScope in checkpointScopes)
                     {
-                        var acquired = await AcquireSubscriptionLockAsync(name, checkpointScope, stoppingToken);
-
-                        if (acquired == null)
+                        if (!scopeWorkers.ContainsKey(checkpointScope))
                         {
-                            continue;
+                            scopeWorkers.Add(
+                                checkpointScope,
+                                RunCheckpointWorkerAsync(
+                                    registration,
+                                    checkpointScope,
+                                    limiter,
+                                    ct));
                         }
+                    }
 
+                    await Task.Delay(
+                        _options.PollingInterval,
+                        _timeProvider,
+                        ct);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(
+                        ex,
+                        "Error discovering checkpoint scopes for subscription {Subscription}. Retrying in {RetryDelay}",
+                        registration.Name,
+                        _options.RetryDelay);
+                    EventStoreDaemonDiagnostics.Retry(
+                        registration.Name,
+                        "subscription");
+                    await DelayAfterFailureAsync(_options.RetryDelay, ct);
+                }
+            }
+        }
+        finally
+        {
+            await AwaitWorkersAsync(scopeWorkers.Values);
+        }
+    }
+
+    private async Task RunCheckpointWorkerAsync(
+        SubscriptionRegistration registration,
+        CheckpointScopeKey checkpointScope,
+        DaemonExecutionLimiter limiter,
+        CancellationToken ct)
+    {
+        var name = registration.Name;
+        EventStoreDaemonDiagnostics.WorkerStarted(name, "subscription");
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    var acquired = await AcquireSubscriptionLockAsync(
+                        name,
+                        checkpointScope,
+                        ValidateLockTimeout(_options.LockTimeout),
+                        ct);
+                    var iteration = (ProcessedCount: 0, Delay: _options.PollingInterval);
+                    if (acquired is not null)
+                    {
                         await using (acquired)
                         {
-                            using var scope = _serviceProvider.CreateScope();
-                            var processedCount = await ProcessNextBatchAsync(
-                                scope,
-                                registration,
-                                stoppingToken,
-                                checkpointScope);
-                            processedAny = processedAny || processedCount > 0;
+                            iteration = await limiter.RunAsync(
+                                name,
+                                "subscription",
+                                async token =>
+                                {
+                                    using var scope = _serviceProvider.CreateScope();
+                                    var processed = await ProcessNextBatchAsync(
+                                        scope,
+                                        registration,
+                                        token,
+                                        checkpointScope);
+                                    var checkpoint = scope.ServiceProvider
+                                        .GetRequiredService<TDbContext>()
+                                        .Set<DbSubscription>()
+                                        .Local
+                                        .FirstOrDefault(row =>
+                                            row.SubscriptionAssemblyQualifiedName == name &&
+                                            row.CheckpointScope == checkpointScope.Scope &&
+                                            row.TenantId == checkpointScope.TenantId);
+                                    return (
+                                        processed,
+                                        GetNextDelay(checkpoint));
+                                },
+                                ct);
                         }
 
                         logger.LogInformation(
@@ -83,36 +181,76 @@ public sealed class SubscriptionDaemon<TDbContext>(
                             checkpointScope);
                     }
 
-                    if (!processedAny)
+                    if (iteration.ProcessedCount == 0)
                     {
                         logger.LogInformation(
-                            "No new events to process for subscription {Subscription}",
-                            name);
-                        await Task.Delay(_options.PollingInterval, _timeProvider, stoppingToken);
+                            "No new events to process for subscription {Subscription} in checkpoint scope {Scope}",
+                            name,
+                            checkpointScope);
+                        await Task.Delay(
+                            iteration.Delay,
+                            _timeProvider,
+                            ct);
+                    }
+                    else
+                    {
+                        await Task.Yield();
                     }
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
-                    logger.LogInformation("Subscription {Subscription} stopping gracefully", name);
                     break;
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex,
-                        "Error processing events for subscription {Subscription}. Retrying in {RetrySeconds} seconds",
-                        name, _options.RetryDelay);
-
-                    try
-                    {
-                        EventStoreDaemonDiagnostics.Retry(name, "subscription");
-                        await Task.Delay(_options.RetryDelay, _timeProvider, stoppingToken);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        break;
-                    }
+                    logger.LogError(
+                        ex,
+                        "Error processing events for subscription {Subscription} in checkpoint scope {Scope}. Retrying in {RetryDelay}",
+                        name,
+                        checkpointScope,
+                        _options.RetryDelay);
+                    EventStoreDaemonDiagnostics.Retry(name, "subscription");
+                    await DelayAfterFailureAsync(_options.RetryDelay, ct);
                 }
             }
+        }
+        finally
+        {
+            EventStoreDaemonDiagnostics.WorkerStopped(name, "subscription");
+        }
+    }
+
+    private async Task DelayAfterFailureAsync(TimeSpan delay, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(delay, _timeProvider, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+    }
+
+    private TimeSpan GetNextDelay(DbSubscription? checkpoint)
+    {
+        if (checkpoint?.State == SubscriptionState.Faulted &&
+            checkpoint.NextAttemptAt is { } nextAttemptAt)
+        {
+            var remaining = nextAttemptAt - _timeProvider.GetUtcNow();
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+        }
+
+        return _options.PollingInterval;
+    }
+
+    private static async Task AwaitWorkersAsync(IEnumerable<Task> workers)
+    {
+        try
+        {
+            await Task.WhenAll(workers);
+        }
+        catch (OperationCanceledException)
+        {
         }
     }
 
@@ -195,7 +333,10 @@ public sealed class SubscriptionDaemon<TDbContext>(
         var name = registration.Name;
         var dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
         var startedAt = _timeProvider.GetTimestamp();
-        using var activity = EventStoreDaemonDiagnostics.StartBatch(name, "subscription");
+        using var activity = EventStoreDaemonDiagnostics.StartBatch(
+            name,
+            "subscription",
+            checkpointScope);
 
         await using var transaction = await dbContext.Database.BeginTransactionAsync(stoppingToken);
 
@@ -250,7 +391,10 @@ public sealed class SubscriptionDaemon<TDbContext>(
                     await transaction.CommitAsync(stoppingToken);
                 }
 
-                _serviceProvider.GetService<DaemonHealthMonitor>()?.Heartbeat(name, "subscription");
+                _serviceProvider.GetService<DaemonHealthMonitor>()?.Heartbeat(
+                    name,
+                    "subscription",
+                    checkpointScope);
                 return 0;
             }
 
@@ -428,7 +572,10 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 processedCount,
                 _timeProvider.GetElapsedTime(startedAt),
                 checkpointLag);
-            _serviceProvider.GetService<DaemonHealthMonitor>()?.Heartbeat(name, "subscription");
+            _serviceProvider.GetService<DaemonHealthMonitor>()?.Heartbeat(
+                name,
+                "subscription",
+                checkpointScope);
 
             return processedCount;
         }
@@ -453,6 +600,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
         return await AcquireSubscriptionLockAsync(
             typeof(TSub).AssemblyQualifiedName!,
             CheckpointScopeKey.Global,
+            ValidateLockTimeout(_options.LockTimeout),
             cancellationToken);
     }
 
@@ -467,12 +615,14 @@ public sealed class SubscriptionDaemon<TDbContext>(
         return await AcquireSubscriptionLockAsync(
             subType.AssemblyQualifiedName!,
             CheckpointScopeKey.Global,
+            ValidateLockTimeout(_options.LockTimeout),
             cancellationToken);
     }
 
     private async Task<IAsyncDisposable?> AcquireSubscriptionLockAsync(
         string subscriptionName,
         CheckpointScopeKey checkpointScope,
+        TimeSpan timeout,
         CancellationToken cancellationToken)
     {
         var lockName = $"{subscriptionName}{checkpointScope.LockSuffix}";
@@ -485,7 +635,7 @@ public sealed class SubscriptionDaemon<TDbContext>(
                 subscriptionName,
                 checkpointScope);
             var acquired = await _distributedLockProvider
-                  .AcquireLockAsync(lockName, ValidateLockTimeout(_options.LockTimeout), cancellationToken: cancellationToken);
+                  .AcquireLockAsync(lockName, timeout, cancellationToken: cancellationToken);
 
             if (acquired == null)
             {
@@ -735,6 +885,10 @@ public sealed class SubscriptionDaemon<TDbContext>(
                     identity);
             }
         }
-        _serviceProvider.GetService<DaemonHealthMonitor>()?.Fault(identity, kind, exception);
+        _serviceProvider.GetService<DaemonHealthMonitor>()?.Fault(
+            identity,
+            kind,
+            exception,
+            checkpointScope);
     }
 }

--- a/src/EventStoreCore/SubscriptionOptions.cs
+++ b/src/EventStoreCore/SubscriptionOptions.cs
@@ -8,28 +8,35 @@ namespace EventStoreCore;
 public sealed class SubscriptionOptions
 {
     /// <summary>
-    /// The number of events to read and process in each daemon batch.
+    /// The maximum number of subscription checkpoint workers that may process batches concurrently.
+    /// Polling and retry delays do not consume concurrency slots. The value must be positive.
+    /// </summary>
+    public int MaxConcurrentWorkers { get; set; } = 8;
+
+    /// <summary>
+    /// The positive number of events to read and process in each daemon batch.
     /// </summary>
     public int BatchSize { get; set; } = 500;
 
     /// <summary>
-    /// How many processed events to handle before persisting the subscription checkpoint.
+    /// The positive number of processed events to handle before persisting the subscription checkpoint.
     /// </summary>
     public int CheckpointFrequency { get; set; } = 1;
 
     /// <summary>
-    /// How often to poll for new events when caught up.
+    /// How often to poll for new events when caught up. The value must be non-negative.
     /// </summary>
     public TimeSpan PollingInterval { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Maximum time to wait to acquire a distributed lock for a subscription.
-    /// The acquired lock is held until its handle is disposed.
+    /// Lock acquisition does not consume worker capacity. The acquired lock is held
+    /// until its handle is disposed.
     /// </summary>
     public TimeSpan LockTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
-    /// Maximum retry attempts before giving up in the daemon loop.
+    /// The positive maximum retry attempts before giving up in the daemon loop.
     /// </summary>
     public int MaxRetryAttempts { get; set; } = 3;
 
@@ -39,7 +46,7 @@ public sealed class SubscriptionOptions
     public CheckpointScope CheckpointScope { get; set; } = CheckpointScope.Global;
 
     /// <summary>
-    /// Delay between retry attempts when processing fails.
+    /// Delay between retry attempts when processing fails. The value must be non-negative.
     /// </summary>
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(10);
 }

--- a/tests/EventStoreCore.Tests/CloudEventSubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/CloudEventSubscriptionTests.cs
@@ -77,7 +77,7 @@ public class CloudEventSubscriptionTests(PostgresFixture fixture) : IClassFixtur
         List<object> events = [new TestEvent(), new TestEvent2()];
         eventStore.StartStream(streamId, events: events);
         await eventStoreDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
-        var lastWrittenSequence = await eventStoreDbContext.Events
+        var lastWrittenSequence = await eventStoreDbContext.Set<DbEvent>()
             .Where(e => e.StreamId == streamId)
             .MaxAsync(e => e.Sequence, TestContext.Current.CancellationToken);
 

--- a/tests/EventStoreCore.Tests/Coverage/SubscriptionManagerCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/SubscriptionManagerCoverageTests.cs
@@ -149,7 +149,7 @@ public class SubscriptionManagerCoverageTests
         db.Streams.StartStream(streamId, events: [new object()]);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var trackedEvent = await db.Events
+        var trackedEvent = await db.Set<DbEvent>()
             .OrderBy(e => e.Sequence)
             .FirstAsync(TestContext.Current.CancellationToken);
         trackedEvent.Timestamp = DateTimeOffset.UtcNow;

--- a/tests/EventStoreCore.Tests/Coverage/TestDbContextCoverageTests.cs
+++ b/tests/EventStoreCore.Tests/Coverage/TestDbContextCoverageTests.cs
@@ -20,7 +20,7 @@ public class TestDbContextCoverageTests
     {
         var dbContext = new TestDbContext(Guid.NewGuid().ToString("N"));
 
-        Assert.NotNull(dbContext.Events);
+        Assert.NotNull(dbContext.Set<DbEvent>());
         Assert.NotNull(dbContext.Stream);
     }
 }

--- a/tests/EventStoreCore.Tests/DaemonOptionsTests.cs
+++ b/tests/EventStoreCore.Tests/DaemonOptionsTests.cs
@@ -1,0 +1,82 @@
+using EventStoreCore;
+using EventStoreCore.Abstractions;
+using Medallion.Threading;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace EventStoreCore.Tests;
+
+public sealed class DaemonOptionsTests
+{
+    [Fact]
+    public void ProjectionDaemonOptions_HasExpectedSchedulingDefaults()
+    {
+        var options = new ProjectionDaemonOptions();
+
+        Assert.Equal(8, options.MaxConcurrentWorkers);
+        Assert.Equal(500, options.BatchSize);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.PollingInterval);
+        Assert.Equal(TimeSpan.FromMinutes(5), options.LockTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(30), options.RetryDelay);
+        Assert.Equal(CheckpointScope.Global, options.CheckpointScope);
+    }
+
+    [Fact]
+    public void EntityOutboxOptions_HasExpectedSchedulingDefaults()
+    {
+        var options = new EntityOutboxOptions();
+
+        Assert.Equal(8, options.MaxConcurrentWorkers);
+        Assert.Equal(500, options.BatchSize);
+        Assert.Equal(TimeSpan.FromSeconds(10), options.PollingInterval);
+        Assert.Equal(TimeSpan.FromMinutes(5), options.LockTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(10), options.RetryDelay);
+        Assert.Equal(CheckpointScope.Global, options.CheckpointScope);
+    }
+
+    [Fact]
+    public void SubscriptionDaemon_RejectsNonPositiveWorkerLimit()
+    {
+        var services = new ServiceCollection();
+        var builder = new EfCoreEventEventStoreBuilder<ValidationDbContext>(services);
+        builder.AddSubscriptionDaemon(
+            _ => Substitute.For<IDistributedLockProvider>(),
+            options => options.MaxConcurrentWorkers = 0);
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<SubscriptionOptions>>().Value);
+    }
+
+    [Fact]
+    public void ProjectionDaemon_RejectsNonPositiveWorkerLimit()
+    {
+        var services = new ServiceCollection();
+        var builder = new EfCoreEventEventStoreBuilder<ValidationDbContext>(services);
+        builder.AddProjectionDaemon(
+            _ => Substitute.For<IDistributedLockProvider>(),
+            options => options.MaxConcurrentWorkers = 0);
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ProjectionDaemonOptions>>().Value);
+    }
+
+    [Fact]
+    public void EntityOutboxDaemon_RejectsNonPositiveWorkerLimit()
+    {
+        var services = new ServiceCollection();
+        services.AddEntityOutboxDaemon<ValidationDbContext>(
+            _ => Substitute.For<IDistributedLockProvider>(),
+            options => options.MaxConcurrentWorkers = 0);
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<EntityOutboxOptions>>().Value);
+    }
+
+    private sealed class ValidationDbContext(
+        DbContextOptions<ValidationDbContext> options) : DbContext(options);
+}

--- a/tests/EventStoreCore.Tests/DaemonRegistrationTests.cs
+++ b/tests/EventStoreCore.Tests/DaemonRegistrationTests.cs
@@ -131,4 +131,25 @@ public sealed class DaemonRegistrationTests
         Assert.Single(report.Entries);
         Assert.Equal(time.GetUtcNow().AddMinutes(-6), report.Entries[0].LastHeartbeat);
     }
+
+    [Fact]
+    public void Healthy_tenant_heartbeat_does_not_clear_another_tenant_fault()
+    {
+        var monitor = new DaemonHealthMonitor();
+        var faultedTenant = CheckpointScopeKey.Tenant(Guid.NewGuid());
+        var healthyTenant = CheckpointScopeKey.Tenant(Guid.NewGuid());
+
+        monitor.Fault(
+            "orders",
+            "subscription",
+            new InvalidOperationException("failed"),
+            faultedTenant);
+        monitor.Heartbeat("orders", "subscription", healthyTenant);
+
+        var report = monitor.CheckHealth(TimeSpan.FromMinutes(5));
+
+        Assert.Equal(DaemonHealthStatus.Unhealthy, report.Status);
+        Assert.Equal(2, report.Entries.Count);
+        Assert.Single(report.Entries, entry => entry.IsFaulted);
+    }
 }

--- a/tests/EventStoreCore.Tests/Daemons/DaemonHarnessTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/DaemonHarnessTests.cs
@@ -188,7 +188,7 @@ public class DaemonHarnessTests
         db.Streams.StartStream(Guid.NewGuid(), events: [new ProjectionEvent { Name = "one" }]);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var storedEvent = await db.Events.FirstAsync(TestContext.Current.CancellationToken);
+        var storedEvent = await db.Set<DbEvent>().FirstAsync(TestContext.Current.CancellationToken);
         if (storedEvent.Sequence == 0)
         {
             storedEvent.Sequence = 1;
@@ -348,7 +348,7 @@ public class DaemonHarnessTests
             Type = typeof(ProjectionEvent).AssemblyQualifiedName!,
             Data = "{\"Name\":\"Active\"}"
         };
-        db.Events.Add(dbEvent);
+        db.Set<DbEvent>().Add(dbEvent);
         db.Set<DbProjectionStatus>().Add(new DbProjectionStatus
         {
             ProjectionName = registration.Name,
@@ -406,7 +406,7 @@ public class DaemonHarnessTests
             TypeName = "old_projection_event",
             Data = "{\"OldName\":\"Upcasted\"}"
         };
-        db.Events.Add(dbEvent);
+        db.Set<DbEvent>().Add(dbEvent);
         db.Set<DbProjectionStatus>().Add(new DbProjectionStatus
         {
             ProjectionName = registration.Name,

--- a/tests/EventStoreCore.Tests/Daemons/DaemonSchedulingIsolationTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/DaemonSchedulingIsolationTests.cs
@@ -1,0 +1,910 @@
+using EventStoreCore;
+using EventStoreCore.Abstractions;
+using EventStoreCore.Postgres;
+using Medallion.Threading;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace EventStoreCore.Tests;
+
+public sealed class DaemonSchedulingIsolationTests
+{
+    [Fact]
+    public async Task Slow_stream_subscription_does_not_block_another_registration()
+    {
+        var slowEntered = NewSignal();
+        var releaseSlow = NewSignal();
+        var fastHandled = NewSignal();
+        var slow = new BlockingSubscription(slowEntered, releaseSlow);
+        var fast = new SignalingSubscription(fastHandled);
+        await using var provider = BuildStreamProvider(
+            Registration("slow", slow),
+            Registration("fast", fast));
+        await SeedStreamEventAsync(provider);
+        var daemon = CreateSubscriptionDaemon(provider, maxConcurrentWorkers: 2);
+        using var stop = new CancellationTokenSource();
+        var execution = RunSubscriptionDaemonAsync(daemon, stop.Token);
+
+        try
+        {
+            await WaitForTestAsync(slowEntered.Task);
+            await WaitForTestAsync(fastHandled.Task);
+            await WaitForSubscriptionCheckpointAsync(provider, "fast", 1);
+        }
+        finally
+        {
+            stop.Cancel();
+            releaseSlow.TrySetResult();
+            await WaitForTestAsync(execution);
+        }
+    }
+
+    [Fact]
+    public async Task Slow_tenant_checkpoint_does_not_block_another_checkpoint_scope()
+    {
+        var slowTenant = Guid.Empty;
+        var fastTenant = Guid.NewGuid();
+        var slowEntered = NewSignal();
+        var releaseSlow = NewSignal();
+        var fastHandled = NewSignal();
+        var subscription = new TenantBlockingSubscription(
+            slowTenant,
+            slowEntered,
+            releaseSlow,
+            fastHandled);
+        await using var provider = BuildStreamProvider(
+            Registration("tenant-worker", subscription));
+        await SeedTenantStreamEventsAsync(provider, slowTenant, fastTenant);
+        var daemon = CreateSubscriptionDaemon(
+            provider,
+            maxConcurrentWorkers: 2,
+            checkpointScope: CheckpointScope.Tenant);
+        using var stop = new CancellationTokenSource();
+        var execution = RunSubscriptionDaemonAsync(daemon, stop.Token);
+
+        try
+        {
+            await WaitForTestAsync(slowEntered.Task);
+            await WaitForTestAsync(fastHandled.Task);
+            await WaitForSubscriptionCheckpointAsync(
+                provider,
+                "tenant-worker",
+                2,
+                fastTenant);
+        }
+        finally
+        {
+            stop.Cancel();
+            releaseSlow.TrySetResult();
+            await WaitForTestAsync(execution);
+        }
+    }
+
+    [Fact]
+    public async Task Tenant_checkpoint_worker_is_discovered_after_daemon_start()
+    {
+        var tenantId = Guid.NewGuid();
+        var handled = NewSignal();
+        await using var provider = BuildStreamProvider(
+            Registration("dynamic-tenant", new SignalingSubscription(handled)));
+        await EnsureStreamDatabaseAsync(provider);
+        var daemon = CreateSubscriptionDaemon(
+            provider,
+            maxConcurrentWorkers: 1,
+            checkpointScope: CheckpointScope.Tenant,
+            pollingInterval: TimeSpan.FromMilliseconds(10));
+        using var stop = new CancellationTokenSource();
+        var execution = RunSubscriptionDaemonAsync(daemon, stop.Token);
+
+        try
+        {
+            await SeedTenantStreamEventAsync(provider, tenantId);
+            await WaitForTestAsync(handled.Task);
+            await WaitForSubscriptionCheckpointAsync(
+                provider,
+                "dynamic-tenant",
+                1,
+                tenantId);
+        }
+        finally
+        {
+            stop.Cancel();
+            await WaitForTestAsync(execution);
+        }
+    }
+
+    [Fact]
+    public async Task Cancellation_stops_a_blocked_worker_without_external_release()
+    {
+        var entered = NewSignal();
+        await using var provider = BuildStreamProvider(
+            Registration("cancelable", new CancellationBlockingSubscription(entered)));
+        await SeedStreamEventAsync(provider);
+        var daemon = CreateSubscriptionDaemon(provider, maxConcurrentWorkers: 1);
+        using var stop = new CancellationTokenSource();
+        var execution = RunSubscriptionDaemonAsync(daemon, stop.Token);
+
+        await WaitForTestAsync(entered.Task);
+        stop.Cancel();
+
+        await WaitForTestAsync(execution);
+    }
+
+    [Theory]
+    [InlineData(BlockingCheckpoint.Idle)]
+    [InlineData(BlockingCheckpoint.Paused)]
+    [InlineData(BlockingCheckpoint.Failing)]
+    public async Task Idle_paused_or_failing_stream_subscription_does_not_block_another_registration(
+        BlockingCheckpoint firstCheckpoint)
+    {
+        var firstLockAttempted = NewSignal();
+        var fastHandled = NewSignal();
+        ISubscription first = firstCheckpoint == BlockingCheckpoint.Failing
+            ? new ThrowingSubscription()
+            : new SignalingSubscription(NewSignal());
+        await using var provider = BuildStreamProvider(
+            Registration("first", first),
+            Registration("fast", new SignalingSubscription(fastHandled)));
+        await SeedStreamEventAsync(provider);
+        await SeedSubscriptionCheckpointAsync(provider, firstCheckpoint);
+        var daemon = CreateSubscriptionDaemon(
+            provider,
+            maxConcurrentWorkers: 2,
+            new SignalingLockProvider("first", firstLockAttempted));
+        using var stop = new CancellationTokenSource();
+        var execution = RunSubscriptionDaemonAsync(daemon, stop.Token);
+
+        try
+        {
+            await WaitForTestAsync(firstLockAttempted.Task);
+            await WaitForTestAsync(fastHandled.Task);
+            await WaitForSubscriptionCheckpointAsync(provider, "fast", 1);
+        }
+        finally
+        {
+            stop.Cancel();
+            await WaitForTestAsync(execution);
+        }
+    }
+
+    [Fact]
+    public async Task Stream_worker_concurrency_is_bounded_and_queued_work_progresses()
+    {
+        var twoEntered = NewSignal();
+        var allEntered = NewSignal();
+        using var releases = new SemaphoreSlim(0);
+        var tracker = new ConcurrencyTracker(twoEntered, allEntered, releases);
+        await using var provider = BuildStreamProvider(
+            Registration("one", new TrackingSubscription(tracker)),
+            Registration("two", new TrackingSubscription(tracker)),
+            Registration("three", new TrackingSubscription(tracker)));
+        await SeedStreamEventAsync(provider);
+        var daemon = CreateSubscriptionDaemon(provider, maxConcurrentWorkers: 2);
+        using var stop = new CancellationTokenSource();
+        var execution = RunSubscriptionDaemonAsync(daemon, stop.Token);
+
+        try
+        {
+            await WaitForTestAsync(twoEntered.Task);
+            Assert.Equal(2, tracker.MaxActive);
+            Assert.False(allEntered.Task.IsCompleted);
+
+            releases.Release();
+            await WaitForTestAsync(allEntered.Task);
+            Assert.Equal(2, tracker.MaxActive);
+        }
+        finally
+        {
+            stop.Cancel();
+            releases.Release(3);
+            await WaitForTestAsync(execution);
+        }
+    }
+
+    [Fact]
+    public async Task Contended_lock_wait_does_not_consume_batch_capacity()
+    {
+        var contendedAttempted = NewSignal();
+        var fastHandled = NewSignal();
+        await using var provider = BuildStreamProvider(
+            Registration("contended", new SignalingSubscription(NewSignal())),
+            Registration("fast", new SignalingSubscription(fastHandled)));
+        await SeedStreamEventAsync(provider);
+        var daemon = CreateSubscriptionDaemon(
+            provider,
+            maxConcurrentWorkers: 1,
+            new BlockingLockProvider("contended", contendedAttempted));
+        using var stop = new CancellationTokenSource();
+        var execution = RunSubscriptionDaemonAsync(daemon, stop.Token);
+
+        try
+        {
+            await WaitForTestAsync(contendedAttempted.Task);
+            await WaitForTestAsync(fastHandled.Task);
+            await WaitForSubscriptionCheckpointAsync(provider, "fast", 1);
+        }
+        finally
+        {
+            stop.Cancel();
+            await WaitForTestAsync(execution);
+        }
+    }
+
+    [Fact]
+    public async Task Slow_outbox_subscription_does_not_block_another_registration()
+    {
+        var state = new OutboxIsolationState();
+        await using var provider = BuildOutboxProvider(state);
+        await SeedOutboxMessageAsync(provider);
+        var daemon = provider.GetRequiredService<EntityOutboxDaemon<OutboxIsolationDbContext>>();
+        using var stop = new CancellationTokenSource();
+        var execution = RunOutboxDaemonAsync(daemon, stop.Token);
+
+        try
+        {
+            await WaitForTestAsync(state.SlowEntered.Task);
+            await WaitForTestAsync(state.FastHandled.Task);
+            await WaitForOutboxCheckpointAsync(provider, "fast", 1);
+        }
+        finally
+        {
+            stop.Cancel();
+            state.ReleaseSlow.TrySetResult();
+            await WaitForTestAsync(execution);
+        }
+    }
+
+    [Fact]
+    public async Task Failing_projection_does_not_block_another_registration()
+    {
+        var failingEntered = NewSignal();
+        var healthyHandled = NewSignal();
+        await using var provider = BuildProjectionProvider(
+            ProjectionRegistration(
+                "failing",
+                typeof(FailingProjectionSnapshot),
+                (_, _, _, _, _) =>
+                {
+                    failingEntered.TrySetResult();
+                    throw new InvalidOperationException("Projection failed.");
+                }),
+            ProjectionRegistration(
+                "healthy",
+                typeof(HealthyProjectionSnapshot),
+                (_, _, snapshot, _, _) =>
+                {
+                    ((HealthyProjectionSnapshot)snapshot).Handled = true;
+                    healthyHandled.TrySetResult();
+                    return Task.CompletedTask;
+                }));
+        await SeedProjectionEventAsync(provider);
+        var daemon = new ProjectionDaemon<ProjectionIsolationDbContext>(
+            NullLogger<ProjectionDaemon<ProjectionIsolationDbContext>>.Instance,
+            provider,
+            new SignalingLockProvider(),
+            Options.Create(new ProjectionDaemonOptions
+            {
+                MaxConcurrentWorkers = 2,
+                PollingInterval = TimeSpan.FromHours(1),
+                RetryDelay = TimeSpan.FromHours(1)
+            }));
+        using var stop = new CancellationTokenSource();
+        var execution = RunProjectionDaemonAsync(daemon, stop.Token);
+
+        try
+        {
+            await WaitForTestAsync(failingEntered.Task);
+            await WaitForTestAsync(healthyHandled.Task);
+            await WaitForProjectionCheckpointAsync(provider, "healthy", 1);
+        }
+        finally
+        {
+            stop.Cancel();
+            await WaitForTestAsync(execution);
+        }
+    }
+
+    private static ServiceProvider BuildStreamProvider(
+        params SubscriptionRegistration[] registrations)
+    {
+        var databaseName = Guid.NewGuid().ToString("N");
+        var services = new ServiceCollection();
+        services.AddDbContext<StreamIsolationDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName)
+                .ConfigureWarnings(warnings =>
+                    warnings.Ignore(InMemoryEventId.TransactionIgnoredWarning)));
+        foreach (var registration in registrations)
+        {
+            services.AddSingleton(registration);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceProvider BuildOutboxProvider(OutboxIsolationState state)
+    {
+        var databaseName = Guid.NewGuid().ToString("N");
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(state);
+        services.AddDbContext<OutboxIsolationDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName));
+        services.AddEntityOutbox<OutboxIsolationDbContext>(_ => { });
+        services.AddOutboxSubscription<SlowOutboxSubscription>(
+            options => options.Name = "slow");
+        services.AddOutboxSubscription<FastOutboxSubscription>(
+            options => options.Name = "fast");
+        services.AddEntityOutboxDaemon<OutboxIsolationDbContext>(
+            _ => new SignalingLockProvider(),
+            options =>
+            {
+                options.MaxConcurrentWorkers = 2;
+                options.PollingInterval = TimeSpan.FromHours(1);
+                options.RetryDelay = TimeSpan.FromHours(1);
+            });
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceProvider BuildProjectionProvider(
+        params ProjectionRegistration[] registrations)
+    {
+        var databaseName = Guid.NewGuid().ToString("N");
+        var services = new ServiceCollection();
+        services.AddDbContext<ProjectionIsolationDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName)
+                .ConfigureWarnings(warnings =>
+                    warnings.Ignore(InMemoryEventId.TransactionIgnoredWarning)));
+        foreach (var registration in registrations)
+        {
+            services.AddSingleton(registration);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private static SubscriptionDaemon<StreamIsolationDbContext> CreateSubscriptionDaemon(
+        IServiceProvider provider,
+        int maxConcurrentWorkers,
+        IDistributedLockProvider? lockProvider = null,
+        CheckpointScope checkpointScope = CheckpointScope.Global,
+        TimeSpan? pollingInterval = null) =>
+        new(
+            NullLogger<SubscriptionDaemon<StreamIsolationDbContext>>.Instance,
+            provider,
+            lockProvider ?? new SignalingLockProvider(),
+            Options.Create(new SubscriptionOptions
+            {
+                MaxConcurrentWorkers = maxConcurrentWorkers,
+                CheckpointScope = checkpointScope,
+                PollingInterval = pollingInterval ?? TimeSpan.FromHours(1),
+                RetryDelay = TimeSpan.FromHours(1)
+            }));
+
+    private static SubscriptionRegistration Registration(
+        string name,
+        ISubscription subscription) =>
+        new()
+        {
+            Name = name,
+            Subscription = subscription,
+            Options = new SubscriptionRegistrationOptions()
+        };
+
+    private static ProjectionRegistration ProjectionRegistration(
+        string name,
+        Type snapshotType,
+        Func<DbContext, IServiceProvider, object, IEvent, CancellationToken, Task> evolve)
+    {
+        var options = new ProjectionOptions();
+        options.Handles<IsolationEvent>();
+        return new ProjectionRegistration
+        {
+            Name = name,
+            Mode = ProjectionMode.Eventual,
+            Version = 1,
+            ProjectionType = snapshotType,
+            SnapshotType = snapshotType,
+            Options = options,
+            ClearAction = (_, _, _) => Task.CompletedTask,
+            EvolveAction = evolve,
+            GetOrCreateSnapshotAction = (_, _, _) =>
+                Task.FromResult(Activator.CreateInstance(snapshotType)!),
+            AddSnapshotAction = (db, snapshot) => db.Add(snapshot)
+        };
+    }
+
+    private static async Task SeedStreamEventAsync(IServiceProvider provider)
+    {
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<StreamIsolationDbContext>();
+        await db.Database.EnsureCreatedAsync();
+        db.Set<DbEvent>().Add(CreateEvent());
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task EnsureStreamDatabaseAsync(IServiceProvider provider)
+    {
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<StreamIsolationDbContext>();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private static async Task SeedTenantStreamEventAsync(
+        IServiceProvider provider,
+        Guid tenantId)
+    {
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<StreamIsolationDbContext>();
+        var @event = CreateEvent();
+        @event.TenantId = tenantId;
+        db.Set<DbEvent>().Add(@event);
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedProjectionEventAsync(IServiceProvider provider)
+    {
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ProjectionIsolationDbContext>();
+        await db.Database.EnsureCreatedAsync();
+        db.Set<DbEvent>().Add(CreateEvent());
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedTenantStreamEventsAsync(
+        IServiceProvider provider,
+        Guid slowTenant,
+        Guid fastTenant)
+    {
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<StreamIsolationDbContext>();
+        await db.Database.EnsureCreatedAsync();
+        var slowEvent = CreateEvent();
+        slowEvent.TenantId = slowTenant;
+        var fastEvent = CreateEvent();
+        fastEvent.Sequence = 2;
+        fastEvent.TenantId = fastTenant;
+        db.Set<DbEvent>().AddRange(slowEvent, fastEvent);
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedSubscriptionCheckpointAsync(
+        IServiceProvider provider,
+        BlockingCheckpoint checkpoint)
+    {
+        if (checkpoint == BlockingCheckpoint.Failing)
+        {
+            return;
+        }
+
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<StreamIsolationDbContext>();
+        db.Set<DbSubscription>().Add(new DbSubscription
+        {
+            SubscriptionAssemblyQualifiedName = "first",
+            Sequence = checkpoint == BlockingCheckpoint.Idle ? 1 : 0,
+            State = checkpoint == BlockingCheckpoint.Paused
+                ? SubscriptionState.Paused
+                : SubscriptionState.Active
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedOutboxMessageAsync(IServiceProvider provider)
+    {
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<OutboxIsolationDbContext>();
+        await db.Database.EnsureCreatedAsync();
+        db.Set<DbOutboxMessage>().Add(new DbOutboxMessage
+        {
+            EventId = Guid.NewGuid(),
+            Sequence = 1,
+            TypeName = "isolation_event",
+            Type = typeof(OutboxPayload).AssemblyQualifiedName!,
+            Data = """{"Value":"one"}""",
+            Timestamp = DateTimeOffset.UtcNow,
+            SourceEntityType = typeof(object).AssemblyQualifiedName!,
+            SourceEntityKey = "{}",
+            ChangeKind = EntityChangeKind.Added
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static DbEvent CreateEvent() =>
+        new()
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = Guid.NewGuid(),
+            Sequence = 1,
+            Version = 1,
+            TypeName = "isolation_event",
+            Type = typeof(IsolationEvent).AssemblyQualifiedName!,
+            Data = """{"Value":"one"}""",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+    private static Task RunSubscriptionDaemonAsync(
+        SubscriptionDaemon<StreamIsolationDbContext> daemon,
+        CancellationToken ct) =>
+        InvokeExecuteAsync(daemon, ct);
+
+    private static Task RunOutboxDaemonAsync(
+        EntityOutboxDaemon<OutboxIsolationDbContext> daemon,
+        CancellationToken ct) =>
+        InvokeExecuteAsync(daemon, ct);
+
+    private static Task RunProjectionDaemonAsync(
+        ProjectionDaemon<ProjectionIsolationDbContext> daemon,
+        CancellationToken ct) =>
+        InvokeExecuteAsync(daemon, ct);
+
+    private static Task InvokeExecuteAsync<TDaemon>(TDaemon daemon, CancellationToken ct)
+    {
+        var method = typeof(TDaemon).GetMethod(
+            "ExecuteAsync",
+            System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (Task)method!.Invoke(daemon, [ct])!;
+    }
+
+    private static Task WaitForTestAsync(Task task) =>
+        task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+    private static async Task WaitForSubscriptionCheckpointAsync(
+        IServiceProvider provider,
+        string name,
+        long sequence,
+        Guid tenantId = default)
+    {
+        await WaitForConditionAsync(async () =>
+        {
+            await using var scope = provider.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<StreamIsolationDbContext>();
+            return await db.Set<DbSubscription>()
+                .AsNoTracking()
+                .AnyAsync(
+                    row =>
+                        row.SubscriptionAssemblyQualifiedName == name &&
+                        row.TenantId == tenantId &&
+                        row.Sequence >= sequence,
+                    TestContext.Current.CancellationToken);
+        });
+    }
+
+    private static async Task WaitForOutboxCheckpointAsync(
+        IServiceProvider provider,
+        string name,
+        long sequence)
+    {
+        await WaitForConditionAsync(async () =>
+        {
+            await using var scope = provider.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<OutboxIsolationDbContext>();
+            return await db.Set<DbOutboxSubscription>()
+                .AsNoTracking()
+                .AnyAsync(
+                    row =>
+                        row.SubscriptionAssemblyQualifiedName == name &&
+                        row.Sequence >= sequence,
+                    TestContext.Current.CancellationToken);
+        });
+    }
+
+    private static async Task WaitForProjectionCheckpointAsync(
+        IServiceProvider provider,
+        string name,
+        long sequence)
+    {
+        await WaitForConditionAsync(async () =>
+        {
+            await using var scope = provider.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<ProjectionIsolationDbContext>();
+            return await db.Set<DbProjectionStatus>()
+                .AsNoTracking()
+                .AnyAsync(
+                    row =>
+                        row.ProjectionName == name &&
+                        row.Position >= sequence,
+                    TestContext.Current.CancellationToken);
+        });
+    }
+
+    private static async Task WaitForConditionAsync(Func<Task<bool>> predicate)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (!await predicate())
+        {
+            Assert.True(DateTimeOffset.UtcNow < deadline, "Timed out waiting for durable daemon progress.");
+            await Task.Delay(
+                TimeSpan.FromMilliseconds(10),
+                TestContext.Current.CancellationToken);
+        }
+    }
+
+    private static TaskCompletionSource NewSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public enum BlockingCheckpoint
+    {
+        Idle,
+        Paused,
+        Failing
+    }
+
+    private sealed record IsolationEvent(string Value);
+
+    private sealed record OutboxPayload(string Value);
+
+    private sealed class StreamIsolationDbContext(
+        DbContextOptions<StreamIsolationDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.UseEventStore();
+    }
+
+    private sealed class ProjectionIsolationDbContext(
+        DbContextOptions<ProjectionIsolationDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.UseEventStore();
+            modelBuilder.Entity<FailingProjectionSnapshot>().HasKey(x => x.Id);
+            modelBuilder.Entity<HealthyProjectionSnapshot>().HasKey(x => x.Id);
+        }
+    }
+
+    private sealed class OutboxIsolationDbContext(
+        DbContextOptions<OutboxIsolationDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            ModelBuilderExtensions.ConfigureEntityOutboxModel(modelBuilder);
+    }
+
+    private sealed class FailingProjectionSnapshot
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+    }
+
+    private sealed class HealthyProjectionSnapshot
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public bool Handled { get; set; }
+    }
+
+    private sealed class BlockingSubscription(
+        TaskCompletionSource entered,
+        TaskCompletionSource release) : ISubscription
+    {
+        public async Task Handle(IEvent @event, CancellationToken ct)
+        {
+            entered.TrySetResult();
+            await release.Task.WaitAsync(ct);
+        }
+    }
+
+    private sealed class CancellationBlockingSubscription(TaskCompletionSource entered)
+        : ISubscription
+    {
+        public async Task Handle(IEvent @event, CancellationToken ct)
+        {
+            entered.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        }
+    }
+
+    private sealed class TenantBlockingSubscription(
+        Guid slowTenant,
+        TaskCompletionSource slowEntered,
+        TaskCompletionSource releaseSlow,
+        TaskCompletionSource fastHandled) : ISubscription
+    {
+        public async Task Handle(IEvent @event, CancellationToken ct)
+        {
+            if (@event.TenantId == slowTenant)
+            {
+                slowEntered.TrySetResult();
+                await releaseSlow.Task.WaitAsync(ct);
+                return;
+            }
+
+            fastHandled.TrySetResult();
+        }
+    }
+
+    private sealed class SignalingSubscription(TaskCompletionSource handled) : ISubscription
+    {
+        public Task Handle(IEvent @event, CancellationToken ct)
+        {
+            handled.TrySetResult();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingSubscription : ISubscription
+    {
+        public Task Handle(IEvent @event, CancellationToken ct) =>
+            throw new InvalidOperationException("Subscription failed.");
+    }
+
+    private sealed class TrackingSubscription(ConcurrencyTracker tracker) : ISubscription
+    {
+        public async Task Handle(IEvent @event, CancellationToken ct)
+        {
+            tracker.Enter();
+            try
+            {
+                await tracker.WaitForReleaseAsync(ct);
+            }
+            finally
+            {
+                tracker.Exit();
+            }
+        }
+    }
+
+    private sealed class ConcurrencyTracker(
+        TaskCompletionSource twoEntered,
+        TaskCompletionSource allEntered,
+        SemaphoreSlim releases)
+    {
+        private int _active;
+        private int _entered;
+        private int _maxActive;
+
+        internal int MaxActive => Volatile.Read(ref _maxActive);
+
+        internal void Enter()
+        {
+            var active = Interlocked.Increment(ref _active);
+            var currentMax = Volatile.Read(ref _maxActive);
+            while (active > currentMax)
+            {
+                var observed = Interlocked.CompareExchange(
+                    ref _maxActive,
+                    active,
+                    currentMax);
+                if (observed == currentMax)
+                {
+                    break;
+                }
+                currentMax = observed;
+            }
+
+            var entered = Interlocked.Increment(ref _entered);
+            if (entered >= 2)
+            {
+                twoEntered.TrySetResult();
+            }
+            if (entered >= 3)
+            {
+                allEntered.TrySetResult();
+            }
+        }
+
+        internal void Exit() => Interlocked.Decrement(ref _active);
+
+        internal Task WaitForReleaseAsync(CancellationToken ct) =>
+            releases.WaitAsync(ct);
+    }
+
+    private sealed class OutboxIsolationState
+    {
+        internal TaskCompletionSource SlowEntered { get; } = NewSignal();
+        internal TaskCompletionSource ReleaseSlow { get; } = NewSignal();
+        internal TaskCompletionSource FastHandled { get; } = NewSignal();
+    }
+
+    private sealed class SlowOutboxSubscription(OutboxIsolationState state)
+        : IOutboxSubscription
+    {
+        public async Task Handle(IOutboxEvent @event, CancellationToken ct)
+        {
+            state.SlowEntered.TrySetResult();
+            await state.ReleaseSlow.Task.WaitAsync(ct);
+        }
+    }
+
+    private sealed class FastOutboxSubscription(OutboxIsolationState state)
+        : IOutboxSubscription
+    {
+        public Task Handle(IOutboxEvent @event, CancellationToken ct)
+        {
+            state.FastHandled.TrySetResult();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SignalingLockProvider(
+        string? signaledLockName = null,
+        TaskCompletionSource? attempted = null) : IDistributedLockProvider
+    {
+        public IDistributedLock CreateLock(string name)
+        {
+            if (string.Equals(name, signaledLockName, StringComparison.Ordinal))
+            {
+                attempted?.TrySetResult();
+            }
+            return new SignalingLock(name);
+        }
+    }
+
+    private sealed class BlockingLockProvider(
+        string blockedName,
+        TaskCompletionSource attempted) : IDistributedLockProvider
+    {
+        public IDistributedLock CreateLock(string name) =>
+            string.Equals(name, blockedName, StringComparison.Ordinal)
+                ? new BlockingLock(name, attempted)
+                : new SignalingLock(name);
+    }
+
+    private sealed class BlockingLock(
+        string name,
+        TaskCompletionSource attempted) : IDistributedLock
+    {
+        public string Name { get; } = name;
+
+        public IDistributedSynchronizationHandle Acquire(
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default)
+        {
+            attempted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("The blocking lock wait completed unexpectedly.");
+        }
+
+        public IDistributedSynchronizationHandle? TryAcquire(
+            TimeSpan timeout = default,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(
+            TimeSpan timeout = default,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class SignalingLock(string name) : IDistributedLock
+    {
+        public string Name { get; } = name;
+
+        public IDistributedSynchronizationHandle Acquire(
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default) =>
+            new LockHandle();
+
+        public ValueTask<IDistributedSynchronizationHandle> AcquireAsync(
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IDistributedSynchronizationHandle>(new LockHandle());
+
+        public IDistributedSynchronizationHandle? TryAcquire(
+            TimeSpan timeout = default,
+            CancellationToken cancellationToken = default) =>
+            new LockHandle();
+
+        public ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(
+            TimeSpan timeout = default,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IDistributedSynchronizationHandle?>(new LockHandle());
+    }
+
+    private sealed class LockHandle : IDistributedSynchronizationHandle
+    {
+        public CancellationToken HandleLostToken => CancellationToken.None;
+        public void Dispose()
+        {
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/EventStoreCore.Tests/Daemons/ProjectionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/ProjectionDaemonExecutionTests.cs
@@ -132,7 +132,7 @@ public class ProjectionDaemonExecutionTests
         var registration = BuildRegistration();
         var lockProvider = new FakeLockProvider();
 
-        db.Events.Add(new DbEvent
+        db.Set<DbEvent>().Add(new DbEvent
         {
             EventId = Guid.NewGuid(),
             StreamId = Guid.NewGuid(),
@@ -180,7 +180,7 @@ public class ProjectionDaemonExecutionTests
         var streamA = Guid.NewGuid();
         var streamB = Guid.NewGuid();
 
-        db.Events.AddRange(
+        db.Set<DbEvent>().AddRange(
             CreateEvent(tenantA, streamA, 1, "Tenant A"),
             CreateEvent(tenantB, streamB, 2, "Tenant B"));
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -235,7 +235,7 @@ public class ProjectionDaemonExecutionTests
         var streamB = Guid.NewGuid();
         var registration = BuildRegistration(tenantA);
 
-        db.Events.AddRange(
+        db.Set<DbEvent>().AddRange(
             CreateEvent(tenantA, streamA, 1, "Tenant A"),
             CreateEvent(tenantB, streamB, 2, "Tenant B"));
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);

--- a/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
+++ b/tests/EventStoreCore.Tests/Daemons/SubscriptionDaemonExecutionTests.cs
@@ -227,7 +227,7 @@ public class SubscriptionDaemonExecutionTests
         db.Streams.StartStream(Guid.NewGuid(), events: [new object()]);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var storedEvent = await db.Events.FirstAsync(TestContext.Current.CancellationToken);
+        var storedEvent = await db.Set<DbEvent>().FirstAsync(TestContext.Current.CancellationToken);
         if (storedEvent.Sequence == 0)
         {
             storedEvent.Sequence = 1;
@@ -532,7 +532,7 @@ public class SubscriptionDaemonExecutionTests
                 RetryDelay = TimeSpan.FromSeconds(5)
             }));
 
-        db.Events.AddRange(
+        db.Set<DbEvent>().AddRange(
             CreateEvent(tenantA, 1),
             CreateEvent(tenantB, 2));
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -565,7 +565,7 @@ public class SubscriptionDaemonExecutionTests
 
     private static async Task EnsureSequenceAsync(ExecutionDbContext db)
     {
-        var storedEvent = await db.Events.FirstAsync(TestContext.Current.CancellationToken);
+        var storedEvent = await db.Set<DbEvent>().FirstAsync(TestContext.Current.CancellationToken);
         if (storedEvent.Sequence == 0)
         {
             storedEvent.Sequence = 1;
@@ -575,7 +575,7 @@ public class SubscriptionDaemonExecutionTests
 
     private static async Task EnsureSequencesAsync(ExecutionDbContext db)
     {
-        var events = await db.Events
+        var events = await db.Set<DbEvent>()
             .OrderBy(e => e.Version)
             .ToListAsync(TestContext.Current.CancellationToken);
 

--- a/tests/EventStoreCore.Tests/MassTransitSubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/MassTransitSubscriptionTests.cs
@@ -96,11 +96,11 @@ public class MassTransitSubscriptionTests(PostgresFixture fixture) : IClassFixtu
         var streamId = Guid.NewGuid();
         eventStore.StartStream(streamId, events: [new TestEvent()]);
         await eventStoreDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
-        var writtenSequence = await eventStoreDbContext.Events
+        var writtenSequence = await eventStoreDbContext.Set<DbEvent>()
             .Where(e => e.StreamId == streamId)
             .Select(e => e.Sequence)
             .SingleAsync(TestContext.Current.CancellationToken);
-        var writtenEventId = await eventStoreDbContext.Events
+        var writtenEventId = await eventStoreDbContext.Set<DbEvent>()
             .Where(e => e.StreamId == streamId)
             .Select(e => e.EventId)
             .SingleAsync(TestContext.Current.CancellationToken);

--- a/tests/EventStoreCore.Tests/ProjectionManagerTests.cs
+++ b/tests/EventStoreCore.Tests/ProjectionManagerTests.cs
@@ -570,7 +570,7 @@ public class ProjectionManagerTests(PostgresFixture fixture) : IClassFixture<Pos
         db.Streams.StartStream(streamId, events: [new TestEvent { Value = "test" }]);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var dbEvent = await db.Events.FirstAsync(TestContext.Current.CancellationToken);
+        var dbEvent = await db.Set<DbEvent>().FirstAsync(TestContext.Current.CancellationToken);
 
         var projectionName = typeof(TestProjection).FullName!;
         

--- a/tests/EventStoreCore.Tests/SubscriptionManagerTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionManagerTests.cs
@@ -41,7 +41,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
     private static async Task ResetDatabaseAsync(EventStoreDbContext dbContext, CancellationToken ct)
     {
         await dbContext.Set<DbSubscription>().ExecuteDeleteAsync(ct);
-        await dbContext.Events.ExecuteDeleteAsync(ct);
+        await dbContext.Set<DbEvent>().ExecuteDeleteAsync(ct);
         await dbContext.Set<DbStream>().ExecuteDeleteAsync(ct);
     }
 
@@ -102,7 +102,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
         db.Streams.StartStream(streamId, events: [new TestEvent(), new TestEvent()]);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var dbEvents = await db.Events
+        var dbEvents = await db.Set<DbEvent>()
             .OrderBy(e => e.Sequence)
             .ToListAsync(TestContext.Current.CancellationToken);
 
@@ -252,7 +252,7 @@ public class SubscriptionManagerTests(PostgresFixture fixture) : IClassFixture<P
         db.Streams.StartStream(streamId, events: [new TestEvent()]);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var dbEvent = await db.Events.FirstAsync(TestContext.Current.CancellationToken);
+        var dbEvent = await db.Set<DbEvent>().FirstAsync(TestContext.Current.CancellationToken);
         var name = typeof(TestSub).AssemblyQualifiedName!;
         db.Set<DbSubscription>().Add(new DbSubscription
         {

--- a/tests/EventStoreCore.Tests/SubscriptionOptionsTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionOptionsTests.cs
@@ -10,6 +10,7 @@ public class SubscriptionOptionsTests
     {
         var options = new SubscriptionOptions();
 
+        Assert.Equal(8, options.MaxConcurrentWorkers);
         Assert.Equal(500, options.BatchSize);
         Assert.Equal(1, options.CheckpointFrequency);
         Assert.Equal(TimeSpan.FromSeconds(10), options.PollingInterval);

--- a/tests/EventStoreCore.Tests/SubscriptionTests.cs
+++ b/tests/EventStoreCore.Tests/SubscriptionTests.cs
@@ -135,7 +135,7 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
     private static async Task ResetDatabaseAsync(EventStoreDbContext dbContext, CancellationToken ct)
     {
         await dbContext.Set<DbSubscription>().ExecuteDeleteAsync(ct);
-        await dbContext.Events.ExecuteDeleteAsync(ct);
+        await dbContext.Set<DbEvent>().ExecuteDeleteAsync(ct);
         await dbContext.Set<DbStream>().ExecuteDeleteAsync(ct);
     }
 
@@ -143,7 +143,7 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
     {
         await dbContext.Set<ProcessedEventRecord>().ExecuteDeleteAsync(ct);
         await dbContext.Set<DbSubscription>().ExecuteDeleteAsync(ct);
-        await dbContext.Events.ExecuteDeleteAsync(ct);
+        await dbContext.Set<DbEvent>().ExecuteDeleteAsync(ct);
         await dbContext.Set<DbStream>().ExecuteDeleteAsync(ct);
     }
 
@@ -161,7 +161,7 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         var streamId = Guid.NewGuid();
         eventStore.StartStream(streamId, events: [new TestEvent()]);
         await eventStoreDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
-        var persistedEvent = await eventStoreDbContext.Events
+        var persistedEvent = await eventStoreDbContext.Set<DbEvent>()
             .AsNoTracking()
             .SingleAsync(e => e.StreamId == streamId, TestContext.Current.CancellationToken);
 
@@ -243,7 +243,7 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
         eventStoreDbContext.Streams.StartStream(streamId, events: [new TestEvent()]);
         await eventStoreDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var expectedEvent = await eventStoreDbContext.Events
+        var expectedEvent = await eventStoreDbContext.Set<DbEvent>()
             .AsNoTracking()
             .SingleAsync(e => e.StreamId == streamId, TestContext.Current.CancellationToken);
 
@@ -338,4 +338,3 @@ public class SubscriptionTests(PostgresFixture fixture) : IClassFixture<Postgres
                 TestContext.Current.CancellationToken);
     }
 }
-


### PR DESCRIPTION
## Summary
- run stream, outbox, and eventual projection registrations as independent checkpoint-scope workers
- bound concurrent batch execution with configurable MaxConcurrentWorkers while keeping lock, polling, retry, and batch-delay waits isolated
- preserve distributed-lock and at-least-once checkpoint boundaries, including durable scope-specific health faults and projection rollback before fault persistence
- add worker telemetry, XML/public API documentation, deterministic isolation/backpressure/shutdown tests, and dynamic tenant discovery coverage

## Validation
- dotnet test tests/EventStoreCore.Tests/EventStoreCore.Tests.csproj --configuration Release --no-build --no-restore --disable-build-servers -m:1 (306 passed)
- dotnet build EventStoreCore.slnx --configuration Release --no-restore --disable-build-servers -m:1
- dotnet pack EventStoreCore.slnx --configuration Release --no-build --disable-build-servers -m:1
- pwsh -NoLogo -NoProfile -File eng/Validate-Packages.ps1 -PackageDirectory artifacts/packages (14 packages validated)

## Local environment note
The separate scheduling test project reported 25 passing tests and one unrelated TickerQ integration failure because port 5000 was already owned by another local application. The process was left untouched.