### PR TITLE
Add inline domain event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,57 @@ redeliver the event and handlers must remain idempotent.
 
 Add migrations for the `OutboxMessages` and `OutboxSubscriptions` tables after enabling the feature.
 
+## Inline domain event handlers
+
+Inline handlers are for module-local reactions that must commit atomically with
+an event. They can handle events appended to EventStoreCore streams, events
+captured from ordinary EF entities, or both:
+
+```csharp
+services.AddInlineEventHandlers<AppDbContext>(handlers =>
+{
+    handlers.Add<ReserveInventory, OrderPlaced>(options =>
+    {
+        options.Order = 10;
+        options.Sources = InlineEventSource.Stream;
+    });
+});
+
+public sealed class ReserveInventory(AppDbContext dbContext)
+    : IInlineEventHandler<OrderPlaced>
+{
+    public Task Handle(IEventEnvelope<OrderPlaced> @event, CancellationToken ct)
+    {
+        dbContext.InventoryReservations.Add(
+            new InventoryReservation(@event.Data.OrderId));
+        return Task.CompletedTask;
+    }
+}
+```
+
+Handlers are scoped and receive the same `DbContext` instance whose
+`SaveChanges` triggered dispatch. They run sequentially by `Order`, then by
+registration order. Exceptions and cancellation abort the outer save. Both
+`SaveChanges` and `SaveChangesAsync` are supported, though asynchronous saves
+are preferred.
+
+`IEventEnvelope<T>` exposes the identity, payload, timestamp, and tenant shared
+by both sources. The concrete envelope remains `IEvent<T>` for a stream event or
+`IOutboxEvent<T>` for an entity event, so handlers can inspect source-specific
+metadata when needed. Database-generated sequence values are still zero before
+the save commits.
+
+Entity events remain in the outbox even when handled inline. If a handler
+changes another outbox-enabled entity, its events are captured and handled in a
+later breadth-first dispatch wave. The default limit is 1,000 source envelopes
+per save and can be changed with `handlers.MaxDispatchCount`.
+
+Keep inline work inside the tracked state of the same context. Handlers must not
+call `SaveChanges`, append another stream, execute direct SQL, publish messages,
+make network calls, or use a separate context. Use `ISubscription<T>` or
+`IOutboxSubscription<T>` for durable post-commit work and all external or
+cross-module side effects.
+
 ## Inline projection contract
 
 Inline projections run inside the same `DbContext` scope and `SaveChanges` transaction that appends events. If an inline projection throws, the append is rolled back with it.

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -6,7 +6,7 @@ EventStoreCore is still pre-1.0. Public API changes may be made between beta rel
 
 The supported contracts are deliberately concentrated in these areas:
 
-- `EventStoreCore.Abstractions`: events, typed and untyped streams, event stores, global event-log reads, projections, subscriptions, entity-outbox subscriptions, checkpoint scopes, optimistic-concurrency expectations, and their management DTOs.
+- `EventStoreCore.Abstractions`: events and common envelopes, typed and untyped streams, event stores, global event-log reads, projections, inline event handlers, subscriptions, entity-outbox subscriptions, checkpoint scopes, optimistic-concurrency expectations, and their management DTOs.
 - `EventStoreCore`: dependency-injection and EF Core builder interfaces and extension methods, projection and subscription options, snapshot configuration, event type registration, projection context helpers, and public operational exceptions.
 - `EventStoreCore.Postgres`, `EventStoreCore.SqlServer`, and `EventStoreCore.Sqlite`: provider-specific `ModelBuilder.UseEventStore` and `ModelBuilder.UseEntityOutbox` extensions.
 - `EventStoreCore.CloudEvents`, `EventStoreCore.EventGrid`, and `EventStoreCore.MassTransit`: transport registration, transformation options, and transport subscription contracts.
@@ -27,6 +27,11 @@ Every shipped project generates XML documentation and enables the .NET SDK packa
 ## Pre-1.0 compatibility notes
 
 The following changes are intentional for the next beta:
+
+- `IEvent<T>` and `IOutboxEvent<T>` now share `IEventEnvelope<T>`, and
+  `IInlineEventHandler<T>` plus the Core inline-handler builder add
+  same-`DbContext` transactional reactions without changing subscription
+  delivery semantics.
 
 - `IEventStore.AppendAsync(AppendOperation)` adds a backwards-compatible
   default contract for compact append results. EventStoreCore's EF

--- a/eng/PublicApiBaseline.txt
+++ b/eng/PublicApiBaseline.txt
@@ -82,6 +82,7 @@ EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IEventStoreSerializer.
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IEventStoreSerializer.Serialize(System.Object,System.Type)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IHandler`1.Handle(`0)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IHandler`2.Handle(EventStoreCore.Abstractions.IStream{`0},`1)
+EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IInlineEventHandler`1.Handle(EventStoreCore.Abstractions.IEventEnvelope{`0},System.Threading.CancellationToken)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IOutboxReader.CleanupAsync(System.Int64,System.Threading.CancellationToken)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IOutboxReader.ReadAsync(System.Int64,System.Int32,System.Nullable{System.Guid},System.Threading.CancellationToken)
 EventStoreCore.Abstractions|M:EventStoreCore.Abstractions.IOutboxSubscription.Handle(EventStoreCore.Abstractions.IOutboxEvent,System.Threading.CancellationToken)
@@ -223,6 +224,12 @@ EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEvent.Timestamp
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEvent.TypeName
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEvent.Version
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEvent`1.Data
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEventEnvelope.Data
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEventEnvelope.EventType
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEventEnvelope.Id
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEventEnvelope.TenantId
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEventEnvelope.Timestamp
+EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IEventEnvelope`1.Data
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IOutboxEvent.ChangeKind
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IOutboxEvent.Data
 EventStoreCore.Abstractions|P:EventStoreCore.Abstractions.IOutboxEvent.EventType
@@ -330,11 +337,14 @@ EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.ExpectedVersionMode
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.FailedEventDto
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEvent
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEvent`1
+EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEventEnvelope
+EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEventEnvelope`1
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEventLogReader
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEventStore
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IEventStoreSerializer
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IHandler`1
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IHandler`2
+EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IInlineEventHandler`1
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IOutboxEvent
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IOutboxEvent`1
 EventStoreCore.Abstractions|T:EventStoreCore.Abstractions.IOutboxReader
@@ -545,6 +555,9 @@ EventStoreCore|F:EventStoreCore.DaemonHealthStatus.Healthy
 EventStoreCore|F:EventStoreCore.DaemonHealthStatus.Unhealthy
 EventStoreCore|F:EventStoreCore.EventStoreDaemonTelemetry.ActivitySourceName
 EventStoreCore|F:EventStoreCore.EventStoreDaemonTelemetry.MeterName
+EventStoreCore|F:EventStoreCore.InlineEventSource.All
+EventStoreCore|F:EventStoreCore.InlineEventSource.EntityOutbox
+EventStoreCore|F:EventStoreCore.InlineEventSource.Stream
 EventStoreCore|F:EventStoreCore.ProjectionMode.Eventual
 EventStoreCore|F:EventStoreCore.ProjectionMode.Inline
 EventStoreCore|F:EventStoreCore.SnapshotSchemaMismatchBehavior.Rebuild
@@ -677,6 +690,8 @@ EventStoreCore|M:EventStoreCore.IEventTypeBuilder`1.AddAlias(System.String)
 EventStoreCore|M:EventStoreCore.IEventTypeBuilder`1.AddUpcaster(System.Int32,System.Int32,System.Func{System.String,System.String})
 EventStoreCore|M:EventStoreCore.IEventTypeBuilder`1.AddUpcaster(System.String,System.Func{System.Text.Json.Nodes.JsonObject,`0})
 EventStoreCore|M:EventStoreCore.IEventTypeBuilder`1.AddUpcaster``1(System.String,System.Func{``0,`0})
+EventStoreCore|M:EventStoreCore.IInlineEventHandlerBuilder.Add``2(System.Action{EventStoreCore.InlineEventHandlerRegistrationOptions})
+EventStoreCore|M:EventStoreCore.InlineEventHandlerServiceCollectionExtensions.AddInlineEventHandlers``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{EventStoreCore.IInlineEventHandlerBuilder})
 EventStoreCore|M:EventStoreCore.IProjectionDaemonRegistrar.AddProjectionDaemon(System.Func{System.IServiceProvider,Medallion.Threading.IDistributedLockProvider},System.Action{EventStoreCore.ProjectionDaemonOptions})
 EventStoreCore|M:EventStoreCore.IScopedSubscription.HandleAsync(Microsoft.EntityFrameworkCore.DbContext,System.IServiceProvider,EventStoreCore.Abstractions.IEvent,System.Threading.CancellationToken)
 EventStoreCore|M:EventStoreCore.ISnapshotBuilder.For``1(System.Action{EventStoreCore.SnapshotOptions})
@@ -891,6 +906,9 @@ EventStoreCore|P:EventStoreCore.IEfCoreEventStoreBuilder`1.Services
 EventStoreCore|P:EventStoreCore.IEntityOutboxBuilder.SerializerOptions
 EventStoreCore|P:EventStoreCore.IEventStoreBuilder.Provider
 EventStoreCore|P:EventStoreCore.IEventStoreBuilder.Services
+EventStoreCore|P:EventStoreCore.IInlineEventHandlerBuilder.MaxDispatchCount
+EventStoreCore|P:EventStoreCore.InlineEventHandlerRegistrationOptions.Order
+EventStoreCore|P:EventStoreCore.InlineEventHandlerRegistrationOptions.Sources
 EventStoreCore|P:EventStoreCore.OutboxSubscriptionRegistrationOptions.Name
 EventStoreCore|P:EventStoreCore.OutboxSubscriptionRegistrationOptions.UnknownEventPolicy
 EventStoreCore|P:EventStoreCore.ProjectionContext.DbContext
@@ -982,6 +1000,10 @@ EventStoreCore|T:EventStoreCore.IEntityOutboxChangeBuilder`1
 EventStoreCore|T:EventStoreCore.IEntityOutboxEntityBuilder`1
 EventStoreCore|T:EventStoreCore.IEventStoreBuilder
 EventStoreCore|T:EventStoreCore.IEventTypeBuilder`1
+EventStoreCore|T:EventStoreCore.IInlineEventHandlerBuilder
+EventStoreCore|T:EventStoreCore.InlineEventHandlerRegistrationOptions
+EventStoreCore|T:EventStoreCore.InlineEventHandlerServiceCollectionExtensions
+EventStoreCore|T:EventStoreCore.InlineEventSource
 EventStoreCore|T:EventStoreCore.IProjectionDaemonRegistrar
 EventStoreCore|T:EventStoreCore.IScopedSubscription
 EventStoreCore|T:EventStoreCore.ISnapshotBuilder

--- a/src/EventStoreCore.Abstractions/IEvent.cs
+++ b/src/EventStoreCore.Abstractions/IEvent.cs
@@ -9,12 +9,12 @@ namespace EventStoreCore.Abstractions;
 /// identifiers, versioning, timestamps, and tenant context for multi-tenant scenarios. The interface is designed to
 /// support event sourcing patterns, allowing consumers to track, process, and reconstruct state from event streams.
 /// All properties are read-only and provide essential information for event handling and auditing.</remarks>
-public interface IEvent
+public interface IEvent : IEventEnvelope
 {
     /// <summary>
     ///     Unique stable identifier for the event. The identifier is not an ordering value.
     /// </summary>
-    Guid Id { get; }
+    new Guid Id { get; }
 
     /// <summary>
     ///     The version of the stream this event reflects. The place in the stream.
@@ -25,7 +25,7 @@ public interface IEvent
     /// <summary>
     ///     The actual event data body
     /// </summary>
-    object Data { get; }
+    new object Data { get; }
 
     /// <summary>
     ///     Stream's Id
@@ -35,17 +35,27 @@ public interface IEvent
     /// <summary>
     ///     The UTC time that this event was originally captured
     /// </summary>
-    DateTimeOffset Timestamp { get; }
+    new DateTimeOffset Timestamp { get; }
 
     /// <summary>
     ///     If using multi-tenancy by tenant id
     /// </summary>
-    Guid TenantId { get; }
+    new Guid TenantId { get; }
 
     /// <summary>
     ///     The .Net type of the event body
     /// </summary>
-    Type EventType { get; }
+    new Type EventType { get; }
+
+    Guid IEventEnvelope.Id => Id;
+
+    object IEventEnvelope.Data => Data;
+
+    Type IEventEnvelope.EventType => EventType;
+
+    DateTimeOffset IEventEnvelope.Timestamp => Timestamp;
+
+    Guid IEventEnvelope.TenantId => TenantId;
 
     /// <summary>
     ///     The logical event type name stored independently of the CLR type name.
@@ -84,10 +94,12 @@ public interface IEvent
 /// Defines a strongly-typed event wrapper.
 /// </summary>
 /// <typeparam name="T">The event payload type.</typeparam>
-public interface IEvent<out T> : IEvent where T : class
+public interface IEvent<out T> : IEvent, IEventEnvelope<T> where T : class
 {
     /// <summary>
     /// The event payload.
     /// </summary>
     new T Data { get; }
+
+    object IEventEnvelope.Data => Data;
 }

--- a/src/EventStoreCore.Abstractions/IEventEnvelope.cs
+++ b/src/EventStoreCore.Abstractions/IEventEnvelope.cs
@@ -1,0 +1,35 @@
+namespace EventStoreCore.Abstractions;
+
+/// <summary>
+/// Describes the common identity and payload exposed by an event source.
+/// </summary>
+public interface IEventEnvelope
+{
+    /// <summary>The unique event identifier.</summary>
+    Guid Id { get; }
+
+    /// <summary>The event payload.</summary>
+    object Data { get; }
+
+    /// <summary>The CLR type of the event payload.</summary>
+    Type EventType { get; }
+
+    /// <summary>When the event was created in UTC.</summary>
+    DateTimeOffset Timestamp { get; }
+
+    /// <summary>The tenant identifier.</summary>
+    Guid TenantId { get; }
+}
+
+/// <summary>
+/// Describes the common identity and strongly typed payload exposed by an event source.
+/// </summary>
+/// <typeparam name="TEvent">The event payload type.</typeparam>
+public interface IEventEnvelope<out TEvent> : IEventEnvelope
+    where TEvent : class
+{
+    /// <summary>The strongly typed event payload.</summary>
+    new TEvent Data { get; }
+
+    object IEventEnvelope.Data => Data;
+}

--- a/src/EventStoreCore.Abstractions/IInlineEventHandler.cs
+++ b/src/EventStoreCore.Abstractions/IInlineEventHandler.cs
@@ -1,0 +1,19 @@
+namespace EventStoreCore.Abstractions;
+
+/// <summary>
+/// Handles an event inline while the originating <c>SaveChanges</c> operation is in progress.
+/// </summary>
+/// <typeparam name="TEvent">The event payload type.</typeparam>
+/// <remarks>
+/// Implementations may mutate tracked state owned by the same persistence context. They must not
+/// call <c>SaveChanges</c>, append streams, perform remote I/O, or execute other effects that cannot
+/// be rolled back with the outer save.
+/// </remarks>
+public interface IInlineEventHandler<TEvent>
+    where TEvent : class
+{
+    /// <summary>Handles one event before the originating save commits.</summary>
+    /// <param name="event">The common event envelope.</param>
+    /// <param name="ct">Cancellation token for the outer save.</param>
+    Task Handle(IEventEnvelope<TEvent> @event, CancellationToken ct);
+}

--- a/src/EventStoreCore.Abstractions/IOutboxEvent.cs
+++ b/src/EventStoreCore.Abstractions/IOutboxEvent.cs
@@ -3,12 +3,12 @@ namespace EventStoreCore.Abstractions;
 /// <summary>
 /// Describes a domain event captured from an EF entity change.
 /// </summary>
-public interface IOutboxEvent
+public interface IOutboxEvent : IEventEnvelope
 {
     /// <summary>
     /// The unique event identifier.
     /// </summary>
-    Guid Id { get; }
+    new Guid Id { get; }
 
     /// <summary>
     /// The outbox sequence used for ordered reading and checkpoints.
@@ -18,22 +18,32 @@ public interface IOutboxEvent
     /// <summary>
     /// The event payload.
     /// </summary>
-    object Data { get; }
+    new object Data { get; }
 
     /// <summary>
     /// The CLR type of the event payload.
     /// </summary>
-    Type EventType { get; }
+    new Type EventType { get; }
 
     /// <summary>
     /// When the event was captured in UTC.
     /// </summary>
-    DateTimeOffset Timestamp { get; }
+    new DateTimeOffset Timestamp { get; }
 
     /// <summary>
     /// The tenant identifier.
     /// </summary>
-    Guid TenantId { get; }
+    new Guid TenantId { get; }
+
+    Guid IEventEnvelope.Id => Id;
+
+    object IEventEnvelope.Data => Data;
+
+    Type IEventEnvelope.EventType => EventType;
+
+    DateTimeOffset IEventEnvelope.Timestamp => Timestamp;
+
+    Guid IEventEnvelope.TenantId => TenantId;
 
     /// <summary>
     /// The assembly-qualified CLR type name of the source entity.
@@ -55,11 +65,13 @@ public interface IOutboxEvent
 /// Describes a strongly typed domain event captured from an EF entity change.
 /// </summary>
 /// <typeparam name="T">The event payload type.</typeparam>
-public interface IOutboxEvent<out T> : IOutboxEvent
+public interface IOutboxEvent<out T> : IOutboxEvent, IEventEnvelope<T>
     where T : class
 {
     /// <summary>
     /// The strongly typed event payload.
     /// </summary>
     new T Data { get; }
+
+    object IEventEnvelope.Data => Data;
 }

--- a/src/EventStoreCore.Abstractions/README.md
+++ b/src/EventStoreCore.Abstractions/README.md
@@ -12,6 +12,10 @@ Most applications should install `EventStoreCore` plus a persistence provider.
 Reference this package directly when a domain or integration assembly needs only
 contracts and should not depend on EF Core or daemon implementations.
 
+`IEventEnvelope<TEvent>` is the common envelope implemented by stream events
+and entity-outbox events. `IInlineEventHandler<TEvent>` defines module-local
+reactions that are dispatched by the Core EF integration during `SaveChanges`.
+
 The package contains interfaces and DTOs only. It does not register services,
 configure persistence, or start background workers.
 

--- a/src/EventStoreCore/EntityOutboxCapture.cs
+++ b/src/EventStoreCore/EntityOutboxCapture.cs
@@ -1,0 +1,102 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using EventStoreCore.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace EventStoreCore;
+
+internal sealed class EntityOutboxCapture<TDbContext>(
+    EntityOutboxRegistry<TDbContext> registry,
+    EventTypeRegistry eventTypes,
+    TimeProvider timeProvider)
+    where TDbContext : DbContext
+{
+    private readonly ConditionalWeakTable<DbContext, CaptureState> _states = new();
+
+    internal void Capture(DbContext dbContext)
+    {
+        dbContext.ChangeTracker.DetectChanges();
+
+        var state = _states.GetValue(dbContext, _ => new CaptureState());
+        var entries = dbContext.ChangeTracker.Entries()
+            .Where(entry =>
+                (entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted) &&
+                registry.Registrations.ContainsKey(entry.Metadata.ClrType) &&
+                !state.Entities.Contains(entry.Entity))
+            .ToArray();
+
+        foreach (var entry in entries)
+        {
+            var registration = registry.Registrations[entry.Metadata.ClrType];
+            var changeKind = ToChangeKind(entry.State);
+            var events = registration.CreateEvents(entry, changeKind);
+
+            foreach (var @event in events)
+            {
+                var eventType = @event.GetType();
+                if (eventType.IsValueType)
+                {
+                    throw new InvalidOperationException(
+                        $"Entity outbox event type '{eventType}' must be a reference type.");
+                }
+
+                var message = new DbOutboxMessage
+                {
+                    EventId = Guid.NewGuid(),
+                    TenantId = registration.GetTenantId(entry.Entity),
+                    Type = eventType.AssemblyQualifiedName
+                        ?? throw new InvalidOperationException($"Event type '{eventType}' has no assembly-qualified name."),
+                    TypeName = eventTypes.ResolveName(eventType),
+                    Data = JsonSerializer.Serialize(@event, eventType, registry.SerializerOptions),
+                    Timestamp = timeProvider.GetUtcNow(),
+                    SourceEntityType = registration.EntityType.AssemblyQualifiedName
+                        ?? registration.EntityType.FullName
+                        ?? registration.EntityType.Name,
+                    SourceEntityKey = SerializeKey(entry, registry.SerializerOptions),
+                    ChangeKind = changeKind
+                };
+
+                dbContext.Set<DbOutboxMessage>().Add(message);
+                state.Events.Add(new CapturedOutboxEvent(message, eventType, @event));
+            }
+
+            state.Entities.Add(entry.Entity);
+        }
+    }
+
+    internal IReadOnlyList<CapturedOutboxEvent> GetEvents(DbContext dbContext) =>
+        _states.TryGetValue(dbContext, out var state) ? state.Events : [];
+
+    internal void Clear(DbContext dbContext) => _states.Remove(dbContext);
+
+    private static string SerializeKey(EntityEntry entry, JsonSerializerOptions serializerOptions)
+    {
+        var primaryKey = entry.Metadata.FindPrimaryKey()
+            ?? throw new InvalidOperationException(
+                $"Entity type '{entry.Metadata.ClrType.FullName}' must have a primary key to emit outbox events.");
+
+        var values = primaryKey.Properties.ToDictionary(
+            property => property.Name,
+            property => entry.Property(property.Name).CurrentValue);
+
+        return JsonSerializer.Serialize(values, serializerOptions);
+    }
+
+    private static EntityChangeKind ToChangeKind(EntityState state) => state switch
+    {
+        EntityState.Added => EntityChangeKind.Added,
+        EntityState.Modified => EntityChangeKind.Modified,
+        EntityState.Deleted => EntityChangeKind.Deleted,
+        _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
+    };
+
+    private sealed class CaptureState
+    {
+        internal HashSet<object> Entities { get; } = new(ReferenceEqualityComparer.Instance);
+
+        internal List<CapturedOutboxEvent> Events { get; } = [];
+    }
+}
+
+internal sealed record CapturedOutboxEvent(DbOutboxMessage Message, Type EventType, object Data);

--- a/src/EventStoreCore/EntityOutboxCapture.cs
+++ b/src/EventStoreCore/EntityOutboxCapture.cs
@@ -16,53 +16,61 @@ internal sealed class EntityOutboxCapture<TDbContext>(
 
     internal void Capture(DbContext dbContext)
     {
+        while (CaptureNext(dbContext))
+        {
+        }
+    }
+
+    internal bool CaptureNext(DbContext dbContext)
+    {
         dbContext.ChangeTracker.DetectChanges();
 
         var state = _states.GetValue(dbContext, _ => new CaptureState());
-        var entries = dbContext.ChangeTracker.Entries()
-            .Where(entry =>
+        var entry = dbContext.ChangeTracker.Entries()
+            .FirstOrDefault(entry =>
                 (entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted) &&
                 registry.Registrations.ContainsKey(entry.Metadata.ClrType) &&
-                !state.Entities.Contains(entry.Entity))
-            .ToArray();
-
-        foreach (var entry in entries)
+                !state.Entities.Contains(entry.Entity));
+        if (entry is null)
         {
-            var registration = registry.Registrations[entry.Metadata.ClrType];
-            var changeKind = ToChangeKind(entry.State);
-            var events = registration.CreateEvents(entry, changeKind);
+            return false;
+        }
 
-            foreach (var @event in events)
+        var registration = registry.Registrations[entry.Metadata.ClrType];
+        var changeKind = ToChangeKind(entry.State);
+        var events = registration.CreateEvents(entry, changeKind);
+
+        foreach (var @event in events)
+        {
+            var eventType = @event.GetType();
+            if (eventType.IsValueType)
             {
-                var eventType = @event.GetType();
-                if (eventType.IsValueType)
-                {
-                    throw new InvalidOperationException(
-                        $"Entity outbox event type '{eventType}' must be a reference type.");
-                }
-
-                var message = new DbOutboxMessage
-                {
-                    EventId = Guid.NewGuid(),
-                    TenantId = registration.GetTenantId(entry.Entity),
-                    Type = eventType.AssemblyQualifiedName
-                        ?? throw new InvalidOperationException($"Event type '{eventType}' has no assembly-qualified name."),
-                    TypeName = eventTypes.ResolveName(eventType),
-                    Data = JsonSerializer.Serialize(@event, eventType, registry.SerializerOptions),
-                    Timestamp = timeProvider.GetUtcNow(),
-                    SourceEntityType = registration.EntityType.AssemblyQualifiedName
-                        ?? registration.EntityType.FullName
-                        ?? registration.EntityType.Name,
-                    SourceEntityKey = SerializeKey(entry, registry.SerializerOptions),
-                    ChangeKind = changeKind
-                };
-
-                dbContext.Set<DbOutboxMessage>().Add(message);
-                state.Events.Add(new CapturedOutboxEvent(message, eventType, @event));
+                throw new InvalidOperationException(
+                    $"Entity outbox event type '{eventType}' must be a reference type.");
             }
 
-            state.Entities.Add(entry.Entity);
+            var message = new DbOutboxMessage
+            {
+                EventId = Guid.NewGuid(),
+                TenantId = registration.GetTenantId(entry.Entity),
+                Type = eventType.AssemblyQualifiedName
+                    ?? throw new InvalidOperationException($"Event type '{eventType}' has no assembly-qualified name."),
+                TypeName = eventTypes.ResolveName(eventType),
+                Data = JsonSerializer.Serialize(@event, eventType, registry.SerializerOptions),
+                Timestamp = timeProvider.GetUtcNow(),
+                SourceEntityType = registration.EntityType.AssemblyQualifiedName
+                    ?? registration.EntityType.FullName
+                    ?? registration.EntityType.Name,
+                SourceEntityKey = SerializeKey(entry, registry.SerializerOptions),
+                ChangeKind = changeKind
+            };
+
+            dbContext.Set<DbOutboxMessage>().Add(message);
+            state.Events.Add(new CapturedOutboxEvent(message, eventType, @event));
         }
+
+        state.Entities.Add(entry.Entity);
+        return true;
     }
 
     internal IReadOnlyList<CapturedOutboxEvent> GetEvents(DbContext dbContext) =>

--- a/src/EventStoreCore/EntityOutboxInterceptor.cs
+++ b/src/EventStoreCore/EntityOutboxInterceptor.cs
@@ -1,25 +1,20 @@
-using System.Runtime.CompilerServices;
-using System.Text.Json;
-using EventStoreCore.Abstractions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace EventStoreCore;
 
 internal sealed class EntityOutboxInterceptor<TDbContext>(
-    EntityOutboxRegistry<TDbContext> registry,
-    EventTypeRegistry eventTypes,
-    TimeProvider timeProvider) : SaveChangesInterceptor
+    EntityOutboxCapture<TDbContext> capture) : SaveChangesInterceptor
     where TDbContext : DbContext
 {
-    private static readonly ConditionalWeakTable<DbContext, HashSet<object>> CapturedEntities = new();
-
     public override InterceptionResult<int> SavingChanges(
         DbContextEventData eventData,
         InterceptionResult<int> result)
     {
-        Capture(eventData.Context);
+        if (eventData.Context is DbContext dbContext)
+        {
+            capture.Capture(dbContext);
+        }
         return result;
     }
 
@@ -28,13 +23,19 @@ internal sealed class EntityOutboxInterceptor<TDbContext>(
         InterceptionResult<int> result,
         CancellationToken cancellationToken = default)
     {
-        Capture(eventData.Context);
+        if (eventData.Context is DbContext dbContext)
+        {
+            capture.Capture(dbContext);
+        }
         return ValueTask.FromResult(result);
     }
 
     public override int SavedChanges(SaveChangesCompletedEventData eventData, int result)
     {
-        Clear(eventData.Context);
+        if (eventData.Context is DbContext dbContext)
+        {
+            capture.Clear(dbContext);
+        }
         return result;
     }
 
@@ -43,91 +44,10 @@ internal sealed class EntityOutboxInterceptor<TDbContext>(
         int result,
         CancellationToken cancellationToken = default)
     {
-        Clear(eventData.Context);
+        if (eventData.Context is DbContext dbContext)
+        {
+            capture.Clear(dbContext);
+        }
         return ValueTask.FromResult(result);
-    }
-
-    private void Capture(DbContext? dbContext)
-    {
-        if (dbContext is null)
-        {
-            return;
-        }
-
-        dbContext.ChangeTracker.DetectChanges();
-
-        var alreadyCaptured = CapturedEntities.GetValue(
-            dbContext,
-            _ => new HashSet<object>(ReferenceEqualityComparer.Instance));
-        var entries = dbContext.ChangeTracker.Entries()
-            .Where(entry =>
-                entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted &&
-                registry.Registrations.ContainsKey(entry.Metadata.ClrType) &&
-                !alreadyCaptured.Contains(entry.Entity))
-            .ToArray();
-
-        foreach (var entry in entries)
-        {
-            var registration = registry.Registrations[entry.Metadata.ClrType];
-            var changeKind = ToChangeKind(entry.State);
-            var events = registration.CreateEvents(entry, changeKind);
-
-            foreach (var @event in events)
-            {
-                var eventType = @event.GetType();
-                if (eventType.IsValueType)
-                {
-                    throw new InvalidOperationException(
-                        $"Entity outbox event type '{eventType}' must be a reference type.");
-                }
-
-                dbContext.Set<DbOutboxMessage>().Add(new DbOutboxMessage
-                {
-                    EventId = Guid.NewGuid(),
-                    TenantId = registration.GetTenantId(entry.Entity),
-                    Type = eventType.AssemblyQualifiedName
-                        ?? throw new InvalidOperationException($"Event type '{eventType}' has no assembly-qualified name."),
-                    TypeName = eventTypes.ResolveName(eventType),
-                    Data = JsonSerializer.Serialize(@event, eventType, registry.SerializerOptions),
-                    Timestamp = timeProvider.GetUtcNow(),
-                    SourceEntityType = registration.EntityType.AssemblyQualifiedName
-                        ?? registration.EntityType.FullName
-                        ?? registration.EntityType.Name,
-                    SourceEntityKey = SerializeKey(entry, registry.SerializerOptions),
-                    ChangeKind = changeKind
-                });
-            }
-
-            alreadyCaptured.Add(entry.Entity);
-        }
-    }
-
-    private static string SerializeKey(EntityEntry entry, JsonSerializerOptions serializerOptions)
-    {
-        var primaryKey = entry.Metadata.FindPrimaryKey()
-            ?? throw new InvalidOperationException(
-                $"Entity type '{entry.Metadata.ClrType.FullName}' must have a primary key to emit outbox events.");
-
-        var values = primaryKey.Properties.ToDictionary(
-            property => property.Name,
-            property => entry.Property(property.Name).CurrentValue);
-
-        return JsonSerializer.Serialize(values, serializerOptions);
-    }
-
-    private static EntityChangeKind ToChangeKind(EntityState state) => state switch
-    {
-        EntityState.Added => EntityChangeKind.Added,
-        EntityState.Modified => EntityChangeKind.Modified,
-        EntityState.Deleted => EntityChangeKind.Deleted,
-        _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
-    };
-
-    private static void Clear(DbContext? dbContext)
-    {
-        if (dbContext is not null)
-        {
-            CapturedEntities.Remove(dbContext);
-        }
     }
 }

--- a/src/EventStoreCore/EntityOutboxInterceptor.cs
+++ b/src/EventStoreCore/EntityOutboxInterceptor.cs
@@ -4,14 +4,15 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 namespace EventStoreCore;
 
 internal sealed class EntityOutboxInterceptor<TDbContext>(
-    EntityOutboxCapture<TDbContext> capture) : SaveChangesInterceptor
+    EntityOutboxCapture<TDbContext> capture,
+    bool deferCapture) : SaveChangesInterceptor
     where TDbContext : DbContext
 {
     public override InterceptionResult<int> SavingChanges(
         DbContextEventData eventData,
         InterceptionResult<int> result)
     {
-        if (eventData.Context is DbContext dbContext)
+        if (!deferCapture && eventData.Context is DbContext dbContext)
         {
             capture.Capture(dbContext);
         }
@@ -23,7 +24,7 @@ internal sealed class EntityOutboxInterceptor<TDbContext>(
         InterceptionResult<int> result,
         CancellationToken cancellationToken = default)
     {
-        if (eventData.Context is DbContext dbContext)
+        if (!deferCapture && eventData.Context is DbContext dbContext)
         {
             capture.Capture(dbContext);
         }

--- a/src/EventStoreCore/EntityOutboxServiceCollectionExtensions.cs
+++ b/src/EventStoreCore/EntityOutboxServiceCollectionExtensions.cs
@@ -44,7 +44,8 @@ public static class EntityOutboxServiceCollectionExtensions
         services.AddDbContext<TDbContext>((sp, options) =>
         {
             options.AddInterceptors(new EntityOutboxInterceptor<TDbContext>(
-                sp.GetRequiredService<EntityOutboxCapture<TDbContext>>()));
+                sp.GetRequiredService<EntityOutboxCapture<TDbContext>>(),
+                sp.GetService<InlineEventHandlerConfiguration<TDbContext>>() is not null));
             SequenceCommitOrder.Configure(sp, options);
         });
 

--- a/src/EventStoreCore/EntityOutboxServiceCollectionExtensions.cs
+++ b/src/EventStoreCore/EntityOutboxServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class EntityOutboxServiceCollectionExtensions
         var registry = builder.Build();
 
         services.AddSingleton(registry);
+        services.TryAddSingleton<EntityOutboxCapture<TDbContext>>();
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton(sp => new EventTypeRegistry(
             sp.GetServices<EventTypeRegistration>(),
@@ -43,9 +44,7 @@ public static class EntityOutboxServiceCollectionExtensions
         services.AddDbContext<TDbContext>((sp, options) =>
         {
             options.AddInterceptors(new EntityOutboxInterceptor<TDbContext>(
-                sp.GetRequiredService<EntityOutboxRegistry<TDbContext>>(),
-                sp.GetRequiredService<EventTypeRegistry>(),
-                sp.GetRequiredService<TimeProvider>()));
+                sp.GetRequiredService<EntityOutboxCapture<TDbContext>>()));
             SequenceCommitOrder.Configure(sp, options);
         });
 

--- a/src/EventStoreCore/IInlineEventHandlerBuilder.cs
+++ b/src/EventStoreCore/IInlineEventHandlerBuilder.cs
@@ -1,0 +1,24 @@
+using EventStoreCore.Abstractions;
+
+namespace EventStoreCore;
+
+/// <summary>
+/// Registers inline event handlers for one EF Core context.
+/// </summary>
+public interface IInlineEventHandlerBuilder
+{
+    /// <summary>
+    /// Gets or sets the maximum number of source envelopes dispatched by one save operation.
+    /// </summary>
+    int MaxDispatchCount { get; set; }
+
+    /// <summary>Registers a handler for a strongly typed event payload.</summary>
+    /// <typeparam name="THandler">The handler implementation.</typeparam>
+    /// <typeparam name="TEvent">The event payload type.</typeparam>
+    /// <param name="configure">Optional ordering and source configuration.</param>
+    /// <returns>The builder for chaining.</returns>
+    IInlineEventHandlerBuilder Add<THandler, TEvent>(
+        Action<InlineEventHandlerRegistrationOptions>? configure = null)
+        where THandler : class, IInlineEventHandler<TEvent>
+        where TEvent : class;
+}

--- a/src/EventStoreCore/InlineEventHandlerInterceptor.cs
+++ b/src/EventStoreCore/InlineEventHandlerInterceptor.cs
@@ -1,0 +1,169 @@
+using System.Runtime.CompilerServices;
+using EventStoreCore.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace EventStoreCore;
+
+internal sealed class InlineEventHandlerInterceptor<TDbContext>(
+    IServiceProvider serviceProvider,
+    InlineEventHandlerConfiguration<TDbContext> configuration,
+    EntityOutboxCapture<TDbContext>? outboxCapture,
+    EventTypeRegistry? eventTypes,
+    IEventStoreSerializer? serializer) : SaveChangesInterceptor
+    where TDbContext : DbContext
+{
+    private readonly ConditionalWeakTable<DbContext, DispatchState> _states = new();
+    private readonly IEventStoreSerializer _serializer =
+        serializer ?? new SystemTextJsonEventStoreSerializer();
+
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        DispatchAsync(eventData.Context, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+        return result;
+    }
+
+    public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        await DispatchAsync(eventData.Context, cancellationToken);
+        return result;
+    }
+
+    private async Task DispatchAsync(DbContext? dbContext, CancellationToken ct)
+    {
+        if (dbContext is null)
+        {
+            return;
+        }
+
+        var state = _states.GetValue(dbContext, _ => new DispatchState());
+        if (state.IsDispatching)
+        {
+            throw new InvalidOperationException(
+                "Inline event handlers cannot call SaveChanges. Mutate tracked state and let the outer save commit it.");
+        }
+
+        var scopedContext = serviceProvider.GetService(typeof(TDbContext));
+        if (!ReferenceEquals(scopedContext, dbContext))
+        {
+            throw new InvalidOperationException(
+                $"Inline event handlers for '{typeof(TDbContext).FullName}' must be resolved from the same DI scope as the committing DbContext.");
+        }
+
+        dbContext.ChangeTracker.DetectChanges();
+        var initialStreamEventIds = dbContext.ChangeTracker.Entries<DbEvent>()
+            .Where(entry => entry.State == EntityState.Added)
+            .Select(entry => entry.Entity.EventId)
+            .ToHashSet();
+        var handled = new HashSet<InlineEventKey>();
+        var dispatchedCount = 0;
+
+        state.IsDispatching = true;
+        try
+        {
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+                outboxCapture?.Capture(dbContext);
+                EnsureNoStreamAppends(dbContext, initialStreamEventIds);
+
+                var wave = GetWave(dbContext, handled);
+                if (wave.Count == 0)
+                {
+                    break;
+                }
+
+                foreach (var sourceEvent in wave)
+                {
+                    handled.Add(sourceEvent.Key);
+                    var registrations = configuration.Registrations
+                        .Where(registration =>
+                            registration.EventType == sourceEvent.Envelope.EventType &&
+                            (registration.Sources & sourceEvent.Source) != 0)
+                        .ToArray();
+                    if (registrations.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    dispatchedCount++;
+                    if (dispatchedCount > configuration.MaxDispatchCount)
+                    {
+                        throw new InvalidOperationException(
+                            $"Inline event dispatch exceeded the configured limit of {configuration.MaxDispatchCount} source envelopes.");
+                    }
+
+                    foreach (var registration in registrations)
+                    {
+                        await registration.Handle(serviceProvider, sourceEvent.Envelope, ct);
+                        EnsureNoStreamAppends(dbContext, initialStreamEventIds);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            state.IsDispatching = false;
+        }
+    }
+
+    private IReadOnlyList<SourceEvent> GetWave(
+        DbContext dbContext,
+        HashSet<InlineEventKey> handled)
+    {
+        var streamEvents = dbContext.ChangeTracker.Entries<DbEvent>()
+            .Where(entry => entry.State == EntityState.Added)
+            .Select(entry => entry.Entity)
+            .OrderBy(@event => @event.StreamType, StringComparer.Ordinal)
+            .ThenBy(@event => @event.StreamId)
+            .ThenBy(@event => @event.Version)
+            .Select(@event => new SourceEvent(
+                new InlineEventKey(InlineEventSource.Stream, @event.EventId),
+                InlineEventSource.Stream,
+                @event.ToEvent(eventTypes, _serializer)))
+            .Where(@event => !handled.Contains(@event.Key));
+
+        var outboxEvents = (outboxCapture?.GetEvents(dbContext) ?? [])
+            .Select(captured => new SourceEvent(
+                new InlineEventKey(InlineEventSource.EntityOutbox, captured.Message.EventId),
+                InlineEventSource.EntityOutbox,
+                new OutboxEvent(captured.Message, captured.EventType, captured.Data)))
+            .Where(@event => !handled.Contains(@event.Key));
+
+        return streamEvents.Concat(outboxEvents).ToArray();
+    }
+
+    private static void EnsureNoStreamAppends(
+        DbContext dbContext,
+        HashSet<Guid> initialStreamEventIds)
+    {
+        var appended = dbContext.ChangeTracker.Entries<DbEvent>()
+            .Where(entry => entry.State == EntityState.Added)
+            .Select(entry => entry.Entity.EventId)
+            .FirstOrDefault(eventId => !initialStreamEventIds.Contains(eventId));
+        if (appended != Guid.Empty)
+        {
+            throw new InvalidOperationException(
+                "Inline event handlers cannot append stream events. Use a command boundary or durable subscription for cross-stream reactions.");
+        }
+    }
+
+    private sealed class DispatchState
+    {
+        internal bool IsDispatching { get; set; }
+    }
+
+    private readonly record struct InlineEventKey(InlineEventSource Source, Guid Id);
+
+    private sealed record SourceEvent(
+        InlineEventKey Key,
+        InlineEventSource Source,
+        IEventEnvelope Envelope);
+}

--- a/src/EventStoreCore/InlineEventHandlerInterceptor.cs
+++ b/src/EventStoreCore/InlineEventHandlerInterceptor.cs
@@ -71,10 +71,14 @@ internal sealed class InlineEventHandlerInterceptor<TDbContext>(
             while (true)
             {
                 ct.ThrowIfCancellationRequested();
-                outboxCapture?.Capture(dbContext);
                 EnsureNoStreamAppends(dbContext, initialStreamEventIds);
 
                 var wave = GetWave(dbContext, handled);
+                if (wave.Count == 0 && outboxCapture?.CaptureNext(dbContext) == true)
+                {
+                    wave = GetWave(dbContext, handled);
+                }
+
                 if (wave.Count == 0)
                 {
                     break;

--- a/src/EventStoreCore/InlineEventHandlerRegistrationOptions.cs
+++ b/src/EventStoreCore/InlineEventHandlerRegistrationOptions.cs
@@ -1,0 +1,16 @@
+namespace EventStoreCore;
+
+/// <summary>
+/// Configures ordering and source selection for an inline event handler.
+/// </summary>
+public sealed class InlineEventHandlerRegistrationOptions
+{
+    /// <summary>
+    /// Gets or sets the handler order. Lower values run first; registrations with the same value
+    /// run in registration order.
+    /// </summary>
+    public int Order { get; set; }
+
+    /// <summary>Gets or sets the event sources handled by the registration.</summary>
+    public InlineEventSource Sources { get; set; } = InlineEventSource.All;
+}

--- a/src/EventStoreCore/InlineEventHandlerServiceCollectionExtensions.cs
+++ b/src/EventStoreCore/InlineEventHandlerServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using EventStoreCore.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace EventStoreCore;
 
@@ -77,7 +76,20 @@ internal sealed class InlineEventHandlerBuilder(IServiceCollection services) : I
                 $"'{typeof(TEvent).FullName}' with an overlapping source selection.");
         }
 
-        services.TryAddScoped<THandler>();
+        var existingDescriptors = services
+            .Where(descriptor => descriptor.ServiceType == typeof(THandler))
+            .ToArray();
+        if (existingDescriptors.Any(descriptor => descriptor.Lifetime != ServiceLifetime.Scoped))
+        {
+            throw new InvalidOperationException(
+                $"Inline handler '{typeof(THandler).FullName}' must be registered with scoped lifetime.");
+        }
+
+        if (existingDescriptors.Length == 0)
+        {
+            services.AddScoped<THandler>();
+        }
+
         _registrations.Add(new InlineEventHandlerRegistration<THandler, TEvent>(
             options.Order,
             options.Sources,

--- a/src/EventStoreCore/InlineEventHandlerServiceCollectionExtensions.cs
+++ b/src/EventStoreCore/InlineEventHandlerServiceCollectionExtensions.cs
@@ -1,0 +1,199 @@
+using EventStoreCore.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace EventStoreCore;
+
+/// <summary>
+/// Registers module-local event handlers that participate in an EF Core save operation.
+/// </summary>
+public static class InlineEventHandlerServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers inline event handlers for the specified context and adds their save interceptor.
+    /// </summary>
+    /// <typeparam name="TDbContext">The context whose save operation dispatches the handlers.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Configures handlers, ordering, source filters, and the dispatch limit.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddInlineEventHandlers<TDbContext>(
+        this IServiceCollection services,
+        Action<IInlineEventHandlerBuilder> configure)
+        where TDbContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (services.Any(descriptor =>
+                descriptor.ServiceType == typeof(InlineEventHandlerRegistrationMarker<TDbContext>)))
+        {
+            throw new InvalidOperationException(
+                $"Inline event handlers are already configured for DbContext '{typeof(TDbContext).FullName}'.");
+        }
+
+        var builder = new InlineEventHandlerBuilder(services);
+        configure(builder);
+        var configuration = builder.Build<TDbContext>();
+
+        services.AddSingleton(new InlineEventHandlerRegistrationMarker<TDbContext>());
+        services.AddSingleton(configuration);
+        services.AddDbContext<TDbContext>((serviceProvider, options) =>
+        {
+            options.AddInterceptors(new InlineEventHandlerInterceptor<TDbContext>(
+                serviceProvider,
+                serviceProvider.GetRequiredService<InlineEventHandlerConfiguration<TDbContext>>(),
+                serviceProvider.GetService<EntityOutboxCapture<TDbContext>>(),
+                serviceProvider.GetService<EventTypeRegistry>(),
+                serviceProvider.GetService<IEventStoreSerializer>()));
+        });
+
+        return services;
+    }
+}
+
+internal sealed class InlineEventHandlerBuilder(IServiceCollection services) : IInlineEventHandlerBuilder
+{
+    private readonly List<InlineEventHandlerRegistration> _registrations = [];
+
+    public int MaxDispatchCount { get; set; } = 1_000;
+
+    public IInlineEventHandlerBuilder Add<THandler, TEvent>(
+        Action<InlineEventHandlerRegistrationOptions>? configure = null)
+        where THandler : class, IInlineEventHandler<TEvent>
+        where TEvent : class
+    {
+        var options = new InlineEventHandlerRegistrationOptions();
+        configure?.Invoke(options);
+        ValidateSources(options.Sources);
+
+        if (_registrations.Any(registration =>
+                registration.HandlerType == typeof(THandler) &&
+                registration.EventType == typeof(TEvent) &&
+                (registration.Sources & options.Sources) != 0))
+        {
+            throw new InvalidOperationException(
+                $"Inline handler '{typeof(THandler).FullName}' is already registered for event " +
+                $"'{typeof(TEvent).FullName}' with an overlapping source selection.");
+        }
+
+        services.TryAddScoped<THandler>();
+        _registrations.Add(new InlineEventHandlerRegistration<THandler, TEvent>(
+            options.Order,
+            options.Sources,
+            _registrations.Count));
+        return this;
+    }
+
+    internal InlineEventHandlerConfiguration<TDbContext> Build<TDbContext>()
+        where TDbContext : DbContext
+    {
+        if (MaxDispatchCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(MaxDispatchCount)} must be greater than zero.");
+        }
+
+        return new InlineEventHandlerConfiguration<TDbContext>(
+            MaxDispatchCount,
+            _registrations
+                .OrderBy(registration => registration.Order)
+                .ThenBy(registration => registration.RegistrationIndex)
+                .ToArray());
+    }
+
+    private static void ValidateSources(InlineEventSource sources)
+    {
+        if (sources == 0 || (sources & ~InlineEventSource.All) != 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(InlineEventHandlerRegistrationOptions.Sources)} must select Stream, EntityOutbox, or All.");
+        }
+    }
+}
+
+internal sealed record InlineEventHandlerConfiguration<TDbContext>(
+    int MaxDispatchCount,
+    IReadOnlyList<InlineEventHandlerRegistration> Registrations)
+    where TDbContext : DbContext;
+
+internal sealed class InlineEventHandlerRegistrationMarker<TDbContext>
+    where TDbContext : DbContext;
+
+internal abstract class InlineEventHandlerRegistration(
+    Type handlerType,
+    Type eventType,
+    int order,
+    InlineEventSource sources,
+    int registrationIndex)
+{
+    internal Type HandlerType { get; } = handlerType;
+
+    internal Type EventType { get; } = eventType;
+
+    internal int Order { get; } = order;
+
+    internal InlineEventSource Sources { get; } = sources;
+
+    internal int RegistrationIndex { get; } = registrationIndex;
+
+    internal abstract Task Handle(
+        IServiceProvider serviceProvider,
+        IEventEnvelope envelope,
+        CancellationToken ct);
+}
+
+internal sealed class InlineEventHandlerRegistration<THandler, TEvent>(
+    int order,
+    InlineEventSource sources,
+    int registrationIndex) : InlineEventHandlerRegistration(
+        typeof(THandler),
+        typeof(TEvent),
+        order,
+        sources,
+        registrationIndex)
+    where THandler : class, IInlineEventHandler<TEvent>
+    where TEvent : class
+{
+    internal override Task Handle(
+        IServiceProvider serviceProvider,
+        IEventEnvelope envelope,
+        CancellationToken ct)
+    {
+        var typedEnvelope = envelope switch
+        {
+            IEvent streamEvent => (IEventEnvelope<TEvent>)new TypedEvent<TEvent>(streamEvent),
+            IOutboxEvent outboxEvent => new TypedOutboxEvent<TEvent>(outboxEvent),
+            _ => throw new InvalidOperationException(
+                $"Unsupported inline event envelope '{envelope.GetType().FullName}'.")
+        };
+
+        return serviceProvider.GetRequiredService<THandler>().Handle(typedEnvelope, ct);
+    }
+}
+
+internal sealed class TypedOutboxEvent<TEvent>(IOutboxEvent source) : IOutboxEvent<TEvent>
+    where TEvent : class
+{
+    public Guid Id => source.Id;
+
+    public long Sequence => source.Sequence;
+
+    public TEvent Data => (TEvent)source.Data;
+
+    object IOutboxEvent.Data => Data;
+
+    object IEventEnvelope.Data => Data;
+
+    public Type EventType => source.EventType;
+
+    public DateTimeOffset Timestamp => source.Timestamp;
+
+    public Guid TenantId => source.TenantId;
+
+    public string SourceEntityType => source.SourceEntityType;
+
+    public string SourceEntityKey => source.SourceEntityKey;
+
+    public EntityChangeKind ChangeKind => source.ChangeKind;
+}

--- a/src/EventStoreCore/InlineEventSource.cs
+++ b/src/EventStoreCore/InlineEventSource.cs
@@ -1,0 +1,17 @@
+namespace EventStoreCore;
+
+/// <summary>
+/// Identifies event sources eligible for inline event-handler delivery.
+/// </summary>
+[Flags]
+public enum InlineEventSource
+{
+    /// <summary>Events appended to EventStoreCore streams.</summary>
+    Stream = 1,
+
+    /// <summary>Events captured from ordinary EF entity changes into the outbox.</summary>
+    EntityOutbox = 2,
+
+    /// <summary>Events from streams and entity-outbox capture.</summary>
+    All = Stream | EntityOutbox
+}

--- a/src/EventStoreCore/README.md
+++ b/src/EventStoreCore/README.md
@@ -24,6 +24,7 @@ infrastructure remains application-owned.
 ## Highlights
 
 - Inline and eventual projections
+- Transactional inline event handlers for stream and EF entity events
 - Subscription daemons with checkpointing
 - Stable global event-log paging across streams
 - Atomic domain-event capture from ordinary EF entities
@@ -42,10 +43,25 @@ infrastructure remains application-owned.
   compact `AppendResult`; conflicting reuse throws
   `EventStoreIdempotencyConflictException`.
 - Inline projections participate in the append transaction.
+- Inline event handlers can add tracked state to the originating `SaveChanges`;
+  failures abort that save.
 - Subscriptions and eventual projections are at-least-once and consumers must be
   idempotent.
 - Provider-specific storage types and migration considerations are documented by
   the PostgreSQL, SQL Server, and SQLite packages.
+
+## Inline event handlers
+
+Use `AddInlineEventHandlers<TDbContext>` for local domain reactions that must be
+atomic with the outer save. Handlers implement `IInlineEventHandler<TEvent>`,
+are resolved from the committing context's scope, and may handle stream events,
+entity-outbox events, or both. Entity events remain durably written to the
+outbox, including events captured from entities changed by an earlier handler
+in the same save.
+
+Inline handlers may only mutate tracked state in that context. Nested saves,
+stream appends, direct SQL, remote I/O, and separate contexts are outside the
+contract. Use stream or outbox subscriptions for durable post-commit work.
 
 ## Idempotent writes
 

--- a/src/EventStoreCore/SubscriptionRegistration.cs
+++ b/src/EventStoreCore/SubscriptionRegistration.cs
@@ -24,8 +24,13 @@ internal sealed class TypedEvent<TEvent>(IEvent source) : IEvent<TEvent>
     public long Version => source.Version;
     public TEvent Data => (TEvent)source.Data;
     object IEvent.Data => Data;
+    object IEventEnvelope.Data => Data;
     public Guid StreamId => source.StreamId;
     public DateTimeOffset Timestamp => source.Timestamp;
     public Guid TenantId => source.TenantId;
     public Type EventType => source.EventType;
+    public string TypeName => source.TypeName;
+    public string StreamType => source.StreamType;
+    public long Sequence => source.Sequence;
+    public EventMetadata Metadata => source.Metadata;
 }

--- a/tests/EventStoreCore.Tests/InlineEventHandlerTests.cs
+++ b/tests/EventStoreCore.Tests/InlineEventHandlerTests.cs
@@ -1,0 +1,390 @@
+using EventStoreCore.Abstractions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStoreCore.Tests;
+
+public sealed class InlineEventHandlerTests
+{
+    [Fact]
+    public async Task Stream_handlers_share_the_committing_scope_and_honor_order_and_source_filters()
+    {
+        await using var fixture = await InlineFixture.CreateAsync(handlers =>
+        {
+            handlers.Add<SecondStreamHandler, SharedEvent>(options => options.Order = 20);
+            handlers.Add<FirstStreamHandler, SharedEvent>(options =>
+            {
+                options.Order = 10;
+                options.Sources = InlineEventSource.Stream;
+            });
+            handlers.Add<EntityOnlySharedHandler, SharedEvent>(options =>
+                options.Sources = InlineEventSource.EntityOutbox);
+            handlers.Add<ThirdStreamHandler, SharedEvent>(options => options.Order = 20);
+        });
+        await using var scope = fixture.Provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InlineDbContext>();
+        var eventId = Guid.NewGuid();
+
+        db.Streams.StartStream(Guid.NewGuid(), new SharedEvent("stream").WithEventId(eventId));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var recorder = scope.ServiceProvider.GetRequiredService<Recorder>();
+        Assert.Equal(["first", "second", "third"], recorder.Entries);
+        Assert.Equal(0, scope.ServiceProvider.GetRequiredService<EntityOnlySharedHandler>().Calls);
+        var first = scope.ServiceProvider.GetRequiredService<FirstStreamHandler>();
+        Assert.Same(db, first.Context);
+        Assert.True(first.SawTypedStreamEnvelope);
+        Assert.Equal(eventId, first.EventId);
+        Assert.Single(await db.Reactions.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Entity_handlers_dispatch_cascades_breadth_first_and_keep_every_outbox_event()
+    {
+        await using var fixture = await InlineFixture.CreateAsync(handlers =>
+        {
+            handlers.Add<SecondOrderHandler, OrderAdded>(options =>
+            {
+                options.Order = 20;
+                options.Sources = InlineEventSource.EntityOutbox;
+            });
+            handlers.Add<FirstOrderHandler, OrderAdded>(options =>
+            {
+                options.Order = 10;
+                options.Sources = InlineEventSource.EntityOutbox;
+            });
+            handlers.Add<ShipmentHandler, ShipmentAdded>(options =>
+                options.Sources = InlineEventSource.EntityOutbox);
+        });
+        await using var scope = fixture.Provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InlineDbContext>();
+        var orderId = Guid.NewGuid();
+
+        db.Orders.Add(new Order { Id = orderId, Status = "new" });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var recorder = scope.ServiceProvider.GetRequiredService<Recorder>();
+        Assert.Equal(["order:first", "order:second", "shipment"], recorder.Entries);
+        Assert.True(scope.ServiceProvider.GetRequiredService<FirstOrderHandler>().SawTypedOutboxEnvelope);
+        Assert.Single(await db.Shipments.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(
+            2,
+            await db.Set<DbOutboxMessage>().CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Handler_failure_rolls_back_originating_event_and_tracked_side_effects()
+    {
+        await using var fixture = await InlineFixture.CreateAsync(handlers =>
+            handlers.Add<FailingHandler, SharedEvent>());
+        await using (var scope = fixture.Provider.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<InlineDbContext>();
+            db.Streams.StartStream(Guid.NewGuid(), new SharedEvent("fail"));
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => db.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+            Assert.Equal("handler failed", exception.Message);
+        }
+
+        await using var assertionScope = fixture.Provider.CreateAsyncScope();
+        var assertDb = assertionScope.ServiceProvider.GetRequiredService<InlineDbContext>();
+        Assert.Empty(await assertDb.Set<DbStream>().ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await assertDb.Reactions.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Nested_save_and_stream_append_are_rejected()
+    {
+        await using (var nestedFixture = await InlineFixture.CreateAsync(handlers =>
+            handlers.Add<NestedSaveHandler, SharedEvent>()))
+        {
+            await using var scope = nestedFixture.Provider.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<InlineDbContext>();
+            db.Streams.StartStream(Guid.NewGuid(), new SharedEvent("nested"));
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => db.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+            Assert.Contains("cannot call SaveChanges", exception.Message, StringComparison.Ordinal);
+        }
+
+        await using var appendFixture = await InlineFixture.CreateAsync(handlers =>
+            handlers.Add<StreamAppendingHandler, SharedEvent>());
+        await using var appendScope = appendFixture.Provider.CreateAsyncScope();
+        var appendDb = appendScope.ServiceProvider.GetRequiredService<InlineDbContext>();
+        appendDb.Streams.StartStream(Guid.NewGuid(), new SharedEvent("append"));
+
+        var appendException = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => appendDb.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("cannot append stream events", appendException.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Dispatch_limit_aborts_an_entity_cascade()
+    {
+        await using var fixture = await InlineFixture.CreateAsync(handlers =>
+        {
+            handlers.MaxDispatchCount = 1;
+            handlers.Add<FirstOrderHandler, OrderAdded>(options =>
+                options.Sources = InlineEventSource.EntityOutbox);
+            handlers.Add<ShipmentHandler, ShipmentAdded>(options =>
+                options.Sources = InlineEventSource.EntityOutbox);
+        });
+        await using var scope = fixture.Provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InlineDbContext>();
+        db.Orders.Add(new Order { Id = Guid.NewGuid(), Status = "new" });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => db.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("configured limit of 1", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Synchronous_save_is_supported_and_committed_append_retries_do_not_redispatch()
+    {
+        await using var fixture = await InlineFixture.CreateAsync(handlers =>
+            handlers.Add<CountingHandler, SharedEvent>(options =>
+                options.Sources = InlineEventSource.Stream));
+        using var scope = fixture.Provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<InlineDbContext>();
+        var counter = scope.ServiceProvider.GetRequiredService<CountingHandler>();
+
+        db.Streams.StartStream(Guid.NewGuid(), new SharedEvent("sync"));
+        db.SaveChanges();
+        Assert.Equal(1, counter.Calls);
+
+        var streamId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var operation = new AppendOperation(
+            streamId,
+            ExpectedVersion.NoStream,
+            [new SharedEvent("retry").WithEventId(eventId)]);
+
+        var first = await db.Streams.AppendAsync(operation, TestContext.Current.CancellationToken);
+        var retry = await db.Streams.AppendAsync(operation, TestContext.Current.CancellationToken);
+
+        Assert.False(first.WasAlreadyCommitted);
+        Assert.True(retry.WasAlreadyCommitted);
+        Assert.Equal(2, counter.Calls);
+    }
+
+    private sealed class FirstStreamHandler(InlineDbContext dbContext, Recorder recorder)
+        : IInlineEventHandler<SharedEvent>
+    {
+        public InlineDbContext Context { get; } = dbContext;
+
+        public bool SawTypedStreamEnvelope { get; private set; }
+
+        public Guid EventId { get; private set; }
+
+        public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct)
+        {
+            SawTypedStreamEnvelope = @event is IEvent<SharedEvent> { Sequence: 0 };
+            EventId = @event.Id;
+            recorder.Entries.Add("first");
+            Context.Reactions.Add(new Reaction { Id = Guid.NewGuid(), Value = @event.Data.Value });
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SecondStreamHandler(Recorder recorder) : IInlineEventHandler<SharedEvent>
+    {
+        public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct)
+        {
+            recorder.Entries.Add("second");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThirdStreamHandler(Recorder recorder) : IInlineEventHandler<SharedEvent>
+    {
+        public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct)
+        {
+            recorder.Entries.Add("third");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class EntityOnlySharedHandler : IInlineEventHandler<SharedEvent>
+    {
+        public int Calls { get; private set; }
+
+        public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct)
+        {
+            Calls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FirstOrderHandler(InlineDbContext context, Recorder recorder)
+        : IInlineEventHandler<OrderAdded>
+    {
+        public bool SawTypedOutboxEnvelope { get; private set; }
+
+        public Task Handle(IEventEnvelope<OrderAdded> @event, CancellationToken ct)
+        {
+            SawTypedOutboxEnvelope = @event is IOutboxEvent<OrderAdded> { Sequence: 0 };
+            recorder.Entries.Add("order:first");
+            context.Shipments.Add(new Shipment { Id = Guid.NewGuid(), OrderId = @event.Data.OrderId });
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SecondOrderHandler(Recorder recorder) : IInlineEventHandler<OrderAdded>
+    {
+        public Task Handle(IEventEnvelope<OrderAdded> @event, CancellationToken ct)
+        {
+            recorder.Entries.Add("order:second");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ShipmentHandler(Recorder recorder) : IInlineEventHandler<ShipmentAdded>
+    {
+        public Task Handle(IEventEnvelope<ShipmentAdded> @event, CancellationToken ct)
+        {
+            recorder.Entries.Add("shipment");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingHandler(InlineDbContext context) : IInlineEventHandler<SharedEvent>
+    {
+        public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct)
+        {
+            context.Reactions.Add(new Reaction { Id = Guid.NewGuid(), Value = "not committed" });
+            throw new InvalidOperationException("handler failed");
+        }
+    }
+
+    private sealed class NestedSaveHandler(InlineDbContext context) : IInlineEventHandler<SharedEvent>
+    {
+        public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct) =>
+            context.SaveChangesAsync(ct);
+    }
+
+    private sealed class StreamAppendingHandler(InlineDbContext context) : IInlineEventHandler<SharedEvent>
+    {
+        public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct)
+        {
+            context.Streams.StartStream(Guid.NewGuid(), new DerivedEvent());
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CountingHandler : IInlineEventHandler<SharedEvent>
+    {
+        public int Calls { get; private set; }
+
+        public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct)
+        {
+            Calls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class Recorder
+    {
+        public List<string> Entries { get; } = [];
+    }
+
+    private sealed record SharedEvent(string Value);
+
+    private sealed record DerivedEvent;
+
+    private sealed record OrderAdded(Guid OrderId);
+
+    private sealed record ShipmentAdded(Guid ShipmentId, Guid OrderId);
+
+    private sealed class Order
+    {
+        public Guid Id { get; set; }
+
+        public string Status { get; set; } = string.Empty;
+    }
+
+    private sealed class Shipment
+    {
+        public Guid Id { get; set; }
+
+        public Guid OrderId { get; set; }
+    }
+
+    private sealed class Reaction
+    {
+        public Guid Id { get; set; }
+
+        public string Value { get; set; } = string.Empty;
+    }
+
+    private sealed class InlineDbContext(DbContextOptions<InlineDbContext> options) : DbContext(options)
+    {
+        public DbSet<Order> Orders => Set<Order>();
+
+        public DbSet<Shipment> Shipments => Set<Shipment>();
+
+        public DbSet<Reaction> Reactions => Set<Reaction>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            EventStoreCore.Sqlite.ModelBuilderExtensions.UseEventStore(modelBuilder);
+            EventStoreCore.Sqlite.ModelBuilderExtensions.UseEntityOutbox(modelBuilder);
+            modelBuilder.Entity<Order>().HasKey(order => order.Id);
+            modelBuilder.Entity<Shipment>().HasKey(shipment => shipment.Id);
+            modelBuilder.Entity<Reaction>().HasKey(reaction => reaction.Id);
+        }
+    }
+
+    private sealed class InlineFixture : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        private InlineFixture(SqliteConnection connection, ServiceProvider provider)
+        {
+            _connection = connection;
+            Provider = provider;
+        }
+
+        public ServiceProvider Provider { get; }
+
+        public static async Task<InlineFixture> CreateAsync(
+            Action<IInlineEventHandlerBuilder> configureHandlers)
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+            var services = new ServiceCollection();
+            services.AddDbContext<InlineDbContext>(options => options.UseSqlite(connection));
+            services.AddSingleton<Recorder>();
+            services.AddEventStore(builder => builder.ExistingDbContext<InlineDbContext>());
+            services.AddEntityOutbox<InlineDbContext>(outbox =>
+            {
+                outbox.For<Order>().On(change =>
+                    change.Added(entity => new OrderAdded(entity.Entity.Id)));
+                outbox.For<Shipment>().On(change =>
+                    change.Added(entity => new ShipmentAdded(entity.Entity.Id, entity.Entity.OrderId)));
+            });
+            services.AddInlineEventHandlers<InlineDbContext>(configureHandlers);
+
+            var provider = services.BuildServiceProvider();
+            await using (var scope = provider.CreateAsyncScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<InlineDbContext>();
+                await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            }
+
+            return new InlineFixture(connection, provider);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Provider.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/tests/EventStoreCore.Tests/InlineEventHandlerTests.cs
+++ b/tests/EventStoreCore.Tests/InlineEventHandlerTests.cs
@@ -74,6 +74,62 @@ public sealed class InlineEventHandlerTests
     }
 
     [Fact]
+    public async Task Entity_capture_observes_mutations_from_an_earlier_entity_handler()
+    {
+        await using var fixture = await InlineFixture.CreateAsync(handlers =>
+        {
+            handlers.Add<MutatePendingShipmentHandler, OrderAdded>(options =>
+                options.Sources = InlineEventSource.EntityOutbox);
+            handlers.Add<PendingShipmentHandler, ShipmentAdded>(options =>
+                options.Sources = InlineEventSource.EntityOutbox);
+        });
+        await using var scope = fixture.Provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InlineDbContext>();
+        var orderId = Guid.NewGuid();
+        var shipmentId = Guid.NewGuid();
+        db.Orders.Add(new Order { Id = orderId, Status = "new" });
+        db.Shipments.Add(new Shipment
+        {
+            Id = shipmentId,
+            OrderId = orderId,
+            Status = "pending"
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var shipmentHandler = scope.ServiceProvider.GetRequiredService<PendingShipmentHandler>();
+        Assert.Equal("ready", shipmentHandler.Status);
+        var reader = scope.ServiceProvider.GetRequiredService<IOutboxReader>();
+        var events = await reader.ReadAsync(0, ct: TestContext.Current.CancellationToken);
+        var shipmentEvent = Assert.IsAssignableFrom<IOutboxEvent<ShipmentAdded>>(
+            events.Single(@event => @event.EventType == typeof(ShipmentAdded)));
+        Assert.Equal("ready", shipmentEvent.Data.Status);
+    }
+
+    [Fact]
+    public void Pre_registered_inline_handlers_must_have_scoped_lifetime()
+    {
+        var singletonServices = new ServiceCollection();
+        singletonServices.AddSingleton<CountingHandler>();
+        var singletonException = Assert.Throws<InvalidOperationException>(() =>
+            singletonServices.AddInlineEventHandlers<InlineDbContext>(handlers =>
+                handlers.Add<CountingHandler, SharedEvent>()));
+        Assert.Contains("scoped lifetime", singletonException.Message, StringComparison.Ordinal);
+
+        var transientServices = new ServiceCollection();
+        transientServices.AddTransient<CountingHandler>();
+        var transientException = Assert.Throws<InvalidOperationException>(() =>
+            transientServices.AddInlineEventHandlers<InlineDbContext>(handlers =>
+                handlers.Add<CountingHandler, SharedEvent>()));
+        Assert.Contains("scoped lifetime", transientException.Message, StringComparison.Ordinal);
+
+        var scopedServices = new ServiceCollection();
+        scopedServices.AddScoped<CountingHandler>();
+        scopedServices.AddInlineEventHandlers<InlineDbContext>(handlers =>
+            handlers.Add<CountingHandler, SharedEvent>());
+    }
+
+    [Fact]
     public async Task Handler_failure_rolls_back_originating_event_and_tracked_side_effects()
     {
         await using var fixture = await InlineFixture.CreateAsync(handlers =>
@@ -253,6 +309,27 @@ public sealed class InlineEventHandlerTests
         }
     }
 
+    private sealed class MutatePendingShipmentHandler(InlineDbContext context)
+        : IInlineEventHandler<OrderAdded>
+    {
+        public Task Handle(IEventEnvelope<OrderAdded> @event, CancellationToken ct)
+        {
+            context.Shipments.Local.Single(shipment => shipment.OrderId == @event.Data.OrderId).Status = "ready";
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class PendingShipmentHandler : IInlineEventHandler<ShipmentAdded>
+    {
+        public string? Status { get; private set; }
+
+        public Task Handle(IEventEnvelope<ShipmentAdded> @event, CancellationToken ct)
+        {
+            Status = @event.Data.Status;
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class FailingHandler(InlineDbContext context) : IInlineEventHandler<SharedEvent>
     {
         public Task Handle(IEventEnvelope<SharedEvent> @event, CancellationToken ct)
@@ -299,7 +376,7 @@ public sealed class InlineEventHandlerTests
 
     private sealed record OrderAdded(Guid OrderId);
 
-    private sealed record ShipmentAdded(Guid ShipmentId, Guid OrderId);
+    private sealed record ShipmentAdded(Guid ShipmentId, Guid OrderId, string Status);
 
     private sealed class Order
     {
@@ -313,6 +390,8 @@ public sealed class InlineEventHandlerTests
         public Guid Id { get; set; }
 
         public Guid OrderId { get; set; }
+
+        public string Status { get; set; } = string.Empty;
     }
 
     private sealed class Reaction
@@ -367,7 +446,10 @@ public sealed class InlineEventHandlerTests
                 outbox.For<Order>().On(change =>
                     change.Added(entity => new OrderAdded(entity.Entity.Id)));
                 outbox.For<Shipment>().On(change =>
-                    change.Added(entity => new ShipmentAdded(entity.Entity.Id, entity.Entity.OrderId)));
+                    change.Added(entity => new ShipmentAdded(
+                        entity.Entity.Id,
+                        entity.Entity.OrderId,
+                        entity.Entity.Status)));
             });
             services.AddInlineEventHandlers<InlineDbContext>(configureHandlers);
 


### PR DESCRIPTION
## Summary
- add common event envelopes and scoped inline event-handler contracts
- dispatch stream and EF entity-outbox events within the originating SaveChanges boundary
- support source filters, deterministic handler ordering, breadth-first entity cascades, and dispatch limits
- reject nested saves and stream appends during inline dispatch
- document the feature and update the reviewed public API baseline

## Validation
- dotnet build EventStoreCore.slnx --no-restore --configuration Release
- 32 focused inline-handler, entity-outbox, extension, and public API tests passed
- all 15 NuGet packages passed package and public API validation

## Environment note
PostgreSQL projection tests were attempted but could not start because Docker is unavailable in the local environment.